### PR TITLE
Thread/ThreadAddress - Use std::string instead of String

### DIFF
--- a/examples/00_helloservice/generated/src/private/HelloServiceStub.cpp
+++ b/examples/00_helloservice/generated/src/private/HelloServiceStub.cpp
@@ -54,8 +54,8 @@ void HelloServiceStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_HelloServiceStub_startupServiceInterface);
     
-    HelloServiceRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    HelloServiceNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    HelloServiceRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    HelloServiceNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -67,8 +67,8 @@ void HelloServiceStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_HelloServiceStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    HelloServiceRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    HelloServiceNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    HelloServiceRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    HelloServiceNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/01_hello/src/main.cpp
+++ b/examples/01_hello/src/main.cpp
@@ -82,7 +82,7 @@ inline HelloThread & HelloThread::self( void )
 
 void HelloThread::onThreadRuns( void )
 {
-    printf("The thread [ %s ] runs, going to output message.\n", getName().getString());
+    printf("The thread [ %s ] runs, going to output message.\n", getName().c_str());
 
     std::cout << "!!!Hello World!!!" << std::endl; // prints !!!Hello World!!!
 }

--- a/examples/02_buffer/src/main.cpp
+++ b/examples/02_buffer/src/main.cpp
@@ -91,7 +91,7 @@ inline HelloThread & HelloThread::self( void )
 
 void HelloThread::onThreadRuns( void )
 {
-    printf("The thread [ %s ] runs, going to output message:\n", Thread::getCurrentThreadName().getString());
+    printf("The thread [ %s ] runs, going to output message:\n", Thread::getCurrentThreadName().c_str());
 
     int numDigit  = 0;
     float numPI   = 0.0;
@@ -110,7 +110,7 @@ void HelloThread::onThreadRuns( void )
     std::cout << "END dump buffer data ............" << std::endl;
     std::cout << "*********************************" << std::endl;
 
-    printf( "The thread [ %s ] completed job...\n", getName().getString() );
+    printf( "The thread [ %s ] completed job...\n", getName().c_str() );
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/examples/04_trace/src/main.cpp
+++ b/examples/04_trace/src/main.cpp
@@ -98,7 +98,7 @@ void HelloThread::onThreadRuns( void )
 {
     TRACE_SCOPE(main_HelloThread_onThreadRuns);
 
-    TRACE_WARN("The thread [ %s ] runs, going to output messages ...", getName().getString());
+    TRACE_WARN("The thread [ %s ] runs, going to output messages ...", getName().c_str());
     TRACE_INFO("!!!Hello World!!!");
     TRACE_DBG("!!!Hello Tracing!!!");
 }
@@ -132,10 +132,10 @@ int main()
 
         // create and start thread, wait until it is started.
         aThread.createThread(NECommon::WAIT_INFINITE);
-        TRACE_DBG("[ %s ] to create thread [ %s ]", aThread.isValid() ? "SUCCEEDED" : "FAILED", aThread.getName().getString());
+        TRACE_DBG("[ %s ] to create thread [ %s ]", aThread.isValid() ? "SUCCEEDED" : "FAILED", aThread.getName().c_str());
 
         // stop and destroy thread, clean resources. Wait until thread ends.
-        TRACE_INFO("Going to stop and destroy [ %s ] thread.", aThread.getName().getString());
+        TRACE_INFO("Going to stop and destroy [ %s ] thread.", aThread.getName().c_str());
         aThread.destroyThread(NECommon::WAIT_INFINITE);
 
     } while (false);

