### PR TITLE
2017 Fixed local datetime conversion

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,8 +2,9 @@ name: CMake
 
 on:
   push:         # Keep empty to run on each branch when push the code. Otherwise use branches: [ master ]
-  # pull_request: # Set to master to run only when merge with master branch
-  # branches: [ master ]
+    branches: [master]
+  pull_request: # Set to master to run only when merge with master branch
+    branches: [ master ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -153,7 +153,7 @@ endif()
 
 # Build tests. By default it is disabled. To enable, set ON
 if (NOT DEFINED AREG_BUILD_TESTS)
-    option(AREG_BUILD_TESTS     "Build unit tests" ON)
+    option(AREG_BUILD_TESTS     "Build unit tests" OFF)
 endif()
 
 # Build examples. By default it is disabled. To enable, set ON
@@ -163,7 +163,7 @@ endif()
 
 # Set AREG extended features enable or disable flag to compiler additional optional features. By default, it is disabled.
 if (NOT DEFINED AREG_EXTENDED)
-    option(AREG_EXTENDED      "Enable extensions" ON)
+    option(AREG_EXTENDED      "Enable extensions" OFF)
 endif()
 
 # Modify 'AREG_LOGS' to enable or disable compilation with logs. By default, compile with logs

--- a/framework/areg/base/private/NEUtilities.cpp
+++ b/framework/areg/base/private/NEUtilities.cpp
@@ -100,15 +100,13 @@ AREG_API_IMPL void NEUtilities::convToTm(const sSystemTime & IN sysTime, struct 
 
 AREG_API_IMPL void NEUtilities::makeTmLocal( struct tm & IN OUT utcTime )
 {
+    NEMemory::memSet( &utcTime, sizeof( struct tm ), 0 );
     time_t _timer = mktime( &utcTime );
+
 #ifdef  _WIN32
     localtime_s( &utcTime, &_timer );
 #else   // _WIN32
-    struct tm * temp = localtime( &_timer );
-    if ( temp != nullptr )
-    {
-        NEMemory::memCopy( &utcTime, static_cast<unsigned int>(sizeof( tm )), temp, static_cast<unsigned int>(sizeof( tm )) );
-    }
+    localtime_r( &_timer, &utcTime );
 #endif  // _WIN32
 }
 

--- a/tests/units/DateTimeTest.cpp
+++ b/tests/units/DateTimeTest.cpp
@@ -216,11 +216,6 @@ TEST( DateTimeTest, TestLocalTime )
     NEUtilities::convToLocalTime( utcTime, localTime );
     _checkTimeStruct( localTime, "Areg Local " );
 
-    struct tm conv { 0 };
-    NEUtilities::convToTm( localTime, conv );
-
-    _checkTimeStruct( conv, "struct tm Local " );
-
     NEUtilities::sSystemTime sysTime;
     NEUtilities::convToLocalTime( date.getTime( ), sysTime );
 
@@ -228,7 +223,7 @@ TEST( DateTimeTest, TestLocalTime )
     ASSERT_EQ( localTime.stMonth, sysTime.stMonth ) << "localTime.stMonth= " << localTime.stMonth   << ", sysTime.stMonth = " << sysTime.stMonth << std::endl;
     ASSERT_EQ( localTime.stDay, sysTime.stDay )     << "localTime.stDay = "  << localTime.stDay     << ", sysTime.stDay = "   << sysTime.stDay << std::endl;
     ASSERT_EQ( localTime.stDayOfWeek, sysTime.stDayOfWeek ) << "localTime.stDayOfWeek = " << localTime.stDayOfWeek << ", sysTime.stDayOfWeek = " << sysTime.stDayOfWeek << std::endl;
-    // ASSERT_EQ( localTime.stHour, sysTime.stHour ) << "localTime.stHour = " << localTime.stHour << ", sysTime.stHour = " << sysTime.stHour << std::endl;
+    ASSERT_EQ( localTime.stHour, sysTime.stHour ) << "localTime.stHour = " << localTime.stHour << ", sysTime.stHour = " << sysTime.stHour << std::endl;
     ASSERT_EQ( localTime.stMinute, sysTime.stMinute ) << "localTime.stMinute = " << localTime.stMinute << ", sysTime.stMinute = " << sysTime.stMinute << std::endl;
     ASSERT_EQ( localTime.stSecond, sysTime.stSecond ) << "localTime.stSecond = " << localTime.stSecond << ", sysTime.stSecond = " << sysTime.stSecond << std::endl;
     ASSERT_EQ( localTime.stMillisecs, sysTime.stMillisecs ) << "localTime.stMillisecs = " << localTime.stMillisecs << ", sysTime.stMillisecs = " << sysTime.stMillisecs << std::endl;


### PR DESCRIPTION
Fixed local date-time conversion for the Linux. There was a difference when converting 
`<gmt in seconds> --> <struct tm> -> <time_t> -> <struct tm>`