### PR TITLE
Feature/102 extend workflows to check compilations

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -54,12 +54,12 @@ jobs:
              sudo apt-get install ${{matrix.config.cxx}} -y
 
       - name: Fetch CYGWIN installer on Windows
-        if: runner.os == 'Windows' && matrix.config.family == 'cygwin'
+        if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
         run: Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile C:\setup.exe
         shell: powershell
 
       - name: Install CYGWIN on Windows
-        if: runner.os == 'Windows' && matrix.config.family == 'cygwin'
+        if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
         run: |
             c:\setup.exe -qgnO -s http://mirrors.kernel.org/sourceware/cygwin/ -l C:\cygwin-packages\ -P ^
             automake,^
@@ -75,7 +75,7 @@ jobs:
         shell: cmd
 
       - name: set PATH environment variable
-        if: runner.os == 'Windows' && matrix.config.family == 'cygwin'
+        if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
         run: echo "PATH=C:\cygwin64;C:\cygwin64\bin;%SYSTEMROOT%\system32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
          
       - name: Configure CMake

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,19 +77,19 @@ jobs:
 
       - name: set PATH environment variable
         if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
-        run: echo "PATH=C:\cygwin64;C:\cygwin64\bin;C:\cygwin64\lib;%SYSTEMROOT%\system32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        run: echo "PATH=C:\cygwin64;C:\cygwin64\bin;C:\cygwin64\lib;%SYSTEMROOT%\system32;%PATH%" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
          
       - name: Configure CMake on Windows
         if: matrix.config.os == 'windows-latest'
         working-directory: ${{github.workspace}}
-        shell: cmd
+        shell: powershell
         run: |
           cmake -B ./build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON
     
       - name: Build with cmake on Windows
         if: matrix.config.os == 'windows-latest'
         working-directory: ${{github.workspace}}
-        shell: cmd
+        shell: powershell
         # Build your program with the given configuration
         run: cmake --build ./build -j 8
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -83,10 +83,10 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: powershell
         run: |
-          cmake -B ./build                                      \
-                -DAREG_COMPILER_FAMILY=${{matrix.config.family}}\
-                -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}}           \
-                -DAREG_BINARY=${{matrix.config.lib}}            \
+          cmake -B ./build                                       \
+                -DAREG_COMPILER_FAMILY=${{matrix.config.family}} \
+                -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}}            \
+                -DAREG_BINARY=${{matrix.config.lib}}             \
                 -DAREG_BUILD_ALL:BOOL=ON
     
       - name: Build with cmake on Windows
@@ -100,10 +100,10 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         working-directory: ${{github.workspace}}
         run: |
-          cmake -B ./build                                      \
-                -DAREG_COMPILER_FAMILY=${{matrix.config.family}}\
-                -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}}           \
-                -DAREG_BINARY=${{matrix.config.lib}}            \
+          cmake -B ./build                                       \
+                -DAREG_COMPILER_FAMILY=${{matrix.config.family}} \
+                -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}}            \
+                -DAREG_BINARY=${{matrix.config.lib}}             \
                 -DAREG_BUILD_ALL:BOOL=ON
     
       - name: Build with cmake on Linux

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,8 +1,8 @@
 name: CMake
 
 on:
-  push:
-  pull_request:
+  push:         # Keep empty to run on each branch when push the code
+  pull_request: # Set to master to run only when merge with master branch
     branches: [ master ]
 
 env:
@@ -17,10 +17,11 @@ jobs:
   build-tests:
     name: ${{matrix.config.name}}
     runs-on: ${{matrix.config.os}}
+
     strategy:
       fail-fast: false
       matrix:
-        config:
+        config: # Create matrix with combinations
             # compile AREG engine as a shared library with GNU g++ / gcc on Ubuntu Linux
           - { name: linux-gnu-shared,     os: ubuntu-latest,   lib: shared, family: gnu,    cxx: g++,        cc: gcc}
             # compile AREG engine as a static library with GNU g++ / gcc on Ubuntu Linux
@@ -39,13 +40,14 @@ jobs:
           - { name: windows-msvc-static,   os: windows-latest, lib: static, family: msvc,   cxx: cl,         cc: cl}
 
     steps:
-      - name: Checkout sources
+      - name: Checkout AREG engine (AREG SDK) source codes and dependencies
         uses: actions/checkout@v3
         with:
           submodules: recursive
 
-      - name: Install compilers on Linux
+      - name: Update compilers on Linux
         if: matrix.config.os == 'ubuntu-latest'
+        # Update compilers, set C/C++ compilers
         run: |
              sudo apt-get update
              sudo apt-get install ${{matrix.config.cxx}} -y
@@ -72,7 +74,7 @@ jobs:
             ncurses,^
             libncurses-devel
 
-      - name: set PATH environment variable
+      - name: set Windows PATH environment variable
         if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
         run: echo "PATH=C:\cygwin64;C:\cygwin64\bin;C:\cygwin64\lib;%SYSTEMROOT%\system32;%PATH%" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
          
@@ -81,7 +83,11 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: powershell
         run: |
-          cmake -B ./build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON
+          cmake -B ./build                                      \
+                -DAREG_COMPILER_FAMILY=${{matrix.config.family}}\
+                -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}}           \
+                -DAREG_BINARY=${{matrix.config.lib}}            \
+                -DAREG_BUILD_ALL:BOOL=ON
     
       - name: Build with cmake on Windows
         if: matrix.config.os == 'windows-latest'
@@ -94,7 +100,11 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         working-directory: ${{github.workspace}}
         run: |
-          cmake -B ./build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON
+          cmake -B ./build                                      \
+                -DAREG_COMPILER_FAMILY=${{matrix.config.family}}\
+                -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}}           \
+                -DAREG_BINARY=${{matrix.config.lib}}            \
+                -DAREG_BUILD_ALL:BOOL=ON
     
       - name: Build with cmake on Linux
         if: matrix.config.os == 'ubuntu-latest'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,10 +79,12 @@ jobs:
         run: echo "PATH=C:\cygwin64;C:\cygwin64\bin;%SYSTEMROOT%\system32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
          
       - name: Configure CMake
+        shell: cmd
         run: |
           cmake -B ${{github.workspace}}/build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON
     
       - name: Build with cmake
+        shell: cmd
         # Build your program with the given configuration
         run: cmake --build ${{github.workspace}}/build
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -71,7 +71,8 @@ jobs:
             flexdll,^
             gcc-g++,^
             make,^
-            ninja
+            ninja,^
+            ncurses
 
       - name: set PATH environment variable
         if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,6 @@ name: CMake
 
 on:
   push:
-    branches:
-    - master
-    - feature/102-extend-workflows-to-check-compilations
   pull_request:
     branches: [ master ]
 
@@ -91,7 +88,7 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: powershell
         # Build your program with the given configuration
-        run: cmake --build ./build -j 8
+        run: cmake --build ./build -j8
 
       - name: Configure CMake on Linux
         if: matrix.config.os == 'ubuntu-latest'
@@ -103,9 +100,8 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         working-directory: ${{github.workspace}}
         # Build your program with the given configuration
-        run: cmake --build ./build -j 8
+        run: cmake --build ./build -j8
 
       - name: Run Unit Tests
-        working-directory: ${{github.workspace}}/build
-        shell: bash
-        run: ctest --output-on-failure --output-junit test_results.xml
+        working-directory: ${{github.workspace}}
+        run: ctest --test-dir ./build --output-on-failure --output-junit test_results.xml

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,21 +25,21 @@ jobs:
       matrix:
         config:
             # compile AREG engine as a shared library with GNU g++ / gcc on Ubuntu Linux
-          - { name: linux-gnu-shared,     os: ubuntu-latest,   lib: shared, family: gnu,    cxx: g++        }
+          - { name: linux-gnu-shared,     os: ubuntu-latest,   lib: shared, family: gnu,    cxx: g++,        cc: gcc}
             # compile AREG engine as a static library with GNU g++ / gcc on Ubuntu Linux
-          - { name: linux-gnu-static,      os: ubuntu-latest,  lib: static, family: gnu,    cxx: g++        }
+          - { name: linux-gnu-static,      os: ubuntu-latest,  lib: static, family: gnu,    cxx: g++,        cc: gcc}
             # compile AREG engine as a shared library with clang on Ubuntu Linux