--- a/examples/05_timer/src/main.cpp
+++ b/examples/05_timer/src/main.cpp
@@ -156,7 +156,7 @@ bool TimerDispatcher::postEvent( Event & eventElem )
 void TimerDispatcher::processTimer( Timer & timer )
 {
     TRACE_SCOPE(main_TimerDispatcher_processTimer);
-    TRACE_DBG("The timer [ %s ] has expired. Timeout [ %u ] ms, Event Count [ %u ], processing in Thread [ %s ]", timer.getName( ).getString( ), timer.getTimeout(), timer.getEventCount(), getName().getString());
+    TRACE_DBG("The timer [ %s ] has expired. Timeout [ %u ] ms, Event Count [ %u ], processing in Thread [ %s ]", timer.getName( ).getString( ), timer.getTimeout(), timer.getEventCount(), getName().c_str());
 
     printf("[ %s ] : Timer [ %s ] expired...\n", DateTime::getNow().formatTime().getString(), timer.getName().getString());
 
@@ -242,7 +242,7 @@ static void startTimerThread( TimerDispatcher & aThread )
 
     // create and start thread, wait until it is started.
     aThread.createThread(NECommon::WAIT_INFINITE);
-    TRACE_DBG("[ %s ] to create thread [ %s ]", aThread.isValid() ? "SUCCEEDED" : "FAILED", aThread.getName().getString());
+    TRACE_DBG("[ %s ] to create thread [ %s ]", aThread.isValid() ? "SUCCEEDED" : "FAILED", aThread.getName().c_str());
 
     TRACE_DBG("Triggering timers....");
     aThread.startTimers();
@@ -256,14 +256,14 @@ static void stopTimerThread( TimerDispatcher & aThread )
 {
     TRACE_SCOPE(main_stopTimerThread);
 
-    TRACE_INFO("Stopping timers of thread [ %s ]", aThread.getName().getString());
+    TRACE_INFO("Stopping timers of thread [ %s ]", aThread.getName().c_str());
     aThread.stopTimers();
 
-    TRACE_DBG("Comleted demo, going to stop and exit dispatcher thread [ %s ]", aThread.getName().getString());
+    TRACE_DBG("Comleted demo, going to stop and exit dispatcher thread [ %s ]", aThread.getName().c_str());
     aThread.triggerExitEvent();
     aThread.completionWait(NECommon::WAIT_INFINITE);
 
-    TRACE_WARN("The [ %s ] thread has completed job...", aThread.getName().getString());
+    TRACE_WARN("The [ %s ] thread has completed job...", aThread.getName().c_str());
 }
 
 /**

--- a/examples/06_threads/src/main.cpp
+++ b/examples/06_threads/src/main.cpp
@@ -97,7 +97,7 @@ void HelloThread::onThreadRuns( void )
 {
     TRACE_SCOPE(main_HelloThread_onThreadRuns);
 
-    TRACE_INFO("The thread [ %s ] runs, going to output message", getName().getString());
+    TRACE_INFO("The thread [ %s ] runs, going to output message", getName().c_str());
     TRACE_INFO("!!!Hello World!!! !!!Hello Tracing!!!");
 
     Thread::sleep( NECommon::WAIT_500_MILLISECONDS);
@@ -272,22 +272,22 @@ int main()
 
         // create and start thread, wait until it is started.
         helloThread.createThread(NECommon::WAIT_INFINITE);
-        TRACE_DBG("[ %s ] to create thread [ %s ]", helloThread.isValid() ? "SUCCEEDED" : "FAILED", helloThread.getName().getString());
+        TRACE_DBG("[ %s ] to create thread [ %s ]", helloThread.isValid() ? "SUCCEEDED" : "FAILED", helloThread.getName().c_str());
 
         TRACE_DBG("Starting Hello Dispatcher");
         HelloDispatcher helloDispatcher;
         // create and start thread, wait until it is started.
         helloDispatcher.createThread(NECommon::WAIT_INFINITE);
-        TRACE_DBG("[ %s ] to create thread [ %s ]", helloDispatcher.isValid() ? "SUCCEEDED" : "FAILED", helloDispatcher.getName().getString());
+        TRACE_DBG("[ %s ] to create thread [ %s ]", helloDispatcher.isValid() ? "SUCCEEDED" : "FAILED", helloDispatcher.getName().c_str());
 
         TRACE_DBG("Main thread sleep");
         Thread::sleep( NECommon::WAIT_1_SECOND);
 
         // stop and destroy thread, clean resources. Wait until thread ends.
-        TRACE_INFO("Going to stop and destroy [ %s ] thread.", helloDispatcher.getName().getString());
+        TRACE_INFO("Going to stop and destroy [ %s ] thread.", helloDispatcher.getName().c_str());
         helloDispatcher.destroyThread(NECommon::WAIT_INFINITE);
 
-        TRACE_INFO("Going to stop and destroy [ %s ] thread.", helloThread.getName().getString());
+        TRACE_INFO("Going to stop and destroy [ %s ] thread.", helloThread.getName().c_str());
         helloThread.destroyThread(NECommon::WAIT_INFINITE);
 
     } while (false);

--- a/examples/07_synch/src/main.cpp
+++ b/examples/07_synch/src/main.cpp
@@ -148,7 +148,7 @@ void HelloThread::onThreadRuns( void )
 {
     TRACE_SCOPE(main_HelloThread_onThreadRuns);
 
-    TRACE_INFO("The thread [ %s ] runs, going to output message", getName().getString());
+    TRACE_INFO("The thread [ %s ] runs, going to output message", getName().c_str());
     TRACE_INFO("!!!Hello World!!! from thread [ %s ]", THREAD_NAME.data());
 
     // reset events
@@ -219,7 +219,7 @@ void GoodbyeThread::onThreadRuns( void )
 {
     TRACE_SCOPE(main_GoodbyeThread_onThreadRuns);
 
-    TRACE_INFO("The thread [ %s ] runs, going to output message", getName().getString());
+    TRACE_INFO("The thread [ %s ] runs, going to output message", getName().c_str());
     TRACE_INFO("!!!Hello World!!! from thread [ %s ]", THREAD_NAME.data());
 
     mQuit.resetEvent();
@@ -282,7 +282,7 @@ int main()
         TRACE_DBG("Starting Goodbye Thread");
         GoodbyeThread goodbyeThread;
         goodbyeThread.createThread(NECommon::WAIT_INFINITE);
-        TRACE_DBG("Created thread [ %s ], which is in [ %s ] state", goodbyeThread.getName().getString(), goodbyeThread.isRunning() ? "RUNNING" : "NOT RUNNING");
+        TRACE_DBG("Created thread [ %s ], which is in [ %s ] state", goodbyeThread.getName().c_str(), goodbyeThread.isRunning() ? "RUNNING" : "NOT RUNNING");
 
         Thread::sleep( NECommon::WAIT_1_SECOND);           // sleep for no reason
 

--- a/examples/10_locsvc/generated/src/private/HelloWorldStub.cpp
+++ b/examples/10_locsvc/generated/src/private/HelloWorldStub.cpp
@@ -60,8 +60,8 @@ void HelloWorldStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_HelloWorldStub_startupServiceInterface);
     
-    HelloWorldRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    HelloWorldNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    HelloWorldRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    HelloWorldNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -73,8 +73,8 @@ void HelloWorldStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_HelloWorldStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    HelloWorldRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    HelloWorldNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    HelloWorldRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    HelloWorldNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/11_locmesh/generated/src/private/HelloWorldStub.cpp
+++ b/examples/11_locmesh/generated/src/private/HelloWorldStub.cpp
@@ -60,8 +60,8 @@ void HelloWorldStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_HelloWorldStub_startupServiceInterface);
     
-    HelloWorldRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    HelloWorldNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    HelloWorldRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    HelloWorldNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -73,8 +73,8 @@ void HelloWorldStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_HelloWorldStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    HelloWorldRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    HelloWorldNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    HelloWorldRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    HelloWorldNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/11_locmesh/locsvcmesh/src/ServiceClient.cpp
+++ b/examples/11_locmesh/locsvcmesh/src/ServiceClient.cpp
@@ -40,7 +40,7 @@ ServiceClient::ServiceClient(const String & roleName, Component & owner)
                     , roleName.getString()
                     , getServiceName().getString()
                     , owner.getRoleName().getString()
-                    , owner.getMasterThread().getName().getString()
+                    , owner.getMasterThread().getName().c_str()
                     , mTimer.getName().getString());
     TRACE_DBG("Proxy: [ %s ]", ProxyAddress::convAddressToPath(getProxy()->getProxyAddress()).getString());
 }

--- a/examples/12_pubsvc/generated/src/private/HelloWorldStub.cpp
+++ b/examples/12_pubsvc/generated/src/private/HelloWorldStub.cpp
@@ -60,8 +60,8 @@ void HelloWorldStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_HelloWorldStub_startupServiceInterface);
     
-    HelloWorldRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    HelloWorldNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    HelloWorldRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    HelloWorldNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -73,8 +73,8 @@ void HelloWorldStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_HelloWorldStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    HelloWorldRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    HelloWorldNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    HelloWorldRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    HelloWorldNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/12_pubsvc/pubclient/src/ServiceClient.cpp
+++ b/examples/12_pubsvc/pubclient/src/ServiceClient.cpp
@@ -48,7 +48,7 @@ ServiceClient::ServiceClient(const NERegistry::ComponentEntry & entry, Component
                     , entry.mDependencyServices[0].mRoleName.getString()
                     , getServiceName().getString()
                     , getRoleName().getString()
-                    , owner.getName().getString()
+                    , owner.getName().c_str()
                     , mTimer.getName().getString());
     TRACE_DBG("Proxy: [ %s ]", ProxyAddress::convAddressToPath(getProxy()->getProxyAddress()).getString());
 }

--- a/examples/13_pubmesh/generated/src/private/LocalHelloWorldStub.cpp
+++ b/examples/13_pubmesh/generated/src/private/LocalHelloWorldStub.cpp
@@ -60,8 +60,8 @@ void LocalHelloWorldStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_LocalHelloWorldStub_startupServiceInterface);
     
-    LocalHelloWorldRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    LocalHelloWorldNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    LocalHelloWorldRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    LocalHelloWorldNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -73,8 +73,8 @@ void LocalHelloWorldStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_LocalHelloWorldStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    LocalHelloWorldRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    LocalHelloWorldNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    LocalHelloWorldRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    LocalHelloWorldNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/13_pubmesh/generated/src/private/LocalServiceClient.cpp
+++ b/examples/13_pubmesh/generated/src/private/LocalServiceClient.cpp
@@ -34,7 +34,7 @@ LocalServiceClient::LocalServiceClient(const String & roleName, Component & owne
                     , roleName.getString()
                     , LocalHelloWorldClientBase::getServiceName().getString()
                     , owner.getRoleName().getString()
-                    , owner.getMasterThread().getName().getString()
+                    , owner.getMasterThread().getName().c_str()
                     , mTimer.getName().getString()
                     , timeout);
     TRACE_DBG("Proxy: [ %s ]", ProxyAddress::convAddressToPath(LocalHelloWorldClientBase::getProxy()->getProxyAddress()).getString());

--- a/examples/13_pubmesh/generated/src/private/RemoteRegistryStub.cpp
+++ b/examples/13_pubmesh/generated/src/private/RemoteRegistryStub.cpp
@@ -60,8 +60,8 @@ void RemoteRegistryStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_RemoteRegistryStub_startupServiceInterface);
     
-    RemoteRegistryRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    RemoteRegistryNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    RemoteRegistryRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    RemoteRegistryNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -73,8 +73,8 @@ void RemoteRegistryStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_RemoteRegistryStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    RemoteRegistryRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    RemoteRegistryNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    RemoteRegistryRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    RemoteRegistryNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/13_pubmesh/generated/src/private/RemoteServiceClient.cpp
+++ b/examples/13_pubmesh/generated/src/private/RemoteServiceClient.cpp
@@ -41,7 +41,7 @@ RemoteServiceClient::RemoteServiceClient(const String & roleName, Component & ow
                     , roleName.getString()
                     , RemoteRegistryClientBase::getServiceName().getString()
                     , owner.getRoleName().getString()
-                    , owner.getMasterThread().getName().getString()
+                    , owner.getMasterThread().getName().c_str()
                     , mTimer.getName().getString()
                     , timeout);
     TRACE_DBG("Proxy: [ %s ]", ProxyAddress::convAddressToPath(RemoteRegistryClientBase::getProxy()->getProxyAddress()).getString());

--- a/examples/13_pubmesh/generated/src/private/SystemShutdownStub.cpp
+++ b/examples/13_pubmesh/generated/src/private/SystemShutdownStub.cpp
@@ -57,8 +57,8 @@ void SystemShutdownStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_SystemShutdownStub_startupServiceInterface);
     
-    SystemShutdownRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    SystemShutdownNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    SystemShutdownRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    SystemShutdownNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -70,8 +70,8 @@ void SystemShutdownStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_SystemShutdownStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    SystemShutdownRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    SystemShutdownNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    SystemShutdownRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    SystemShutdownNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/14_pubtraffic/generated/src/private/SimpleTrafficLightStub.cpp
+++ b/examples/14_pubtraffic/generated/src/private/SimpleTrafficLightStub.cpp
@@ -60,8 +60,8 @@ void SimpleTrafficLightStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_SimpleTrafficLightStub_startupServiceInterface);
     
-    SimpleTrafficLightRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    SimpleTrafficLightNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    SimpleTrafficLightRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    SimpleTrafficLightNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -73,8 +73,8 @@ void SimpleTrafficLightStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_SimpleTrafficLightStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    SimpleTrafficLightRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    SimpleTrafficLightNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    SimpleTrafficLightRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    SimpleTrafficLightNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/14_pubtraffic/generated/src/private/SimpleTrafficSwitchStub.cpp
+++ b/examples/14_pubtraffic/generated/src/private/SimpleTrafficSwitchStub.cpp
@@ -57,8 +57,8 @@ void SimpleTrafficSwitchStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_SimpleTrafficSwitchStub_startupServiceInterface);
     
-    SimpleTrafficSwitchRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    SimpleTrafficSwitchNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    SimpleTrafficSwitchRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    SimpleTrafficSwitchNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -70,8 +70,8 @@ void SimpleTrafficSwitchStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_SimpleTrafficSwitchStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    SimpleTrafficSwitchRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    SimpleTrafficSwitchNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    SimpleTrafficSwitchRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    SimpleTrafficSwitchNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/15_pubworker/generated/src/private/PatientInformationStub.cpp
+++ b/examples/15_pubworker/generated/src/private/PatientInformationStub.cpp
@@ -57,8 +57,8 @@ void PatientInformationStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_PatientInformationStub_startupServiceInterface);
     
-    PatientInformationRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    PatientInformationNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    PatientInformationRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    PatientInformationNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -70,8 +70,8 @@ void PatientInformationStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_PatientInformationStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    PatientInformationRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    PatientInformationNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    PatientInformationRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    PatientInformationNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/16_pubfsm/generated/src/private/PowerManagerStub.cpp
+++ b/examples/16_pubfsm/generated/src/private/PowerManagerStub.cpp
@@ -57,8 +57,8 @@ void PowerManagerStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_PowerManagerStub_startupServiceInterface);
     
-    PowerManagerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    PowerManagerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    PowerManagerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    PowerManagerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -70,8 +70,8 @@ void PowerManagerStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_PowerManagerStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    PowerManagerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    PowerManagerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    PowerManagerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    PowerManagerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/16_pubfsm/generated/src/private/TrafficControllerStub.cpp
+++ b/examples/16_pubfsm/generated/src/private/TrafficControllerStub.cpp
@@ -60,8 +60,8 @@ void TrafficControllerStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_src_TrafficControllerStub_startupServiceInterface);
     
-    TrafficControllerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    TrafficControllerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    TrafficControllerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    TrafficControllerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -73,8 +73,8 @@ void TrafficControllerStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_src_TrafficControllerStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    TrafficControllerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    TrafficControllerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    TrafficControllerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    TrafficControllerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/17_winchat/generated/private/CentralMessagerStub.cpp
+++ b/examples/17_winchat/generated/private/CentralMessagerStub.cpp
@@ -54,8 +54,8 @@ void CentralMessagerStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_CentralMessagerStub_startupServiceInterface);
     
-    CentralMessagerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    CentralMessagerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    CentralMessagerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    CentralMessagerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -67,8 +67,8 @@ void CentralMessagerStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_CentralMessagerStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    CentralMessagerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    CentralMessagerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    CentralMessagerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    CentralMessagerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/17_winchat/generated/private/ConnectionManagerStub.cpp
+++ b/examples/17_winchat/generated/private/ConnectionManagerStub.cpp
@@ -57,8 +57,8 @@ void ConnectionManagerStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_ConnectionManagerStub_startupServiceInterface);
     
-    ConnectionManagerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    ConnectionManagerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    ConnectionManagerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    ConnectionManagerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -70,8 +70,8 @@ void ConnectionManagerStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_ConnectionManagerStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    ConnectionManagerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    ConnectionManagerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    ConnectionManagerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    ConnectionManagerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/17_winchat/generated/private/DirectConnectionStub.cpp
+++ b/examples/17_winchat/generated/private/DirectConnectionStub.cpp
@@ -57,8 +57,8 @@ void DirectConnectionStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_DirectConnectionStub_startupServiceInterface);
     
-    DirectConnectionRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    DirectConnectionNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    DirectConnectionRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    DirectConnectionNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -70,8 +70,8 @@ void DirectConnectionStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_DirectConnectionStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    DirectConnectionRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    DirectConnectionNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    DirectConnectionRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    DirectConnectionNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/examples/17_winchat/generated/private/DirectMessagerStub.cpp
+++ b/examples/17_winchat/generated/private/DirectMessagerStub.cpp
@@ -57,8 +57,8 @@ void DirectMessagerStub::startupServiceInterface( Component & holder )
 {
     TRACE_SCOPE(generated_DirectMessagerStub_startupServiceInterface);
     
-    DirectMessagerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    DirectMessagerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    DirectMessagerRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    DirectMessagerNotifyRequestEvent::addListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::startupServiceInterface( holder );
 
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] has been started and is available ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
@@ -70,8 +70,8 @@ void DirectMessagerStub::shutdownServiceIntrface( Component & holder )
     TRACE_SCOPE(generated_DirectMessagerStub_shutdownServiceIntrface);
     TRACE_DBG("The Stub Service [ %s ] of component with role name [ %s ] is shutting down and not available anymore ...", mAddress.getServiceName().getString(), mAddress.getRoleName().getString());
     
-    DirectMessagerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
-    DirectMessagerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName() );
+    DirectMessagerRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
+    DirectMessagerNotifyRequestEvent::removeListener( static_cast<IEEventConsumer &>(self()), Thread::getCurrentThreadName().c_str() );
     StubBase::shutdownServiceIntrface( holder );
 }
 

--- a/framework/areg/base/NESocket.hpp
+++ b/framework/areg/base/NESocket.hpp
@@ -18,7 +18,7 @@
  * Include files.
  ************************************************************************/
 #include "areg/base/GEGlobal.h"
-#include "areg/base/String.hpp"
+#include "areg/base/NECommon.hpp"
 
 #include <string>
 #include <string_view>
@@ -456,6 +456,6 @@ inline unsigned short NESocket::SocketAddress::getHostPort( void ) const
 
 inline void NESocket::SocketAddress::resetAddress( void )
 {
-    mIpAddr = String::EmptyString.data();
+    mIpAddr = "";
     mPortNr = NESocket::InvalidPort;
 }

--- a/framework/areg/base/String.hpp
+++ b/framework/areg/base/String.hpp
@@ -95,7 +95,10 @@ public:
      **/
     inline String( const String & source );
 
-    /* temporary ctor to for the movement */
+    /**
+     * \brief    Temporary ctor for the movement to std::string
+     * \param    source     he string data source
+     **/
     inline String( const std::string & source );
 
     /**

--- a/framework/areg/base/String.hpp
+++ b/framework/areg/base/String.hpp
@@ -21,6 +21,7 @@
 #include "areg/base/TEString.hpp"
 #include <stdio.h>
 #include <stdarg.h>
+#include <string>
 #include <string_view>
 
 /************************************************************************
@@ -76,6 +77,7 @@ public:
      * \param    source    The string data source. If nullptr, sets empty string.
      **/
     inline String( const char * source );
+
     /**
      * \brief    Initialization constructor. Copies carCount chars from source
      * \param    source       The string source
@@ -92,6 +94,10 @@ public:
      * \param   source  The source to copy data.
      **/
     inline String( const String & source );
+
+    /* temporary ctor to for the movement */
+    inline String( const std::string & source );
+
     /**
      * \brief   Copy constructor.
      * \param   source  The source to copy data.
@@ -786,6 +792,11 @@ inline String::String( char ch )
 
 inline String::String( const String & source )
     : TEString<char>( static_cast<const TEString<char> &>(source) )
+{
+}
+
+inline String::String( const std::string & source )
+    : TEString<char>( source.c_str() )
 {
 }
 

--- a/framework/areg/base/Thread.hpp
+++ b/framework/areg/base/Thread.hpp
@@ -230,7 +230,7 @@ public:
     /**
      * \brief   Returns thread name
      **/
-    inline const String & getName( void ) const;
+    inline const std::string & getName( void ) const;
 
     /**
      * \brief	Returns the address object of thread.
@@ -341,7 +341,7 @@ public:
      * \brief   Returns the name of current thread.
      *          If Thread is not registered, returns empty string.
      **/
-    static inline const String & getCurrentThreadName( void );
+    static inline const std::string & getCurrentThreadName( void );
 
     /**
      * \brief   Returns the address of current thread.
@@ -363,7 +363,7 @@ public:
      * \brief   Returns the name of thread by specified ID. 
      *          If Thread is not registered, returns empty string.
      **/
-    static const String & getThreadName( id_type threadId );
+    static const std::string & getThreadName( id_type threadId );
 
     /**
      * \brief   Returns the address of thread by specified ID. 
@@ -663,7 +663,7 @@ inline id_type Thread::getId( void ) const
     return mThreadId;
 }
 
-inline const String& Thread::getName( void ) const
+inline const std::string & Thread::getName( void ) const
 {
     Lock lock(mSynchObject);
     return mThreadAddress.getThreadName();
@@ -687,7 +687,7 @@ inline Thread* Thread::findThreadById( id_type threadId)
 
 inline Thread* Thread::findThreadByAddress(const ThreadAddress& threadAddress)
 {
-    return Thread::findThreadByName(threadAddress.getThreadName());
+    return Thread::findThreadByName(threadAddress.getThreadName().c_str());
 }
 
 inline const ThreadAddress & Thread::findThreadAddressById( id_type threadId)
@@ -713,7 +713,7 @@ inline Thread * Thread::getCurrentThread( void )
     return Thread::findThreadById(Thread::getCurrentThreadId());
 }
 
-inline const String & Thread::getCurrentThreadName( void )
+inline const std::string & Thread::getCurrentThreadName( void )
 {
     return Thread::getThreadName( Thread::getCurrentThreadId() );
 }

--- a/framework/areg/base/ThreadAddress.hpp
+++ b/framework/areg/base/ThreadAddress.hpp
@@ -261,6 +261,7 @@ inline std::string ThreadAddress::convToString(void) const
 inline const IEInStream & operator >> (const IEInStream & stream, ThreadAddress & input)
 {
     //FIXME
+    // return ( stream >> input.mThreadName );
     String name;
     stream >> name;
     input.mThreadName = std::string(name);
@@ -270,6 +271,7 @@ inline const IEInStream & operator >> (const IEInStream & stream, ThreadAddress 
 inline IEOutStream & operator << (IEOutStream & stream, const ThreadAddress & output)
 {
     //FIXME
+    // return ( stream << output.mThreadName );
     stream << String(output.mThreadName);
     return stream;
 }

--- a/framework/areg/base/ThreadAddress.hpp
+++ b/framework/areg/base/ThreadAddress.hpp
@@ -19,13 +19,13 @@
 #include "areg/base/GEGlobal.h"
 #include "areg/base/String.hpp"
 
+#include <string>
 #include <string_view>
 #include <utility>
 
 /************************************************************************
  * Dependencies
  ************************************************************************/
-class IEInStream;
 
 //////////////////////////////////////////////////////////////////////////
 // ThreadAddress class declaration
@@ -133,7 +133,7 @@ public:
     /**
      * \brief   Return thread name.
      **/
-    inline const String & getThreadName( void ) const;
+    inline const std::string & getThreadName( void ) const;
 
     /**
      * \brief   Return true if current object is not equal to INVALID_THREAD_ADDRESS
@@ -148,7 +148,7 @@ public:
      * \param	threadAddress	The thread address object to convert.
      * \return	Returns string of thread path
      **/
-    static String convAddressToPath( const ThreadAddress & threadAddress );
+    static std::string convAddressToPath( const ThreadAddress & threadAddress );
 
     /**
      * \brief	Parses passed path and converts passed path to the Thread Address object.
@@ -174,7 +174,7 @@ public:
      *          <string name> is the name of string.
      * \return  Returns converted path of thread as string.
      **/
-    inline String convToString( void ) const;
+    inline std::string convToString( void ) const;
 
     /**
      * \brief	Parse string and retrieves thread address data from path.
@@ -200,7 +200,7 @@ private:
     /**
      * \brief   The thread name.
      **/
-    String          mThreadName;
+    std::string     mThreadName;
     /**
      * \brief   The calculated number of thread address.
      **/
@@ -230,7 +230,7 @@ inline ThreadAddress & ThreadAddress::operator = ( ThreadAddress && src ) noexce
     return (*this);
 }
 
