### PR TITLE
Integrate CMake file #28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.18.0)
+
+# Areg root directory
+set(CMAKE_ROOT_FILE "${CMAKE_SOURCE_DIR}")
+set(AREG_SDK_ROOT "${CMAKE_ROOT_FILE}")
+set(CMAKE_CONFIG_DIR "${AREG_SDK_ROOT}/conf/cmake")
+set(AREG_BASE "${AREGE_SDK_ROOT}/framework")
+set(AREG_EXAMPLES "${AREGE_SDK_ROOT}/examples")
+
+# Project's properties
+set(PROJECT_NAME "AREG-SDK")
+set(PROJECT_VERSION "1.1.0")
+project(${PROJECT_NAME} VERSION ${PROJECT_VERSION})
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(CMAKE_CONFIG_DIR "${AREG_SDK_ROOT}/conf/cmake")
 set(AREG_BASE "${AREGE_SDK_ROOT}/framework")
 set(AREG_EXAMPLES "${AREGE_SDK_ROOT}/examples")
 
+include("${CMAKE_CONFIG_DIR}/common.cmake")
+
 # Project's properties
 set(PROJECT_NAME "AREG-SDK")
 set(PROJECT_VERSION "1.1.0")

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -1,0 +1,17 @@
+set(AREG_OUTPUT_OBJ  ${ProjObjDir})
+set(AREG_OUTPUT_LIB  ${ProjLibDir})
+set(AREG_OUTPUT_BIN  ${ProjBinDir})
+set(AREG_INCLUDES    ${ProjIncludes})
+set(AREG_TOOLCHAIN   ${CrossCompile}$(Toolset))
+set(AREG_AR          ${CrossCompile}ar)
+set(AREG_OS          ${OpSystem})
+set(AREG_STATIC_LIB)
+
+include(${CMAKEFILE_CONFIG_DIR}/user.cmake)
+
+
+if(areg MATCHES "static")
+    set(AREG_BINARY "static")
+else()
+    set(AREG_BINARY "shared")
+endif()

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -1,14 +1,14 @@
-set(AREG_OUTPUT_OBJ  ${ProjObjDir})
-set(AREG_OUTPUT_LIB  ${ProjLibDir})
-set(AREG_OUTPUT_BIN  ${ProjBinDir})
-set(AREG_INCLUDES    ${ProjIncludes})
-set(AREG_TOOLCHAIN   ${CrossCompile}$(Toolset))
-set(AREG_AR          ${CrossCompile}ar)
-set(AREG_OS          ${OpSystem})
+set(AREG_OUTPUT_OBJ  "${ProjObjDir}")
+set(AREG_OUTPUT_LIB  "${ProjLibDir}")
+set(AREG_OUTPUT_BIN  "${ProjBinDir}")
+set(AREG_INCLUDES    "${ProjIncludes}")
+set(AREG_TOOLCHAIN   "${CrossCompile}${Toolset}")
+set(AREG_AR          "${CrossCompile}ar")
+set(AREG_OS          "${OpSystem}")
 set(AREG_STATIC_LIB)
 
-include(${CMAKEFILE_CONFIG_DIR}/user.cmake)
 
+include("${CMAKE_CONFIG_DIR}/user.cmake") 
 
 if(areg MATCHES "static")
     set(AREG_BINARY "static")

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -1,0 +1,66 @@
+
+set(Toolset "g++")
+set(CrossCompile)
+
+# ###########################################################################
+# Settings
+# ###########################################################################
+
+set(areg "shared")
+set(bit)
+
+
+set(Config "Release")
+
+
+set(Platform)
+set(OpSystem)
+
+if(NOT DEFINED Platform)
+    set(Platform x86_64)
+endif()
+if(NOT DEFINED OpSystem)
+    set(OpSystem ${CMAKE_HOST_SYSTEM_NAME})
+endif()
+
+
+set(AregRoot ${AREG_SDK_ROOT})
+
+set(AregInclude ${AREG_BASE})
+
+
+
+set(UserDefines "-DENABLE_TRACES")
+
+set(UserDefIncludes)
+
+set(UserDefLibPaths)
+
+set(UserDefLibs)
+
+set(UserDefOutput)
+
+
+
+
+set(ProjBuildPath)
+
+set(ProjOutputDir "${AregRoot}/${UserDefOutput}/${ProjBuildPath}")
+
+set(ProGenDir "${AregRoot}/${userDefOutput}/generate")
+
+set(ProObjDir "${ProjOutputDir}/obj")
+
+set(ProLibDir "${ProjOutputDir}/lib")
+
+set(ProBinDir "${ProjOutputDir}/bin")
+
+
+set(ProjIncludes)
+set(ProjIncludes "${ProjIncludes} -I${AregInclude}")
+set(ProjIncludes "${ProjIncludes} -I${ProjGenDir}")
+set(ProjIncludes "${ProjIncludes} -I${UserDefIncludes}")
+
+
+
+


### PR DESCRIPTION
# Brief description on changes

Root cmake created with initializing aliases.

configuration files placed in conf/cmake. some of makefile features which represented in conf/make are not compatible with cmake sysntax, therefore need a little bit polishing. (for instance configuring the platform in user.cmake )

Absolutely open to any changes or resolving any mistake :)