-          - { name: linux-clang-shared,    os: ubuntu-latest,  lib: shared, family: clang,  cxx: clang++-13 lld-13 }
+          - { name: linux-clang-shared,    os: ubuntu-latest,  lib: shared, family: clang,  cxx: clang++-13, cc: clang-13 }
             # compile AREG engine as a static library with clang on Ubuntu Linux
-          - { name: linux-clang-static,    os: ubuntu-latest,  lib: static, family: clang,  cxx: clang++-13 lld-13 }
+          - { name: linux-clang-static,    os: ubuntu-latest,  lib: static, family: clang,  cxx: clang++-13, cc: clang-13}
             # compile AREG engine as a shared with CYGWIN g++ / gcc on Windows
-          - { name: windows-cygwin-shared, os: windows-latest, lib: shared, family: cygwin, cxx: g++        }
+          - { name: windows-cygwin-shared, os: windows-latest, lib: shared, family: cygwin, cxx: g++,        cc: gcc}
             # compile AREG engine as a static with CYGWIN g++ / gcc on Windows
-          - { name: windows-cygwin-static, os: windows-latest, lib: static, family: cygwin, cxx: g++        }
+          - { name: windows-cygwin-static, os: windows-latest, lib: static, family: cygwin, cxx: g++,        cc: gcc}
             # compile AREG engine as a shared with MSVC on Windows
-          - { name: windows-msvc-shared,   os: windows-latest, lib: shared, family: msvc,   cxx: cl         }
+          - { name: windows-msvc-shared,   os: windows-latest, lib: shared, family: msvc,   cxx: cl,         cc: cl}
             # compile AREG engine as a static with MSVC on Windows
-          - { name: windows-msvc-static,   os: windows-latest, lib: static, family: msvc,   cxx: cl         }
+          - { name: windows-msvc-static,   os: windows-latest, lib: static, family: msvc,   cxx: cl,         cc: cl}
 
     steps:
       - name: Checkout sources
@@ -52,14 +52,16 @@ jobs:
         run: |
              sudo apt-get update
              sudo apt-get install ${{matrix.config.cxx}} -y
+             export CC=/usr/bin/${{matrix.config.cc}} CXX=/usr/bin/${{matrix.config.cxx}}
 
-      - name: Fetch CYGWIN installer on Windows
+      - name: Fetch cygwin installer on Windows
         if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
-        run: Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile C:\setup.exe
         shell: powershell
+        run: Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile C:\setup.exe
 
-      - name: Install CYGWIN on Windows
+      - name: Install cygwin on Windows
         if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
+        shell: cmd
         run: |
             c:\setup.exe -qgnO -s http://mirrors.kernel.org/sourceware/cygwin/ -l C:\cygwin-packages\ -P ^
             automake,^
@@ -68,25 +70,38 @@ jobs:
             extra-cmake-modules,^
             flexdll,^
             gcc-g++,^
-            gnome-common,^
             make,^
-            ninja,^
-            python39-setuptools
-        shell: cmd
+            ninja
 
       - name: set PATH environment variable
         if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
-        run: echo "PATH=C:\cygwin64;C:\cygwin64\bin;%SYSTEMROOT%\system32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        run: echo "PATH=C:\cygwin64;C:\cygwin64\bin;C:\cygwin64\lib;%SYSTEMROOT%\system32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
          
-      - name: Configure CMake
+      - name: Configure CMake on Windows
+        if: matrix.config.os == 'windows-latest'
+        working-directory: ${{github.workspace}}
         shell: cmd
         run: |
-          cmake -B ${{github.workspace}}/build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON
+          cmake -B ./build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON
     
-      - name: Build with cmake
+      - name: Build with cmake on Windows
+        if: matrix.config.os == 'windows-latest'
+        working-directory: ${{github.workspace}}
         shell: cmd
         # Build your program with the given configuration