-inline const String & ThreadAddress::getThreadName( void ) const
+inline const std::string & ThreadAddress::getThreadName( void ) const
 {
     return mThreadName;
 }
@@ -250,7 +250,7 @@ inline ThreadAddress::operator unsigned int( void ) const
     return mMagicNum;
 }
 
-inline String ThreadAddress::convToString(void) const
+inline std::string ThreadAddress::convToString(void) const
 {
     return mThreadName;
 }
@@ -260,10 +260,16 @@ inline String ThreadAddress::convToString(void) const
 //////////////////////////////////////////////////////////////////////////
 inline const IEInStream & operator >> (const IEInStream & stream, ThreadAddress & input)
 {
-    return ( stream >> input.mThreadName );
+    //FIXME
+    String name;
+    stream >> name;
+    input.mThreadName = std::string(name);
+    return stream;
 }
 
 inline IEOutStream & operator << (IEOutStream & stream, const ThreadAddress & output)
 {
-    return ( stream << output.mThreadName );
+    //FIXME
+    stream << String(output.mThreadName);
+    return stream;
 }

--- a/framework/areg/base/ThreadLocalStorage.hpp
+++ b/framework/areg/base/ThreadLocalStorage.hpp
@@ -95,7 +95,7 @@ public:
      * \brief   Returns the name of thread local storage.
      *          The name of local storage is same as thread name.
      **/
