### PR TITLE
NESocket - Use std::string instead of String

### DIFF
--- a/framework/areg/base/NESocket.hpp
+++ b/framework/areg/base/NESocket.hpp
@@ -284,13 +284,13 @@ namespace NESocket
      *          Creates client TCP/IP socket and connect to specified remote host name and port number.
      *          The host name can be either numeric IP-address or human readable host name to resolve.
      *          If passed out_socketAddr pointer is not nullptr, on output it will contain readable
-     *          numeric IP-address with dots and port number (IP-address like "123.45.678.90"
+     *          numeric IP-address with dots and port number (IP-address like "123.45.67.89"
      * \param   hostName    The host name or IP_address of remote server to connect.
      * \param   portNr      The port number to connect. This should be valid port number.
      * \return  Returns valid socket descriptor, if could create socket and connect to remote peer.
      *          Otherwise, it returns NESocket::InvalidSocketHandle value.
      **/
-    AREG_API SOCKETHANDLE clientSocketConnect( const std::string_view & hostName, unsigned short portNr, NESocket::SocketAddress * out_socketAddr = nullptr );
+    AREG_API SOCKETHANDLE clientSocketConnect( const std::string & hostName, unsigned short portNr, NESocket::SocketAddress * out_socketAddr = nullptr );
 
     /**
      * \brief   NESocket::serverSocketConnect

--- a/framework/areg/base/NESocket.hpp
+++ b/framework/areg/base/NESocket.hpp
@@ -20,6 +20,7 @@
 #include "areg/base/GEGlobal.h"
 #include "areg/base/String.hpp"
 
+#include <string>
 #include <string_view>
 
 /************************************************************************
@@ -153,7 +154,7 @@ namespace NESocket
         /**
          * \brief   Returns IP address of host as readable string.
          **/
-        inline const String & getHostAddress( void ) const;
+        inline const std::string & getHostAddress( void ) const;
 
         /**
          * \brief   Returns port number of host.
@@ -177,7 +178,7 @@ namespace NESocket
         /**
          * \brief   The string containing human readable numeric IP-address.
          **/
-        String          mIpAddr;
+        std::string mIpAddr;
         /**
          * \brief   The port number of socket to connect.
          **/
@@ -440,10 +441,10 @@ namespace NESocket
 
 inline bool NESocket::SocketAddress::isValid( void ) const
 {
-    return ((mIpAddr.isEmpty() == false) && (mPortNr != NESocket::InvalidPort));
+    return ((!mIpAddr.empty()) && (mPortNr != NESocket::InvalidPort));
 }
 
-inline const String & NESocket::SocketAddress::getHostAddress( void ) const
+inline const std::string & NESocket::SocketAddress::getHostAddress() const
 {
     return mIpAddr;
 }

--- a/framework/areg/base/private/NESocket.cpp
+++ b/framework/areg/base/private/NESocket.cpp
@@ -317,11 +317,11 @@ AREG_API int NESocket::getMaxReceiveSize( SOCKETHANDLE hSocket )
     return static_cast<int>(maxData);
 }
 
-AREG_API SOCKETHANDLE NESocket::clientSocketConnect(const std::string_view & hostName, unsigned short portNr, NESocket::SocketAddress * out_socketAddr /*= nullptr*/)
+AREG_API SOCKETHANDLE NESocket::clientSocketConnect(const std::string & hostName, unsigned short portNr, NESocket::SocketAddress * out_socketAddr /*= nullptr*/)
 {
     TRACE_SCOPE(areg_base_NESocket_clientSocketConnect);
 
-    const char * host = hostName.empty() ? hostName.data() : NESocket::LocalHost.data();
+    const char * host = hostName.empty() ? hostName.c_str() : NESocket::LocalHost.data();
 
     TRACE_DBG("Creating client socket to connect remote host [ %s ] and port number [ %u ]", host, static_cast<unsigned int>(portNr));
 

--- a/framework/areg/base/private/NESocket.cpp
+++ b/framework/areg/base/private/NESocket.cpp
@@ -224,7 +224,7 @@ bool NESocket::SocketAddress::resolveAddress( const std::string_view & hostName,
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
                     char ipAddr[32] = { 0 };
                     mIpAddr = inet_ntop( AF_INET, &addrIn->sin_addr, ipAddr, 32 );
-                    result  = mIpAddr.isEmpty() == false;
+                    result  = mIpAddr.empty() == false;
 #else   // (_MSC_VER >= 1800)
                     mIpAddr = inet_ntoa(addrIn->sin_addr);
                     result = true;

--- a/framework/areg/base/private/NESocket.cpp
+++ b/framework/areg/base/private/NESocket.cpp
@@ -99,13 +99,13 @@ bool NESocket::SocketAddress::getAddress(struct sockaddr_in & out_sockAddr) cons
         NEMemory::memZero(&out_sockAddr, sizeof(out_sockAddr));
         out_sockAddr.sin_family = AF_INET;
         out_sockAddr.sin_port   = htons( mPortNr );
-        if (mIpAddr.isEmpty() == false)
+        if (!mIpAddr.empty())
         {
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
-            result = RETURNED_OK == inet_pton(AF_INET, mIpAddr.getString(), &out_sockAddr.sin_addr);
+            result = RETURNED_OK == inet_pton(AF_INET, mIpAddr.c_str(), &out_sockAddr.sin_addr);
 #else   // (_MSC_VER >= 1800)
-            out_sockAddr.sin_addr.s_addr = inet_addr(mIpAddr.getString());
+            out_sockAddr.sin_addr.s_addr = inet_addr(mIpAddr.c_str());
             result = true;
 #endif  // (_MSC_VER >= 1800)
 
@@ -360,7 +360,7 @@ AREG_API SOCKETHANDLE NESocket::clientSocketConnect(const SocketAddress & peerAd
             if ( RETURNED_OK != connect(result, reinterpret_cast<sockaddr *>(&remoteAddr), sizeof(sockaddr_in)))
             {
                 TRACE_ERR("Client failed to connect to remote host [ %s ] and port number [ %u ]. Closing socket [ %u ]"
-                            , static_cast<const char *>(peerAddr.getHostAddress())
+                            , peerAddr.getHostAddress().c_str()
                             , static_cast<unsigned int>(peerAddr.getHostPort())
                             , static_cast<unsigned int>(result));
 
@@ -384,7 +384,7 @@ AREG_API SOCKETHANDLE NESocket::clientSocketConnect(const SocketAddress & peerAd
     }
     else
     {
-        TRACE_ERR("Address [ %s ] or port number [ %u ] is not valid. No client is created", static_cast<const char *>(peerAddr.getHostAddress()), peerAddr.getHostPort());
+        TRACE_ERR("Address [ %s ] or port number [ %u ] is not valid. No client is created", peerAddr.getHostAddress().c_str(), peerAddr.getHostPort());
     }
 
     return result;
@@ -436,7 +436,7 @@ AREG_API SOCKETHANDLE NESocket::serverSocketConnect(const SocketAddress & peerAd
             if ( RETURNED_OK != bind(result, reinterpret_cast<sockaddr *>(&serverAddr), sizeof(sockaddr_in)) )
             {
                 TRACE_ERR("Server failed to bind on host [ %s ] and port number [ %u ]. Closing socket [ %u ]"
-                            , static_cast<const char *>(peerAddr.getHostAddress())
+                            , peerAddr.getHostAddress().c_str()
                             , static_cast<unsigned int>(peerAddr.getHostPort())
                             , static_cast<unsigned int>(result));
 
@@ -448,7 +448,7 @@ AREG_API SOCKETHANDLE NESocket::serverSocketConnect(const SocketAddress & peerAd
             {
                 TRACE_DBG("Server socket [ %u ] succeeded to bind on host [ %s ] and port number [ %u ]. Ready to listen."
                           , static_cast<unsigned int>(result)
-                          , static_cast<const char *>(peerAddr.getHostAddress())
+                          , peerAddr.getHostAddress().c_str()
                           , static_cast<unsigned int>(peerAddr.getHostPort()));
 
             }
@@ -461,7 +461,7 @@ AREG_API SOCKETHANDLE NESocket::serverSocketConnect(const SocketAddress & peerAd
     }
     else
     {
-        TRACE_ERR("Address [ %s ] or port number [ %u ] is not valid. No server is created", static_cast<const char *>(peerAddr.getHostAddress()), peerAddr.getHostPort());
+        TRACE_ERR("Address [ %s ] or port number [ %u ] is not valid. No server is created", peerAddr.getHostAddress().c_str(), peerAddr.getHostPort());
     }
 
     return result;

--- a/framework/areg/base/private/SocketClient.cpp
+++ b/framework/areg/base/private/SocketClient.cpp
@@ -37,10 +37,10 @@ bool SocketClient::createSocket( void )
 
     if ( mAddress.isValid() )
     {
-    	SOCKETHANDLE hSocket = NESocket::clientSocketConnect(static_cast<const char *>(mAddress.getHostAddress()), mAddress.getHostPort());
+        SOCKETHANDLE hSocket = NESocket::clientSocketConnect(mAddress.getHostAddress().c_str(), mAddress.getHostPort());
         if ( hSocket != NESocket::InvalidSocketHandle )
         {
-        	mSocket = std::make_shared<SOCKETHANDLE>(hSocket);
+            mSocket = std::make_shared<SOCKETHANDLE>(hSocket);
         }
     }
 

--- a/framework/areg/base/private/SocketClient.cpp
+++ b/framework/areg/base/private/SocketClient.cpp
@@ -37,7 +37,7 @@ bool SocketClient::createSocket( void )
 
     if ( mAddress.isValid() )
     {
-        SOCKETHANDLE hSocket = NESocket::clientSocketConnect(mAddress.getHostAddress().c_str(), mAddress.getHostPort());
+        SOCKETHANDLE hSocket = NESocket::clientSocketConnect(mAddress.getHostAddress(), mAddress.getHostPort());
         if ( hSocket != NESocket::InvalidSocketHandle )
         {
             mSocket = std::make_shared<SOCKETHANDLE>(hSocket);

--- a/framework/areg/base/private/SocketServer.cpp
+++ b/framework/areg/base/private/SocketServer.cpp
@@ -37,7 +37,7 @@ bool SocketServer::createSocket(void)
     decreaseLock();
     if ( mAddress.isValid() )
     {
-    	SOCKETHANDLE hSocket = NESocket::serverSocketConnect(static_cast<const char *>(mAddress.getHostAddress()), mAddress.getHostPort());
+        SOCKETHANDLE hSocket = NESocket::serverSocketConnect(mAddress.getHostAddress().c_str(), mAddress.getHostPort());
         if ( hSocket != NESocket::InvalidSocketHandle )
         {
             mSocket = std::make_shared<SOCKETHANDLE>( hSocket );

--- a/framework/areg/ipc/private/ClientService.cpp
+++ b/framework/areg/ipc/private/ClientService.cpp
@@ -668,7 +668,7 @@ void ClientService::processReceivedMessage( const RemoteMessage & msgReceived, c
     }
     else
     {
-        TRACE_WARN("Invalid message from host [ %s : %u ], ignore processing", addrHost.getHostAddress().getString(), addrHost.getHostPort());
+        TRACE_WARN("Invalid message from host [ %s : %u ], ignore processing", addrHost.getHostAddress().c_str(), addrHost.getHostPort());
     }
 }
 

--- a/framework/areg/ipc/private/SocketConnectionBase.cpp
+++ b/framework/areg/ipc/private/SocketConnectionBase.cpp
@@ -37,7 +37,7 @@ int SocketConnectionBase::sendMessage(const RemoteMessage & in_message, const So
                         , static_cast<id_type>(in_message.getSource())
                         , static_cast<id_type>(in_message.getTarget())
                         , static_cast<unsigned int>(clientSocket.getHandle())
-                        , clientSocket.getAddress().getHostAddress().getString()
+                        , clientSocket.getAddress().getHostAddress().c_str()
                         , clientSocket.getAddress().getHostPort()
                         , buffer.rbhBufHeader.biBufSize
                         , buffer.rbhBufHeader.biUsed

--- a/framework/mcrouter/tcp/ServerService.hpp
+++ b/framework/mcrouter/tcp/ServerService.hpp
@@ -447,36 +447,38 @@ inline ServerService & ServerService::self( void )
 
 inline bool ServerService::isAddressInWhiteList(const NESocket::SocketAddress & addrClient) const
 {
-    return (mWhiteList.isEmpty() == false ? mWhiteList.find(addrClient.getHostAddress()) != -1 : false);
+    return (mWhiteList.isEmpty() == false ? mWhiteList.find(String(addrClient.getHostAddress().c_str())) != -1 : false);
 }
 
 inline bool ServerService::isAddressInBlackList(const NESocket::SocketAddress & addrClient) const
 {
-    return mBlackList.isEmpty() == false ? mBlackList.find(addrClient.getHostAddress()) != -1 : false;
+    return mBlackList.isEmpty() == false ? mBlackList.find(String(addrClient.getHostAddress().c_str())) != -1 : false;
 }
 
 inline void ServerService::addWhiteList(const NESocket::SocketAddress & addrClient)
 {
-    if ( mWhiteList.find(addrClient.getHostAddress()) == -1 )
+    const auto hostAddr = addrClient.getHostAddress().c_str();
+    if ( mWhiteList.find(hostAddr) == -1 )
     {
-        mWhiteList.add(addrClient.getHostAddress());
+        mWhiteList.add(hostAddr);
     }
 }
 
 inline void ServerService::addBlackList(const NESocket::SocketAddress & addrClient)
 {
-    if ( mBlackList.find(addrClient.getHostAddress()) == -1 )
+    const auto hostAddr = addrClient.getHostAddress().c_str();
+    if ( mBlackList.find(hostAddr) == -1 )
     {
-        mBlackList.add(addrClient.getHostAddress());
+        mBlackList.add(hostAddr);
     }
 }
 
 inline void ServerService::removeWhiteList(const NESocket::SocketAddress & addrClient)
 {
-    mWhiteList.remove( addrClient.getHostAddress(), 0);
+    mWhiteList.remove(String(addrClient.getHostAddress().c_str()), 0);
 }
 
 inline void ServerService::removeBlackList(const NESocket::SocketAddress & addrClient)
 {
-    mBlackList.remove( addrClient.getHostAddress(), 0);
+    mBlackList.remove(String(addrClient.getHostAddress().c_str()), 0);
 }

--- a/framework/mcrouter/tcp/private/ServerReceiveThread.cpp
+++ b/framework/mcrouter/tcp/private/ServerReceiveThread.cpp
@@ -63,7 +63,7 @@ bool ServerReceiveThread::runDispatcher(void)
                         clientSocket = mConnection.getClientByHandle( hSocket );
                         TRACE_DBG("Received connection event of socket [ %u ], client [ %s : %d ]"
                                             , hSocket
-                                            , clientSocket.getAddress().getHostAddress().getString()
+                                            , clientSocket.getAddress().getHostAddress().c_str()
                                             , clientSocket.getAddress().getHostPort());
                     }
                     else
@@ -73,7 +73,7 @@ bool ServerReceiveThread::runDispatcher(void)
                         {
                             TRACE_DBG("Accepting new connection of socket [ %u ], client [ %s : %d ]"
                                             , hSocket
-                                            , addrAccepted.getHostAddress().getString()
+                                            , addrAccepted.getHostAddress().c_str()
                                             , addrAccepted.getHostPort());
                             
                             mConnection.acceptConnection(clientSocket);
@@ -82,7 +82,7 @@ bool ServerReceiveThread::runDispatcher(void)
                         {
                             TRACE_WARN("Rejecting new connection of socket [ %u ], client [ %s : %d ]"
                                             , hSocket
-                                            , addrAccepted.getHostAddress().getString()
+                                            , addrAccepted.getHostAddress().c_str()
                                             , addrAccepted.getHostPort());
                             
                             mConnection.rejectConnection(clientSocket);
@@ -97,7 +97,7 @@ bool ServerReceiveThread::runDispatcher(void)
                         TRACE_DBG("Received message [ %p ] from source [ %p ], client [ %s : %d ]"
                                     , static_cast<id_type>(msgReceived.getMessageId())
                                     , static_cast<id_type>(msgReceived.getSource())
-                                    , addSocket.getHostAddress().getString()
+                                    , addSocket.getHostAddress().c_str()
                                     , addSocket.getHostPort());
 
                         mRemoteService.processReceivedMessage(msgReceived, addSocket, clientSocket.getHandle());
@@ -105,7 +105,7 @@ bool ServerReceiveThread::runDispatcher(void)
                     else
                     {
                         TRACE_DBG("Failed to receive message from client socket [ %s : %d ], socket [ %u ]. Going to close connection"
-                                        , addSocket.getHostAddress().getString()
+                                        , addSocket.getHostAddress().c_str()
                                         , addSocket.getHostPort()
                                         , clientSocket.getHandle());
 

--- a/framework/mcrouter/tcp/private/ServerSendThread.cpp
+++ b/framework/mcrouter/tcp/private/ServerSendThread.cpp
@@ -53,7 +53,7 @@ void ServerSendThread::processEvent( const SendMessageEventData & data )
         TRACE_DBG("Sending message [ %s ] (ID = [ %u ]) to client [ %s : %d ] of socket [ %u ]. The message sent from source [ %u ] to target [ %u ]"
                     , NEService::getString( static_cast<NEService::eFuncIdRange>(msgSend.getMessageId()) )
                     , static_cast<unsigned int>(msgSend.getMessageId())
-                    , client.getAddress().getHostAddress().getString()
+                    , client.getAddress().getHostAddress().c_str()
                     , client.getAddress().getHostPort()
                     , ((unsigned int)(client.getHandle()))
                     , static_cast<unsigned int>(msgSend.getSource())

--- a/framework/mcrouter/tcp/private/ServerService.cpp
+++ b/framework/mcrouter/tcp/private/ServerService.cpp
@@ -185,7 +185,7 @@ void ServerService::connectionLost( SocketAccepted & clientSocket )
     TRACE_WARN("Client lost connection: cookie [ %u ], socket [ %d ], host [ %s : %d ], closing connection"
                 , static_cast<uint32_t>(cookie)
                 , clientSocket.getHandle()
-                , clientSocket.getAddress().getHostAddress().getString()
+                , clientSocket.getAddress().getHostAddress().c_str()
                 , clientSocket.getAddress().getHostPort());
 
     mServerConnection.closeConnection(clientSocket);
@@ -404,7 +404,7 @@ bool ServerService::startConnection(void)
 {
     TRACE_SCOPE(mcrouter_tcp_private_ServerService_startConnection);
     TRACE_DBG("Going to start connection. Address [ %u ], port [ %d ]"
-                , mServerConnection.getAddress().getHostAddress().getString()
+                , mServerConnection.getAddress().getHostAddress().c_str()
                 , mServerConnection.getAddress().getHostPort());
 
 
@@ -494,7 +494,7 @@ void ServerService::registerRemoteStub(const StubAddress & stub)
         if ( stubService.getServiceStatus() == NEService::eServiceConnection::ServiceConnected && listProxies.isEmpty() == false )
         {
             TRACE_DBG("Stub [ %s ] is connected, sending notification messages to [ %d ] waiting proxies"
-                        , StubAddress::convAddressToPath(stubService.getServiceAddress()).getString()
+                        , StubAddress::convAddressToPath(stubService.getServiceAddress())
                         , listProxies.getSize());
             
             TEArrayList<ITEM_ID> sendList;
@@ -765,7 +765,7 @@ void ServerService::processReceivedMessage(const RemoteMessage & msgReceived, co
                         , static_cast<uint32_t>(msgId)
                         , static_cast<uint32_t>(source)
                         , static_cast<uint32_t>(cookie)
-                        , addrHost.getHostAddress().getString()
+                        , addrHost.getHostAddress().c_str()
                         , static_cast<int>(addrHost.getHostPort())
                         , static_cast<id_type>(target));
 


### PR DESCRIPTION
=== NOT READY TO MERGE ===
Converting String to std::string in the areg base can be done incrementally like this.
Still not compilable, but it is quite promising that we can move to std::string step by step.