-        run: cmake --build ${{github.workspace}}/build
+        run: cmake --build ./build
+
+      - name: Configure CMake on Linux
+        if: matrix.config.os == 'ubuntu-latest'
+        working-directory: ${{github.workspace}}
+        run: |
+          cmake -B ./build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON
+    
+      - name: Build with cmake on Linux
+        if: matrix.config.os == 'ubuntu-latest'
+        working-directory: ${{github.workspace}}
+        # Build your program with the given configuration
+        run: cmake --build ./build
 
       - name: Run Unit Tests
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,6 +40,7 @@ jobs:
           - { name: windows-msvc-static,   os: windows-latest, lib: static, family: msvc,   cxx: cl,         cc: cl}
 
     steps:
+
       - name: Checkout AREG engine (AREG SDK) source codes and dependencies
         uses: actions/checkout@v3
         with:
@@ -85,7 +86,6 @@ jobs:
     
       - name: Build with CMake
         working-directory: ${{github.workspace}}
-        shell: powershell
         # Build your program with the given configuration
         run: cmake --build ./build -j8
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,32 +2,94 @@ name: CMake
 
 on:
   push:
-    branches: [ master ]
+    branches:
+    - master
+    - feature/102-extend-workflows-to-check-compilations
   pull_request:
     branches: [ master ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Debug
+  BUILD_TYPE: Release
+
+# The CMake configure and build commands are platform agnostic and should work equally well on Windows or Linux.
+# You can convert this to a matrix build if you need cross-platform coverage.
+# See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
 
 jobs:
-  build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+  build-tests:
+    name: ${{matrix.config.name}}
+    runs-on: ${{matrix.config.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+            # compile AREG engine as a shared library with GNU g++ / gcc on Ubuntu Linux
+          - { name: linux-gnu-shared,     os: ubuntu-latest,   lib: shared, family: gnu,    cxx: g++        }
+            # compile AREG engine as a static library with GNU g++ / gcc on Ubuntu Linux
+          - { name: linux-gnu-static,      os: ubuntu-latest,  lib: static, family: gnu,    cxx: g++        }
+            # compile AREG engine as a shared library with clang on Ubuntu Linux
+          - { name: linux-clang-shared,    os: ubuntu-latest,  lib: shared, family: clang,  cxx: clang++-13 }
+            # compile AREG engine as a static library with clang on Ubuntu Linux
+          - { name: linux-clang-static,    os: ubuntu-latest,  lib: static, family: clang,  cxx: clang++-13 }
+            # compile AREG engine as a shared with CYGWIN g++ / gcc on Windows
+          - { name: windows-cygwin-shared, os: windows-latest, lib: shared, family: cygwin, cxx: g++        }
+            # compile AREG engine as a static with CYGWIN g++ / gcc on Windows
+          - { name: windows-cygwin-static, os: windows-latest, lib: static, family: cygwin, cxx: g++        }
+            # compile AREG engine as a shared with MSVC on Windows
+          - { name: windows-msvc-shared,   os: windows-latest, lib: shared, family: msvc,   cxx: cl         }
+            # compile AREG engine as a static with MSVC on Windows
+          - { name: windows-msvc-static,   os: windows-latest, lib: static, family: msvc,   cxx: cl         }
+
+    env:
+      CTEST_OUTPUT_ON_FAILURE: 1
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-         submodules: recursive
-         
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Install compilers on Linux
+        if: runner.os == 'Linux'
+        run: |
+             sudo apt-get update
+             sudo apt-get install ${{matrix.config.cxx}} -y
+
+      - name: Fetch CYGWIN installer on Windows
+        if: runner.os == 'Windows' && matrix.config.family == 'cygwin'
+        run: Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile C:\setup.exe
+        shell: powershell
+
+      - name: Install CYGWIN on Windows
+        if: runner.os == 'Windows' && matrix.config.family == 'cygwin'
+        run: |
+            c:\setup.exe -qgnO -s http://mirrors.kernel.org/sourceware/cygwin/ -l C:\cygwin-packages\ -P ^
+            automake,^
+            cmake,^
+            dos2unix,^
+            extra-cmake-modules,^
+            flexdll,^
+            gcc-g++,^
+            gnome-common,^
+            make,^
+            ninja,^
+            python39-setuptools
+        shell: cmd
+
+      - name: set PATH environment variable
+        if: runner.os == 'Windows' && matrix.config.family == 'cygwin'
+        run: echo "PATH=C:\cygwin64;C:\cygwin64\bin;%SYSTEMROOT%\system32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+         
+      - name: Configure CMake
+        run: |
+          cmake -B ${{github.workspace}}/build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON -DAREG_OUTPUT_DIR=${{github.workspace}}/product
+    
+      - name: Build with cmake
+        # Build your program with the given configuration
+        run: cmake --build ${{github.workspace}}/build
+
+      - name: Run Unit Tests
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        run: ctest --output-on-failure --output-junit test_results.xml

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,7 +51,7 @@ jobs:
           submodules: recursive
 
       - name: Install compilers on Linux
-        if: runner.os == 'Linux'
+        if: matrix.config.os == 'ubuntu-latest' && matrix.config.family == 'clang'
         run: |
              sudo apt-get update
              sudo apt-get install ${{matrix.config.cxx}} -y

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -72,7 +72,8 @@ jobs:
             gcc-g++,^
             make,^
             ninja,^
-            ncurses
+            ncurses,^
+            libncurses-devel
 
       - name: set PATH environment variable
         if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
@@ -90,7 +91,7 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: cmd
         # Build your program with the given configuration
-        run: cmake --build ./build
+        run: cmake --build ./build -j 8
 
       - name: Configure CMake on Linux
         if: matrix.config.os == 'ubuntu-latest'
@@ -102,7 +103,7 @@ jobs:
         if: matrix.config.os == 'ubuntu-latest'
         working-directory: ${{github.workspace}}
         # Build your program with the given configuration
-        run: cmake --build ./build
+        run: cmake --build ./build -j 8
 
       - name: Run Unit Tests
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -78,37 +78,14 @@ jobs:
         if: matrix.config.os == 'windows-latest' && matrix.config.family == 'cygwin'
         run: echo "PATH=C:\cygwin64;C:\cygwin64\bin;C:\cygwin64\lib;%SYSTEMROOT%\system32;%PATH%" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
          
-      - name: Configure CMake on Windows
-        if: matrix.config.os == 'windows-latest'
-        working-directory: ${{github.workspace}}
-        shell: powershell
-        run: |
-          cmake -B ./build                                       \
-                -DAREG_COMPILER_FAMILY=${{matrix.config.family}} \
-                -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}}            \
-                -DAREG_BINARY=${{matrix.config.lib}}             \
-                -DAREG_BUILD_ALL:BOOL=ON
-    
-      - name: Build with cmake on Windows
-        if: matrix.config.os == 'windows-latest'
-        working-directory: ${{github.workspace}}
-        shell: powershell
-        # Build your program with the given configuration
-        run: cmake --build ./build -j8
-
-      - name: Configure CMake on Linux
-        if: matrix.config.os == 'ubuntu-latest'
+      - name: Configure CMake
         working-directory: ${{github.workspace}}
         run: |
-          cmake -B ./build                                       \
-                -DAREG_COMPILER_FAMILY=${{matrix.config.family}} \
-                -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}}            \
-                -DAREG_BINARY=${{matrix.config.lib}}             \
-                -DAREG_BUILD_ALL:BOOL=ON
+          cmake -B ./build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON
     