-    const String & getName( void ) const;
+    const std::string & getName( void ) const;
 
     /**
      * \brief   Returns true, if there is an local storage item 

--- a/framework/areg/base/private/NESocket.cpp
+++ b/framework/areg/base/private/NESocket.cpp
@@ -372,7 +372,7 @@ AREG_API SOCKETHANDLE NESocket::clientSocketConnect(const SocketAddress & peerAd
             {
                 TRACE_DBG("Client socket [ %u ] succeeded to connect to remote host [ %s ] and port number [ %u ]"
                             , static_cast<unsigned int>(result)
-                            , static_cast<const char *>(peerAddr.getHostAddress())
+                            , peerAddr.getHostAddress().c_str()
                             , static_cast<unsigned int>(peerAddr.getHostPort()));
             }
 #endif  // DEBUG

--- a/framework/areg/base/private/Thread.cpp
+++ b/framework/areg/base/private/Thread.cpp
@@ -236,9 +236,9 @@ void Thread::onPostExitThread( void )
 {
 }
 
-const String & Thread::getThreadName( id_type threadId )
+const std::string & Thread::getThreadName( id_type threadId )
 {
-    static String emptyString;
+    static std::string emptyString = "";
     Thread* threadObj = Thread::findThreadById( threadId);
     return (threadObj != nullptr ? threadObj->getName() : emptyString);
 }
@@ -296,10 +296,10 @@ void Thread::_cleanResources( void )
 bool Thread::_registerThread( void )
 {
     Thread::_mapThreadhHandle.registerResourceObject(mThreadHandle, this);
-    Thread::_mapThreadName.registerResourceObject(mThreadAddress.getThreadName(), this);
+    Thread::_mapThreadName.registerResourceObject(mThreadAddress.getThreadName().c_str(), this);
     Thread::_mapThreadId.registerResourceObject(mThreadId, this);
 
-    _setThreadName(mThreadId, mThreadAddress.getThreadName());
+    _setThreadName(mThreadId, mThreadAddress.getThreadName().c_str());
     return mThreadConsumer.onThreadRegistered(this);
 }
 
@@ -310,7 +310,7 @@ void Thread::_unregisterThread( void )
         mThreadConsumer.onThreadUnregistering();
         
         Thread::_mapThreadhHandle.unregisterResourceObject(mThreadHandle);
-        Thread::_mapThreadName.unregisterResourceObject(mThreadAddress.getThreadName());
+        Thread::_mapThreadName.unregisterResourceObject(mThreadAddress.getThreadName().c_str());
         Thread::_mapThreadId.unregisterResourceObject(mThreadId);
 
         if (Thread::_mapThreadhHandle.isEmpty())

--- a/framework/areg/base/private/ThreadAddress.cpp
+++ b/framework/areg/base/private/ThreadAddress.cpp
@@ -54,7 +54,7 @@ ThreadAddress::ThreadAddress( const char * threadName )
     : mThreadName   ( threadName != nullptr ? threadName : INVALID_THREAD_NAME.data() )
     , mMagicNum     ( NEMath::CHECKSUM_IGNORE )
 {
-    mThreadName.truncate( NEUtilities::ITEM_NAMES_MAX_LENGTH );
+    mThreadName.resize( NEUtilities::ITEM_NAMES_MAX_LENGTH );
     mMagicNum    = ThreadAddress::_magicNumber(*this);
 }
 
@@ -71,9 +71,8 @@ ThreadAddress::ThreadAddress( ThreadAddress && src ) noexcept
     src.mMagicNum   = NEMath::CHECKSUM_IGNORE;
 }
 
+//FIXME
 ThreadAddress::ThreadAddress( const IEInStream & stream )
-    : mThreadName   ( stream )
-    , mMagicNum     ( NEMath::CHECKSUM_IGNORE )
 {
     mMagicNum    = ThreadAddress::_magicNumber(*this);
 }
@@ -86,7 +85,7 @@ bool ThreadAddress::isValid( void ) const
 //////////////////////////////////////////////////////////////////////////
 // Methods
 //////////////////////////////////////////////////////////////////////////
-String ThreadAddress::convAddressToPath( const ThreadAddress& threadAddress )
+std::string ThreadAddress::convAddressToPath( const ThreadAddress& threadAddress )
 {
     return threadAddress.convToString();
 }
@@ -122,9 +121,9 @@ void ThreadAddress::convFromString(const char * threadPath, const char** OUT out
 unsigned int ThreadAddress::_magicNumber(const ThreadAddress & addrThread)
 {
     unsigned int result = NEMath::CHECKSUM_IGNORE;
-    if ((addrThread.mThreadName.isEmpty() == false) && (addrThread.mThreadName != INVALID_THREAD_NAME.data( )))
+    if ((addrThread.mThreadName.empty() == false) && (addrThread.mThreadName != INVALID_THREAD_NAME.data( )))
     {
-        result = NEMath::crc32Calculate(addrThread.mThreadName.getString());
+        result = NEMath::crc32Calculate(addrThread.mThreadName.c_str());
     }
 
     return result;

--- a/framework/areg/base/private/ThreadAddress.cpp
+++ b/framework/areg/base/private/ThreadAddress.cpp
@@ -71,10 +71,11 @@ ThreadAddress::ThreadAddress( ThreadAddress && src ) noexcept
     src.mMagicNum   = NEMath::CHECKSUM_IGNORE;
 }
 
-//FIXME
 ThreadAddress::ThreadAddress( const IEInStream & stream )
+    : mMagicNum     ( NEMath::CHECKSUM_IGNORE )
 {
-    mMagicNum    = ThreadAddress::_magicNumber(*this);
+    String name(stream);
+    mThreadName = std::string(name);
 }
 
 bool ThreadAddress::isValid( void ) const

--- a/framework/areg/base/private/ThreadLocalStorage.cpp
+++ b/framework/areg/base/private/ThreadLocalStorage.cpp
@@ -116,7 +116,7 @@ bool ThreadLocalStorage::existKey( const char* Key ) const
     return (pos != nullptr);
 }
 
-const String & ThreadLocalStorage::getName( void ) const
+const std::string & ThreadLocalStorage::getName( void ) const
 {
     return mOwningThread.getName();
 }

--- a/framework/areg/base/private/posix/ThreadPosix.cpp
+++ b/framework/areg/base/private/posix/ThreadPosix.cpp
@@ -166,7 +166,7 @@ bool Thread::_createSystemThread( void )
 {
     bool result = false;
 
-    if ((_isValidNoLock() == false) && (mThreadAddress.getThreadName().isEmpty() == false))
+    if ((_isValidNoLock() == false) && (mThreadAddress.getThreadName().empty() == false))
     {
         sPosixThread * handle = new sPosixThread;
         if ( handle != nullptr)

--- a/framework/areg/base/private/win32/ThreadWin32.cpp
+++ b/framework/areg/base/private/win32/ThreadWin32.cpp
@@ -149,7 +149,7 @@ Thread::eCompletionStatus Thread::destroyThread(unsigned int waitForStopMs /* = 
 bool Thread::_createSystemThread( void )
 {
     bool result = false;
-    if ((_isValidNoLock() == false) && (mThreadAddress.getThreadName().isEmpty() == false))
+    if ((_isValidNoLock() == false) && (mThreadAddress.getThreadName().empty() == false))
     {
         mWaitForRun.resetEvent();
         mWaitForExit.resetEvent( );

--- a/framework/areg/component/private/ComponentAddress.cpp
+++ b/framework/areg/component/private/ComponentAddress.cpp
@@ -128,7 +128,7 @@ String ComponentAddress::convToString(void) const
 
     result += mRoleName;
     result += NECommon::COMPONENT_PATH_SEPARATOR.data();
-    result += ThreadAddress::convAddressToPath(mThreadAddress);
+    result += ThreadAddress::convAddressToPath(mThreadAddress).c_str();
 
     return result;
 }
@@ -151,7 +151,7 @@ unsigned int ComponentAddress::_magicNumber(const ComponentAddress & addrComp)
     if (addrComp.mThreadAddress.isValid() && (addrComp.mRoleName.isEmpty() == false) && (addrComp.mRoleName != INVALID_COMPONENT_NAME.data()))
     {
         result = NEMath::crc32Init();
-        result = NEMath::crc32Start(result, addrComp.mThreadAddress.getThreadName().getString());
+        result = NEMath::crc32Start(result, addrComp.mThreadAddress.getThreadName().c_str());
         result = NEMath::crc32Start(result, addrComp.mRoleName.getString());
         result = NEMath::crc32Finish(result);
     }

--- a/framework/areg/component/private/ComponentThread.cpp
+++ b/framework/areg/component/private/ComponentThread.cpp
@@ -92,7 +92,7 @@ int ComponentThread::createComponents( void )
 {
     OUTPUT_DBG("Starting to create components in thread [ %s ].", getName().getString());
     int result = 0;
-    const NERegistry::ComponentList& comList = ComponentLoader::getComponentList(getName());
+    const NERegistry::ComponentList& comList = ComponentLoader::getComponentList(getName().c_str());
     if (comList.isValid())
     {
         for (int i = 0; i < comList.getSize(); ++ i)
@@ -126,7 +126,7 @@ void ComponentThread::destroyComponents( void )
         if (comObj != nullptr)
         {
             OUTPUT_DBG("Destroying component [ %s ] in thread [ %s ]...", comObj->getRoleName().getString(), getName().getString());
-            const NERegistry::ComponentEntry& entry = ComponentLoader::findComponentEntry(comObj->getRoleName(), getName());
+            const NERegistry::ComponentEntry& entry = ComponentLoader::findComponentEntry(comObj->getRoleName(), getName().c_str());
             if (entry.isValid() && entry.mFuncDelete != nullptr)
             {
                 Component::unloadComponent(*comObj, entry);

--- a/framework/areg/component/private/DispatcherThread.cpp
+++ b/framework/areg/component/private/DispatcherThread.cpp
@@ -226,7 +226,7 @@ Thread::eCompletionStatus DispatcherThread::destroyThread( unsigned int waitForS
 {
     TRACE_SCOPE( areg_component_private_DispatcherThread_destroyThread);
     TRACE_DBG("Destroying the thread the thread [ %s ] with ID [ %p ]. The current state is [ %s ]"
-                , getName().getString( )
+                , getName().c_str()
                 , static_cast<id_type>(getId( ))
                 , isRunning() ? "RUNNING" : "NOT RUNNING" );
 
@@ -245,7 +245,7 @@ void DispatcherThread::shutdownThread( void )
 {
     TRACE_SCOPE( areg_component_private_DispatcherThread_shutdownThread);
     TRACE_DBG("Shutting down the thread [ %s ] with ID [ %p ]."
-                , getName().getString( )
+                , getName().c_str()
                 , static_cast<id_type>(getId( )));
 
     shutdownDispatcher();
@@ -259,7 +259,7 @@ bool DispatcherThread::runDispatcher( void )
     bool result = EventDispatcher::runDispatcher();
     mEventStarted.resetEvent();
 
-    TRACE_DBG("The dispatcher [ %s ] with ID [ %p ] is stopping.", getName().getString( ), static_cast<id_type>(getId( )));
+    TRACE_DBG("The dispatcher [ %s ] with ID [ %p ] is stopping.", getName().c_str(), static_cast<id_type>(getId( )));
 
     return result;
 }
@@ -273,7 +273,7 @@ void DispatcherThread::triggerExitEvent( void )
 {
     TRACE_SCOPE( areg_component_private_DispatcherThread_triggerExitEvent);
     TRACE_DBG("Requesting to exit thread [ %s ] with ID [ %p ] and status [ %s ]."
-                , getName().getString( )
+                , getName().c_str()
                 , static_cast<id_type>(getId( ))
                 , mHasStarted ? "STARTED" : "NOT STARTED");
 

--- a/framework/areg/component/private/ProxyBase.cpp
+++ b/framework/areg/component/private/ProxyBase.cpp
@@ -185,7 +185,7 @@ ProxyBase * ProxyBase::findOrCreateProxy( const char * roleName
     ProxyBase*   proxy = nullptr;
     if (ownerThread.isValid())
     {
-        ProxyAddress Key(serviceIfData, roleName, ownerThread.getName().getString() );
+        ProxyAddress Key(serviceIfData, roleName, ownerThread.getName().c_str() );
         proxy = _mapRegisteredProxies.findResourceObject(Key);
         if (proxy == nullptr)
         {
@@ -265,7 +265,7 @@ ProxyBase::ProxyBase(const char* roleName, const NEService::SInterfaceData & ser
 
     : IEProxyEventConsumer  ( mProxyAddress )
     
-    , mProxyAddress     ( serviceIfData, roleName, (ownerThread != nullptr) && (ownerThread->isValid()) ? ownerThread->getName().getString() : nullptr )
+    , mProxyAddress     ( serviceIfData, roleName, (ownerThread != nullptr) && (ownerThread->isValid()) ? ownerThread->getName().c_str() : nullptr )
     , mStubAddress      ( StubAddress::INVALID_STUB_ADDRESS )
     , mSequenceCount    ( 0 )
     , mListenerList     ( static_cast<int>(serviceIfData.idAttributeCount + serviceIfData.idResponseCount) )

--- a/framework/areg/component/private/StubBase.cpp
+++ b/framework/areg/component/private/StubBase.cpp
@@ -67,7 +67,7 @@ StubBase::StubBase( Component & masterComp, const NEService::SInterfaceData & si
 
     , mComponent            (masterComp)
     , mInterface            (siData)
-    , mAddress              (siData, masterComp.getAddress().getRoleName(), masterComp.getAddress().getThreadAddress().getThreadName())
+    , mAddress              (siData, masterComp.getAddress().getRoleName(), masterComp.getAddress().getThreadAddress().getThreadName().c_str())
     , mConnectionStatus     ( NEService::eServiceConnection::ServiceDisconnected )
     , mListListener         ( )
     , mCurrListener         (nullptr)

--- a/framework/areg/component/private/TimerManager.cpp
+++ b/framework/areg/component/private/TimerManager.cpp
@@ -155,7 +155,7 @@ bool TimerManager::_registerTimer(Timer &timer, const DispatcherThread & whichTh
     }
     else
     {
-        TRACE_ERR("Either times [ %s ] is not valid or thread [ %s ] is not running, cancel timer.", timer.getName().getString(), whichThread.getName().getString());
+        TRACE_ERR("Either times [ %s ] is not valid or thread [ %s ] is not running, cancel timer.", timer.getName().getString(), whichThread.getName().c_str());
     }
 
     return result;

--- a/framework/areg/ipc/private/ClientReceiveThread.cpp
+++ b/framework/areg/ipc/private/ClientReceiveThread.cpp
@@ -33,7 +33,7 @@ ClientReceiveThread::ClientReceiveThread( IERemoteServiceHandler & remoteService
 bool ClientReceiveThread::runDispatcher(void)
 {
     TRACE_SCOPE(areg_ipc_private_ClientReceiveThread_runDispatcher);
-    TRACE_DBG("Starting client service dispatcher thread [ %s ]", getName().getString());
+    TRACE_DBG("Starting client service dispatcher thread [ %s ]", getName().c_str());
     mEventStarted.setEvent();
 
     IESynchObject* syncObjects[2] = {&mEventExit, &mEventQueue};
@@ -72,7 +72,7 @@ bool ClientReceiveThread::runDispatcher(void)
 
     mEventStarted.resetEvent();
 
-    TRACE_DBG("Exiting client service dispatcher thread [ %s ] with result [ %s ]", getName().getString()
+    TRACE_DBG("Exiting client service dispatcher thread [ %s ] with result [ %s ]", getName().c_str()
                , whichEvent == static_cast<int>(EventDispatcherBase::eEventOrder::EventExit) ? "SUCCESS" : "FAILURE");
 
     return (whichEvent == static_cast<int>(EventDispatcherBase::eEventOrder::EventExit));

--- a/framework/areg/ipc/private/ClientSendThread.cpp
+++ b/framework/areg/ipc/private/ClientSendThread.cpp
@@ -32,14 +32,14 @@ ClientSendThread::ClientSendThread( IERemoteServiceHandler & remoteService, Clie
 bool ClientSendThread::runDispatcher(void)
 {
     TRACE_SCOPE(areg_ipc_private_ClientSendThread_runDispatcher);
-    TRACE_DBG("Starting client service dispatcher thread [ %s ]", getName().getString());
+    TRACE_DBG("Starting client service dispatcher thread [ %s ]", getName().c_str());
 
     SendMessageEvent::addListener( static_cast<IESendMessageEventConsumer &>(*this), static_cast<DispatcherThread &>(*this));
 
     bool result = DispatcherThread::runDispatcher();
 
     SendMessageEvent::removeListener( static_cast<IESendMessageEventConsumer &>(*this), static_cast<DispatcherThread &>(*this));
-    TRACE_DBG("Exiting client service dispatcher thread [ %s ] with result [ %s ]", getName().getString(), result ? "SUCCESS" : "FAILURE");
+    TRACE_DBG("Exiting client service dispatcher thread [ %s ] with result [ %s ]", getName().c_str(), result ? "SUCCESS" : "FAILURE");
     return result;
 }
 

--- a/framework/mcrouter/tcp/private/ServerReceiveThread.cpp
+++ b/framework/mcrouter/tcp/private/ServerReceiveThread.cpp
@@ -36,7 +36,7 @@ ServerReceiveThread::ServerReceiveThread( IEServerConnectionHandler & connectHan
 bool ServerReceiveThread::runDispatcher(void)
 {
     TRACE_SCOPE(areg_ipc_private_ServerReceiveThread_runDispatcher);
-    TRACE_DBG("Starting dispatcher [ %s ]", getName().getString());
+    TRACE_DBG("Starting dispatcher [ %s ]", getName().c_str());
 
     mEventStarted.setEvent();
 


### PR DESCRIPTION
First commit for Thread/ThreadAddress in areg-base for converting from String to std::string