-      - name: Build with cmake on Linux
-        if: matrix.config.os == 'ubuntu-latest'
+      - name: Build with CMake
         working-directory: ${{github.workspace}}
+        shell: powershell
         # Build your program with the given configuration
         run: cmake --build ./build -j8
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,9 +29,9 @@ jobs:
             # compile AREG engine as a static library with GNU g++ / gcc on Ubuntu Linux
           - { name: linux-gnu-static,      os: ubuntu-latest,  lib: static, family: gnu,    cxx: g++        }
             # compile AREG engine as a shared library with clang on Ubuntu Linux
-          - { name: linux-clang-shared,    os: ubuntu-latest,  lib: shared, family: clang,  cxx: clang++-13 }
+          - { name: linux-clang-shared,    os: ubuntu-latest,  lib: shared, family: clang,  cxx: clang++-13 lld-13 }
             # compile AREG engine as a static library with clang on Ubuntu Linux
-          - { name: linux-clang-static,    os: ubuntu-latest,  lib: static, family: clang,  cxx: clang++-13 }
+          - { name: linux-clang-static,    os: ubuntu-latest,  lib: static, family: clang,  cxx: clang++-13 lld-13 }
             # compile AREG engine as a shared with CYGWIN g++ / gcc on Windows
           - { name: windows-cygwin-shared, os: windows-latest, lib: shared, family: cygwin, cxx: g++        }
             # compile AREG engine as a static with CYGWIN g++ / gcc on Windows
@@ -41,9 +41,6 @@ jobs:
             # compile AREG engine as a static with MSVC on Windows
           - { name: windows-msvc-static,   os: windows-latest, lib: static, family: msvc,   cxx: cl         }
 
-    env:
-      CTEST_OUTPUT_ON_FAILURE: 1
-
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -51,7 +48,7 @@ jobs:
           submodules: recursive
 
       - name: Install compilers on Linux
-        if: matrix.config.os == 'ubuntu-latest' && matrix.config.family == 'clang'
+        if: matrix.config.os == 'ubuntu-latest'
         run: |
              sudo apt-get update
              sudo apt-get install ${{matrix.config.cxx}} -y
@@ -83,7 +80,7 @@ jobs:
          
       - name: Configure CMake
         run: |
-          cmake -B ${{github.workspace}}/build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON -DAREG_OUTPUT_DIR=${{github.workspace}}/product
+          cmake -B ${{github.workspace}}/build -DAREG_COMPILER_FAMILY=${{matrix.config.family}} -DAREG_BUILD_TYPE=${{env.BUILD_TYPE}} -DAREG_BINARY=${{matrix.config.lib}} -DAREG_BUILD_ALL:BOOL=ON
     
       - name: Build with cmake
         # Build your program with the given configuration

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -24,9 +24,12 @@ endif()
 # The toolset
 set(AREG_TOOLCHAIN "${CMAKE_CXX_COMPILER_ID}")
 # Relative path of the output folder for the builds
-string(TOLOWER "${AREG_USER_DEF_OUTPUT_DIR}/build/${AREG_TOOLCHAIN}/${AREG_OS}-${AREG_PLATFORM}-${CMAKE_BUILD_TYPE}" AREG_PRODUCT_PATH)
+set(AREG_PRODUCT_PATH "${AREG_USER_DEF_OUTPUT_DIR}/build/${AREG_TOOLCHAIN}/${AREG_OS}-${AREG_PLATFORM}-${CMAKE_BUILD_TYPE}")
+string(TOLOWER "${AREG_PRODUCT_PATH}" AREG_PRODUCT_PATH)
 # The absolute path for builds
-set(AREG_OUTPUT_DIR "${AREG_BUILD_ROOT}/${AREG_PRODUCT_PATH}")
+if (NOT DEFINED AREG_OUTPUT_DIR OR AREG_OUTPUT_DIR STREQUAL "")
+    set(AREG_OUTPUT_DIR "${AREG_BUILD_ROOT}/${AREG_PRODUCT_PATH}")
+endif()
 # The absolute path for generated files
 set(AREG_GENERATE_DIR "${AREG_BUILD_ROOT}/${AREG_USER_DEF_OUTPUT_DIR}/generate")
 # The absolute path for obj files.
@@ -157,6 +160,7 @@ if(UNIX AND NOT APPLE)
     set(CMAKE_EXECUTABLE_SUFFIX ".out")
 endif()
 
-message(STATUS ">>> \'${CMAKE_BUILD_TYPE}\' build for \'${CMAKE_SYSTEM_NAME}\' platform with compiler \'${CMAKE_CXX_COMPILER}\', ID \'${CMAKE_CXX_COMPILER_ID}\'")
+message(STATUS ">>> Build for \'${CMAKE_SYSTEM_NAME}\' platform with compiler \'${CMAKE_CXX_COMPILER}\', ID \'${CMAKE_CXX_COMPILER_ID}\', and build type \'${CMAKE_BUILD_TYPE}\'")
 message(STATUS ">>> Build binary output folder \'${AREG_OUTPUT_BIN}\'")
 message(STATUS ">>> Build library output folder \'${AREG_OUTPUT_LIB}\'")
+message(STATUS ">>> Build examples is '${AREG_BUILD_EXAMPLES}\', build tests is \'${AREG_BUILD_TESTS}\'")

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -71,7 +71,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     endif()
 
     # Clang compile options
-    list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -stdlib=libc++ ${AREG_USER_DEFINES})
+    list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -stdlib=libstdc++ ${AREG_USER_DEFINES})
     # Linker flags (-l is not necessary)
     list(APPEND AREG_LDFLAGS c++ m ncurses pthread rt "${AREG_USER_DEF_LIBS}")
 

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -8,8 +8,11 @@ if(APPLE)
     set(AREG_OS "macOS")
 elseif(UNIX)
     set(AREG_OS "Linux")
-else()
+elseif(WIN32)
     set(AREG_OS "Windows")
+else()
+    message(WARNING ">>> Unrecognized Operating System, set default Linux to try to compile")
+    set(AREG_OS "Linux")
 endif()
 
 # Determining bitness by size of void pointer
@@ -22,7 +25,11 @@ endif()
 # areg specific internal variable settings
 # -----------------------------------------------------
 # The toolset
-set(AREG_TOOLCHAIN "${CMAKE_CXX_COMPILER_ID}")
+if (CYGWIN)
+    set(AREG_TOOLCHAIN "CYGWIN")
+else()
+    set(AREG_TOOLCHAIN "${CMAKE_CXX_COMPILER_ID}")
+endif()
 # Relative path of the output folder for the builds
 set(AREG_PRODUCT_PATH "${AREG_USER_DEF_OUTPUT_DIR}/build/${AREG_TOOLCHAIN}/${AREG_OS}-${AREG_PLATFORM}-${CMAKE_BUILD_TYPE}")
 string(TOLOWER "${AREG_PRODUCT_PATH}" AREG_PRODUCT_PATH)
@@ -88,7 +95,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     endif()
 
     # GNU compile options
-    if (${AREG_OS} MATCHES "Window")
+    if (CYGWIN)
         list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -MMD -std=gnu++17 ${AREG_USER_DEFINES})
     else()
         list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -MMD -std=c++17 ${AREG_USER_DEFINES})
@@ -156,11 +163,14 @@ set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES ${AREG_OUTPUT_DIR}
 link_directories(BEFORE "${AREG_OUTPUT_BIN} ${AREG_OUTPUT_LIB} ${AREG_USER_DEF_LIB_PATHS}")
 
 # Only for Linux
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT CYGWIN)
     set(CMAKE_EXECUTABLE_SUFFIX ".out")
 endif()
 
+message(STATUS "-------------------- Status Report Begin --------------------")
+message(STATUS ">>> Build executables are with extension \'${CMAKE_EXECUTABLE_SUFFIX}\'")
 message(STATUS ">>> Build for \'${CMAKE_SYSTEM_NAME}\' platform with compiler \'${CMAKE_CXX_COMPILER}\', ID \'${CMAKE_CXX_COMPILER_ID}\', and build type \'${CMAKE_BUILD_TYPE}\'")
-message(STATUS ">>> Build binary output folder \'${AREG_OUTPUT_BIN}\'")
-message(STATUS ">>> Build library output folder \'${AREG_OUTPUT_LIB}\'")
+message(STATUS ">>> Binary output folder \'${AREG_OUTPUT_BIN}\'")
+message(STATUS ">>> Library output folder \'${AREG_OUTPUT_LIB}\'")
 message(STATUS ">>> Build examples is '${AREG_BUILD_EXAMPLES}\', build tests is \'${AREG_BUILD_TESTS}\'")
+message(STATUS "-------------------- Status Report End ----------------------")


### PR DESCRIPTION
Extended CMake workflow to force compile codes on each push, so that can check builds:
1. Linux, gcc compiler AREG engine static / shared library
2. Linux, clang compiler AREG engine static / shared library
3. Window, cygwin-gcc compiler AREG engine static / shared library
4. Window, msvc compiler AREG engine static / shared library