### PR TITLE
Fixed resizing ring stack, segmentation fault and exit logging threads

### DIFF
--- a/examples/04_trace/config/areg.init
+++ b/examples/04_trace/config/areg.init
@@ -63,8 +63,7 @@
 #   Meaning of Layout format:
 #       The Layout Format is relevant only when logs the messages in the plain text file.
 #       The Layout Format specification fields are following:
-            %a      -- outputs the ID of a logging object set by the logger.
-            %b      -- outputs the module name of the logging object.
+#           %a      -- outputs the ID of a logging object set by the logger.
 #           %c      -- output tick-count value since process start
 #           %d      -- output day and time data
 #           %e      -- output module (process) ID
@@ -134,8 +133,6 @@ log::*::layout::exit        = %d: [ %t  %x.%z: Exit <-- ]%n    # Exit scope layo
 # ###########################################################################
 
 log::*::scope::*			= DEBUG | SCOPE ;
-# log::*::scope::areg_*       = NOTSET ;
-log::mcrouter::scope::*     = DEBUG | SCOPE ;
 log::logger::scope::*       = NOTSET ;
 
 # ###########################################################################

--- a/framework/areg/base/NESocket.hpp
+++ b/framework/areg/base/NESocket.hpp
@@ -224,26 +224,30 @@ namespace NESocket
      *          The size of buffer to reserve for IP address, like "255.255.255.255"
      **/
     constexpr uint32_t  IP_ADDRESS_SIZE                             { 16 };
+
     /**
-     * \brief   NESocket::DEFAULT_SEGMENT_SIZE
-     *          The default size of segment when sends or receives data.
+     * \brief   NESocket::PACKET_MIN_SIZE
+     *          The minimum size of packet when send or receive data.
      **/
-    constexpr unsigned int              DEFAULT_SEGMENT_SIZE        { 1500 };
+    constexpr unsigned int              PACKET_MIN_SIZE             { 512 };
+
     /**
-     * \brief   NESocket::MAX_SEGMENT_SIZE
-     *          The maximum size of segment when sends or receives data.
+     * \brief   NESocket::PACKET_DEFAULT_SIZE
+     *          The default size of packet when send or receive data.
      **/
-    constexpr unsigned int              MAX_SEGMENT_SIZE            { 8 * NECommon::ONE_MEGABYTE };
+    constexpr unsigned int              PACKET_DEFAULT_SIZE         { 1500 };
+
     /**
-     * \brief   NESocket::MIN_SEGMENT_SIZE
-     *          The minimum size of segment when sends or receives data.
+     * \brief   NESocket::PACKET_MAX_SIZE
+     *          The maximum size of packet when send or receive data.
      **/
-    constexpr unsigned int              MIN_SEGMENT_SIZE            { 8 * NECommon::ONE_KILOBYTE };
+    constexpr unsigned int              PACKET_MAX_SIZE             { 65536 };
+
     /**
-     * \brief   NESocket::SEGMENT_INVALID_SIZE
-     *          The invalid size of segment.
+     * \brief   NESocket::PACKET_INVALID_SIZE
+     *          Packet invalid size.
      **/
-    constexpr unsigned int              SEGMENT_INVALID_SIZE        { 0 };
+    constexpr unsigned int              PACKET_INVALID_SIZE         { 0 };
 
     /**
      * \brief   NESocket::MAXIMUM_LISTEN_QUEUE_SIZE
@@ -387,29 +391,29 @@ namespace NESocket
 
     /**
      * \brief   NESocket::setMaxSendSize
-     *          Sets the socket buffer size in bytes to send the packet at once.
+     *          Sets the socket packet size in bytes to send data at once.
      * \param   hSocket     The valid socket descriptor to set the value.
      * \param   sendSize    The size in bytes to sent the packet at once.
-     *                      The minimum size is NESocket::MIN_SEGMENT_SIZE,
-     *                      the maximum is NESocket::MAX_SEGMENT_SIZE.
+     *                      The minimum size is NESocket::PACKET_MIN_SIZE,
+     *                      the maximum is NESocket::PACKET_MAX_SIZE.
      **/
     AREG_API unsigned int setMaxSendSize(SOCKETHANDLE hSocket, unsigned int sendSize);
 
     /**
      * \brief   NESocket::getMaxReceiveSize
-     *          Calculated the maximum number of package size in bytes, which can be received.
-     *          This value may vary by protocol.
+     *          Maximum size of packet in bytes to receive data.
      * \param   hSocket     The valid socket descriptor to retrieve value.
      **/
     AREG_API unsigned int getMaxReceiveSize( SOCKETHANDLE hSocket );
 
     /**
      * \brief   NESocket::setMaxReceiveSize
-     *          Sets the socket buffer size in bytes to receive the packet at once.
+     *          Sets the socket packet size in bytes to receive data at once.
      * \param   hSocket     The valid socket descriptor to set the value.
      * \param   recvSize    The size in bytes to receive the packet at once.
-     *                      The minimum size is NESocket::MIN_SEGMENT_SIZE,
-     *                      the maximum is NESocket::MAX_SEGMENT_SIZE.
+     *                      The minimum size is NESocket::PACKET_MIN_SIZE.
+     *                      The maximum is NESocket::PACKET_MAX_SIZE.
+     *                      The default seize is NESocket::PACKET_DEFAULT_SIZE.
      **/
     AREG_API unsigned int setMaxReceiveSize(SOCKETHANDLE hSocket, unsigned int recvSize);
 

--- a/framework/areg/base/Socket.hpp
+++ b/framework/areg/base/Socket.hpp
@@ -240,14 +240,14 @@ public:
     bool setAddress( const char * hostName, unsigned short portNr, bool isServer );
 
     /**
-     * \brief   Returns the segment size in bytes to send data.
+     * \brief   Returns the packet size in bytes to send data.
      **/
-    inline unsigned int getSendSegmentSize(void) const;
+    inline unsigned int getSendPacketSize(void) const;
 
     /**
-     * \brief   Returns the segment size in bytes to receive data.
+     * \brief   Returns the packet size in bytes to receive data.
      **/
-    inline unsigned int getRecvSegmentSize(void) const;
+    inline unsigned int getRecvPacketSize(void) const;
 
 protected:
 /************************************************************************/
@@ -269,36 +269,32 @@ protected:
     void decreaseLock( void );
 
     /**
-     * \brief   Sets the segment size in bytes of socket to send data. Before checking, the method checks
-     *          that new size of segment is between NESocket::MIN_SEGMENT_SIZE and NESocket::MAX_SEGMENT_SIZE.
-     *          If value is NESocket::SEGMENT_INVALID_SIZE, it will set the size NESocket::DEFAULT_SEGMENT_SIZE.
-     *          It updates the segment size only if the new value is bigger than the actual or it 'force' value is true.
+     * \brief   Sets the socket packet size in bytes to send data. The packet cannot be smaller than NESocket::PACKET_MIN_SIZE
+     *          and bigger than NESocket::PACKET_MAX_SIZE. 
      * 
-     * \param   sendSize    The new size of segment in bytes to set for sending data.
-     *                      The function checks and normalizes value if it is not in the range
-     *                      between NESocket::MIN_SEGMENT_SIZE and NESocket::MAX_SEGMENT_SIZE.
-     * \param   force       If set true, it forces to update the segment size. Otherwise, the segment size
-     *                      is update only if new size is bigger than the actual.
-     * \return  Returns the actual size of the segment in bytes to send data.
-     *          Returns NESocket::SEGMENT_INVALID_SIZE if socket is not valid.
+     * \param   sendSize    The size of packet in bytes to set to send data.
+     *                      The function checks and normalizes size in range between 
+     *                      NESocket::PACKET_MIN_SIZE and NESocket::PACKET_MAX_SIZE.
+     * \param   force       If true, it forces to update the packet size. Otherwise, the packet size
+     *                      is updated only if new size is bigger than the actual.
+     * \return  Returns the actual size of packet in bytes to send data. If socket is not valid,
+     *          return NESocket::PACKET_INVALID_SIZE.
      **/
-    unsigned int setSendSegmentSize(unsigned int sendSize, bool force = false) const;
+    unsigned int setSendPacketSize(unsigned int sendSize, bool force = false) const;
 
-    /**
-     * \brief   Sets the segment size in bytes of socket to receive data. Before checking, the method checks
-     *          that new size of segment is between NESocket::MIN_SEGMENT_SIZE and NESocket::MAX_SEGMENT_SIZE.
-     *          If value is NESocket::SEGMENT_INVALID_SIZE, it will set the size NESocket::DEFAULT_SEGMENT_SIZE.
-     *          It updates the segment size only if the new value is bigger than the actual or it 'force' value is true.
-     *
-     * \param   recvSize    The new size of segment in bytes to set for receiving data.
-     *                      The function checks and normalizes value if it is not in the range
-     *                      between NESocket::MIN_SEGMENT_SIZE and NESocket::MAX_SEGMENT_SIZE.
-     * \param   force       If set true, it forces to update the segment size. Otherwise, the segment size
-     *                      is update only if new size is bigger than the actual.
-     * \return  Returns the actual size of the segment in bytes to receive data.
-     *          Returns NESocket::SEGMENT_INVALID_SIZE if socket is not valid.
-     **/
-    unsigned int setRecvSegmentSize(unsigned int recvSize, bool force = false) const;
+     /**
+      * \brief   Sets the socket packet size in bytes to receive data. The packet cannot be smaller than NESocket::PACKET_MIN_SIZE
+      *          and bigger than NESocket::PACKET_MAX_SIZE.
+      *
+      * \param   recvSize    The size of packet in bytes to set to receive data.
+      *                      The function checks and normalizes size in range between
+      *                      NESocket::PACKET_MIN_SIZE and NESocket::PACKET_MAX_SIZE.
+      * \param   force       If true, it forces to update the packet size. Otherwise, the packet size
+      *                      is update only if new size is bigger than the actual.
+      * \return  Returns the actual size of packet in bytes to receive data. If socket is not valid,
+      *          return NESocket::PACKET_INVALID_SIZE.
+      **/
+    unsigned int setRecvPacketSize(unsigned int recvSize, bool force = false) const;
 
 //////////////////////////////////////////////////////////////////////////
 // Member variables
@@ -324,19 +320,15 @@ protected:
     NESocket::SocketAddress mAddress;
 
     /**
-     * \brief   The size in bytes of segment to send data.
-     *          It should not be less than NESocket::MIN_SEGMENT_SIZE and
-     *          more than NESocket::MAX_SEGMENT_SIZE.
-     *          The default value is NESocket::DEFAULT_SEGMENT_SIZE
+     * \brief   The size in bytes of packet to send data.
+     *          Should be in range NESocket::PACKET_MIN_SIZE and NESocket::PACKET_MAX_SIZE.
      **/
     mutable unsigned int    mSendSize;
 
-    /**
-     * \brief   The size in bytes of segment to receive data.
-     *          It should not be less than NESocket::MIN_SEGMENT_SIZE and
-     *          more than NESocket::MAX_SEGMENT_SIZE.
-     *          The default value is NESocket::DEFAULT_SEGMENT_SIZE
-     **/
+     /**
+      * \brief   The size in bytes of packet to receive data.
+      *          Should be in range NESocket::PACKET_MIN_SIZE and NESocket::PACKET_MAX_SIZE.
+      **/
     mutable unsigned int    mRecvSize;
 };
 
@@ -384,14 +376,14 @@ inline bool Socket::disableReceive( void ) const
     return (mSocket.get() != nullptr) && NESocket::disableReceive(*mSocket);
 }
 
-inline unsigned int Socket::getSendSegmentSize(void) const
+inline unsigned int Socket::getSendPacketSize(void) const
 {
-    return (isValid() ? mSendSize : NESocket::SEGMENT_INVALID_SIZE);
+    return (isValid() ? mSendSize : NESocket::PACKET_INVALID_SIZE);
 }
 
-unsigned int Socket::getRecvSegmentSize(void) const
+unsigned int Socket::getRecvPacketSize(void) const
 {
-    return (isValid() ? mRecvSize : NESocket::SEGMENT_INVALID_SIZE);
+    return (isValid() ? mRecvSize : NESocket::PACKET_INVALID_SIZE);
 }
 
 #endif  // AREG_BASE_SOCKET_HPP

--- a/framework/areg/base/TEResourceListMap.hpp
+++ b/framework/areg/base/TEResourceListMap.hpp
@@ -95,7 +95,7 @@ protected:
     /**
      * \brief   Destructor.
      **/
-    ~TEResourceListMap( void ) = default;
+    ~TEResourceListMap( void );
 
 //////////////////////////////////////////////////////////////////////////
 // Operations and attributes
@@ -398,6 +398,16 @@ template < typename RESOURCE_KEY
          , class ResourceList   /*= TELinkedList<RESOURCE_OBJECT>*/
          , class HashMap        /*= TEHashMap<RESOURCE_KEY, ResourceList>*/
          , class Tracker        /*= TEResourceListMapImpl<RESOURCE_KEY, RESOURCE_OBJECT, ResourceList>*/>
+inline TEResourceListMap<RESOURCE_KEY, RESOURCE_OBJECT, ResourceList, HashMap, Tracker>::~TEResourceListMap(void)
+{
+    removeAllResources();
+}
+
+template < typename RESOURCE_KEY
+         , typename RESOURCE_OBJECT
+         , class ResourceList   /*= TELinkedList<RESOURCE_OBJECT>*/
+         , class HashMap        /*= TEHashMap<RESOURCE_KEY, ResourceList>*/
+         , class Tracker        /*= TEResourceListMapImpl<RESOURCE_KEY, RESOURCE_OBJECT, ResourceList>*/>
 inline void TEResourceListMap<RESOURCE_KEY, RESOURCE_OBJECT, ResourceList, HashMap, Tracker>::lock( void ) const
 {
     mSynchObj.lock( NECommon::WAIT_INFINITE );
@@ -577,7 +587,7 @@ inline void TEResourceListMap<RESOURCE_KEY, RESOURCE_OBJECT, ResourceList, HashM
 
     for (typename HashMap::MAPPOS pos = HashMap::firstPosition( ); HashMap::isValidPosition(pos); pos = HashMap::nextPosition( pos ) )
     {
-        cleanResourceList(pos->first, pos->second);
+        cleanResourceList(HashMap::keyAtPosition(pos), HashMap::valueAtPosition(pos));
     }
 
     HashMap::clear( );

--- a/framework/areg/base/private/NESocket.cpp
+++ b/framework/areg/base/private/NESocket.cpp
@@ -10,7 +10,7 @@
  * \file        areg/base/private/NESocketWin.cpp
  * \ingroup     AREG Asynchronous Event-Driven Communication Framework
  * \author      Artak Avetyan
- * \brief       AREG Platform. Socket OS independentant methods
+ * \brief       AREG Platform. Socket OS independent methods
  ************************************************************************/
 #include "areg/base/NESocket.hpp"
 
@@ -308,8 +308,8 @@ AREG_API_IMPL unsigned int NESocket::getMaxSendSize( SOCKETHANDLE hSocket )
 {
     ASSERT(isSocketHandleValid(hSocket));
 
-    unsigned long maxData= NESocket::DEFAULT_SEGMENT_SIZE;
-    return (_osGetOption(hSocket, SOL_SOCKET, SO_SNDBUF, maxData) ? static_cast<unsigned int>(maxData) : NESocket::DEFAULT_SEGMENT_SIZE);
+    unsigned long maxData{ NESocket::PACKET_DEFAULT_SIZE };
+    return (_osGetOption(hSocket, SOL_SOCKET, SO_SNDBUF, maxData) ? static_cast<unsigned int>(maxData) : NESocket::PACKET_DEFAULT_SIZE);
 }
 
 AREG_API_IMPL unsigned int NESocket::setMaxSendSize(SOCKETHANDLE hSocket, unsigned int sendSize)
@@ -318,25 +318,26 @@ AREG_API_IMPL unsigned int NESocket::setMaxSendSize(SOCKETHANDLE hSocket, unsign
 
     if (sendSize == 0)
     {
-        sendSize = NESocket::DEFAULT_SEGMENT_SIZE;
+        sendSize = NESocket::PACKET_DEFAULT_SIZE;
     }
-    else if (sendSize < NESocket::MIN_SEGMENT_SIZE)
+    else if (sendSize < NESocket::PACKET_MIN_SIZE)
     {
-        sendSize = NESocket::MIN_SEGMENT_SIZE;
+        sendSize = NESocket::PACKET_MIN_SIZE;
     }
-    else if (sendSize > NESocket::MAX_SEGMENT_SIZE)
+    else if (sendSize > NESocket::PACKET_MAX_SIZE)
     {
-        sendSize = NESocket::MAX_SEGMENT_SIZE;
+        sendSize = NESocket::PACKET_MAX_SIZE;
     }
 
-    return (RETURNED_OK == ::setsockopt(hSocket, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<const char*>(&sendSize), sizeof(sendSize)) ? sendSize : NESocket::MIN_SEGMENT_SIZE);
+    constexpr unsigned int len{ sizeof(unsigned int) };
+    return (RETURNED_OK == ::setsockopt(hSocket, SOL_SOCKET, SO_SNDBUF, reinterpret_cast<const char*>(&sendSize), len) ? sendSize : NESocket::PACKET_MIN_SIZE);
 }
 
 AREG_API_IMPL unsigned int NESocket::getMaxReceiveSize( SOCKETHANDLE hSocket )
 {
     ASSERT(isSocketHandleValid(hSocket));
-    unsigned long maxData = NESocket::DEFAULT_SEGMENT_SIZE;
-    return (_osGetOption(hSocket, SOL_SOCKET, SO_RCVBUF, maxData) ? static_cast<unsigned int>(maxData) : NESocket::DEFAULT_SEGMENT_SIZE);
+    unsigned long maxData{ NESocket::PACKET_DEFAULT_SIZE };
+    return (_osGetOption(hSocket, SOL_SOCKET, SO_RCVBUF, maxData) ? static_cast<unsigned int>(maxData) : NESocket::PACKET_DEFAULT_SIZE);
 }
 
 AREG_API_IMPL unsigned int NESocket::setMaxReceiveSize(SOCKETHANDLE hSocket, unsigned int recvSize)
@@ -345,18 +346,19 @@ AREG_API_IMPL unsigned int NESocket::setMaxReceiveSize(SOCKETHANDLE hSocket, uns
 
     if (recvSize == 0)
     {
-        recvSize = NESocket::DEFAULT_SEGMENT_SIZE;
+        recvSize = NESocket::PACKET_DEFAULT_SIZE;
     }
-    else if (recvSize < NESocket::MIN_SEGMENT_SIZE)
+    else if (recvSize < NESocket::PACKET_MIN_SIZE)
     {
-        recvSize = NESocket::MIN_SEGMENT_SIZE;
+        recvSize = NESocket::PACKET_MIN_SIZE;
     }
-    else if (recvSize > NESocket::MAX_SEGMENT_SIZE)
+    else if (recvSize > NESocket::PACKET_MAX_SIZE)
     {
-        recvSize = NESocket::MAX_SEGMENT_SIZE;
+        recvSize = NESocket::PACKET_MAX_SIZE;
     }
 
-    return (RETURNED_OK == ::setsockopt(hSocket, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<const char*>(&recvSize), sizeof(recvSize)) ? recvSize : NESocket::MIN_SEGMENT_SIZE);
+    constexpr unsigned int len{ sizeof(unsigned int) };
+    return (RETURNED_OK == ::setsockopt(hSocket, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<const char*>(&recvSize), len) ? recvSize : NESocket::PACKET_MIN_SIZE);
 }
 
 AREG_API_IMPL SOCKETHANDLE NESocket::clientSocketConnect(const std::string_view & hostName, unsigned short portNr, NESocket::SocketAddress * out_socketAddr /*= nullptr*/)

--- a/framework/areg/base/private/Socket.cpp
+++ b/framework/areg/base/private/Socket.cpp
@@ -28,8 +28,8 @@
 Socket::Socket( void )
     : mSocket   ( )
     , mAddress  ( )
-    , mSendSize ( NESocket::DEFAULT_SEGMENT_SIZE )
-    , mRecvSize ( NESocket::DEFAULT_SEGMENT_SIZE )
+    , mSendSize ( NESocket::PACKET_DEFAULT_SIZE)
+    , mRecvSize ( NESocket::PACKET_DEFAULT_SIZE)
 {
     static_cast<void>(NESocket::socketInitialize( ));
 }
@@ -37,10 +37,12 @@ Socket::Socket( void )
 Socket::Socket(const SOCKETHANDLE hSocket, const NESocket::SocketAddress & sockAddress)
     : mSocket   ( std::make_shared<SOCKETHANDLE>(hSocket) )
     , mAddress  ( sockAddress )
-    , mSendSize ( NESocket::DEFAULT_SEGMENT_SIZE )
-    , mRecvSize ( NESocket::DEFAULT_SEGMENT_SIZE )
+    , mSendSize ( NESocket::PACKET_DEFAULT_SIZE )
+    , mRecvSize ( NESocket::PACKET_DEFAULT_SIZE )
 {
     static_cast<void>(NESocket::socketInitialize( ));
+    mSendSize = getSendPacketSize();
+    mRecvSize = getRecvPacketSize();
 }
 
 Socket::Socket( const Socket & source )
@@ -146,11 +148,11 @@ void Socket::closeSocketHandle( SOCKETHANDLE hSocket )
     }
 }
 
-unsigned int Socket::setSendSegmentSize(unsigned int sendSize, bool force /*= false*/) const
+unsigned int Socket::setSendPacketSize(unsigned int sendSize, bool force /*= false*/) const
 {
     if (isValid() == false)
     {
-        return NESocket::SEGMENT_INVALID_SIZE;
+        return NESocket::PACKET_INVALID_SIZE;
     }
 
     if (force || (sendSize > mSendSize))
@@ -161,16 +163,16 @@ unsigned int Socket::setSendSegmentSize(unsigned int sendSize, bool force /*= fa
     return mSendSize;
 }
 
-unsigned int Socket::setRecvSegmentSize(unsigned int recvSize, bool force /*= false*/) const
+unsigned int Socket::setRecvPacketSize(unsigned int recvSize, bool force /*= false*/) const
 {
     if (isValid() == false)
     {
-        return NESocket::SEGMENT_INVALID_SIZE;
+        return NESocket::PACKET_INVALID_SIZE;
     }
 
     if (force || (recvSize > mRecvSize))
     {
-        mRecvSize = NESocket::setMaxSendSize(*mSocket, recvSize);
+        mRecvSize = NESocket::setMaxReceiveSize(*mSocket, recvSize);
     }
 
     return mRecvSize;

--- a/framework/areg/base/private/SocketAccepted.cpp
+++ b/framework/areg/base/private/SocketAccepted.cpp
@@ -18,8 +18,6 @@
 SocketAccepted::SocketAccepted( const SOCKETHANDLE hSocket, const NESocket::SocketAddress & sockAddress )
     : Socket  ( hSocket, sockAddress)
 {
-    setRecvSegmentSize(NESocket::DEFAULT_SEGMENT_SIZE);
-    setSendSegmentSize(NESocket::DEFAULT_SEGMENT_SIZE);
 }
 
 bool SocketAccepted::createSocket(const char * /*hostName*/, unsigned short /*portNr*/)

--- a/framework/areg/base/private/SocketClient.cpp
+++ b/framework/areg/base/private/SocketClient.cpp
@@ -41,8 +41,8 @@ bool SocketClient::createSocket( void )
         if ( hSocket != NESocket::InvalidSocketHandle )
         {
         	mSocket = std::make_shared<SOCKETHANDLE>(hSocket);
-            setRecvSegmentSize(NESocket::DEFAULT_SEGMENT_SIZE);
-            setSendSegmentSize(NESocket::DEFAULT_SEGMENT_SIZE);
+            mSendSize = NESocket::getMaxSendSize(hSocket);
+            mRecvSize = NESocket::getMaxReceiveSize(hSocket);
         }
     }
 

--- a/framework/areg/base/private/SocketServer.cpp
+++ b/framework/areg/base/private/SocketServer.cpp
@@ -41,8 +41,8 @@ bool SocketServer::createSocket(void)
         if ( hSocket != NESocket::InvalidSocketHandle )
         {
             mSocket = std::make_shared<SOCKETHANDLE>( hSocket );
-            setRecvSegmentSize(NESocket::DEFAULT_SEGMENT_SIZE);
-            setSendSegmentSize(NESocket::DEFAULT_SEGMENT_SIZE);
+            mSendSize = NESocket::getMaxSendSize(hSocket);
+            mRecvSize = NESocket::getMaxReceiveSize(hSocket);
         }
     }
 

--- a/framework/areg/base/private/Thread.cpp
+++ b/framework/areg/base/private/Thread.cpp
@@ -171,7 +171,8 @@ Thread::Thread(IEThreadConsumer &threadConsumer, const String & threadName )
 
 Thread::~Thread( void )
 {
-    _cleanResources();
+    ASSERT(mThreadHandle == Thread::INVALID_THREAD_HANDLE);
+    ASSERT(mThreadId == Thread::INVALID_THREAD_ID);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -221,6 +222,10 @@ Thread::eCompletionStatus Thread::shutdownThread( unsigned int waitForStopMs /* 
         _unregisterThread( );
         _cleanResources( );
         mSynchObject.unlock( );
+    }
+    else
+    {
+        OUTPUT_WARN("Could not lock the synchronization object, the resource will be not removed");
     }
 
     return result;
@@ -299,15 +304,18 @@ int Thread::_threadEntry( void )
         ; // do nothing
     }
 
+    _unregisterThread();
+    _cleanResources();
+
     return static_cast<int>(result);
 }
 
 void Thread::_cleanResources( void )
 {
-    THREADHANDLE handle = mThreadHandle;
+    THREADHANDLE handle{ mThreadHandle };
 
-    mThreadHandle   = INVALID_THREAD_HANDLE;
-    mThreadId       = INVALID_THREAD_ID;
+    mThreadHandle   = Thread::INVALID_THREAD_HANDLE;
+    mThreadId       = Thread::INVALID_THREAD_ID;
     mIsRunning      = false;
     mThreadPriority = Thread::eThreadPriority::PriorityUndefined;
 

--- a/framework/areg/base/private/posix/NESocketPosix.cpp
+++ b/framework/areg/base/private/posix/NESocketPosix.cpp
@@ -55,7 +55,7 @@ namespace NESocket
         ::close(hSocket);
     }
 
-    int _osSendData(SOCKETHANDLE hSocket, const unsigned char* dataBuffer, int dataLength, int blockMaxSize /*= -1*/)
+    int _osSendData(SOCKETHANDLE hSocket, const unsigned char* dataBuffer, int dataLength, int blockMaxSize)
     {
         ASSERT(hSocket != NESocket::InvalidSocketHandle);
         ASSERT((dataBuffer != nullptr) && (dataLength > 0));

--- a/framework/areg/resources/areg.init
+++ b/framework/areg/resources/areg.init
@@ -63,8 +63,7 @@
 #   Meaning of Layout format:
 #       The Layout Format is relevant only when logs the messages in the plain text file.
 #       The Layout Format specification fields are following:
-            %a      -- outputs the ID of a logging object set by the logger.
-            %b      -- outputs the module name of the logging object.
+#           %a      -- outputs the ID of a logging object set by the logger.
 #           %c      -- output tick-count value since process start
 #           %d      -- output day and time data
 #           %e      -- output module (process) ID
@@ -141,9 +140,9 @@ log::*::layout::exit        = %d: [ %t  %x.%z: Exit <-- ]%n    # Exit scope layo
 # ---------------------------------------------------------------------------
 # Message layout for logger
 # ---------------------------------------------------------------------------
-log::logger::layout::enter  = %d: [ %a.%b.%t.%z: Enter -->]%n # Enter scope layout
-log::logger::layout::message= %d: [ %a.%b.%t.%p >>> ] %m%n    # Log message layout
-log::logger::layout::exit   = %d: [ %a.%b.%t.%z: Exit <-- ]%n # Exit scope layout
+log::logger::layout::enter  = %d: [ %a.%x.%t.%z: Enter -->]%n # Enter scope layout
+log::logger::layout::message= %d: [ %a.%x.%t.%p >>> ] %m%n    # Log message layout
+log::logger::layout::exit   = %d: [ %a.%x.%t.%z: Exit <-- ]%n # Exit scope layout
 
 # ###########################################################################
 # Remote services

--- a/framework/areg/trace/private/LayoutManager.cpp
+++ b/framework/areg/trace/private/LayoutManager.cpp
@@ -152,11 +152,7 @@ inline void LayoutManager::_createLayouts(char* layoutFormat)
                 break;
 
             case NELogging::eLayouts::LayoutCookieId:
-                newLayout = DEBUG_NEW CookieLayoutId();
-                break;
-
-            case NELogging::eLayouts::LayoutCookieName:
-                newLayout = DEBUG_NEW CookieLayoutName();
+                newLayout = DEBUG_NEW CookieIdLayout();
                 break;
 
             case NELogging::eLayouts::LayoutUndefined:  // fall through

--- a/framework/areg/trace/private/Layouts.hpp
+++ b/framework/areg/trace/private/Layouts.hpp
@@ -50,8 +50,7 @@ class IELayout;
     class ThreadNameLayout;
     class ScopeNameLayout;
     class AnyTextLayout;
-    class CookieLayoutId;
-    class CookieLayoutName;
+    class CookieIdLayout;
 
 //////////////////////////////////////////////////////////////////////////
 // IELayout interface declaration
@@ -518,7 +517,7 @@ public:
 // ScopeIdLayout class declaration
 //////////////////////////////////////////////////////////////////////////
 /**
- * \brief   This layout outputs the information of scope ID in the streamming object.
+ * \brief   This layout outputs the information of scope ID in the streaming object.
  **/
 class ScopeIdLayout : public    IELayout
 {
@@ -932,12 +931,12 @@ private:
 };
 
 //////////////////////////////////////////////////////////////////////////
-// CookieLayoutId class declaration
+// CookieIdLayout class declaration
 //////////////////////////////////////////////////////////////////////////
 /**
- * \brief   This layout outputs the cookie ID of the source log message module.
+ * \brief   This layout outputs the cookie ID of the log message module.
  **/
-class CookieLayoutId : public IELayout
+class CookieIdLayout : public IELayout
 {
 //////////////////////////////////////////////////////////////////////////
 // Constructors / Destructor
@@ -946,24 +945,24 @@ public:
     /**
      * \brief   Sets layout type value.
      **/
-    CookieLayoutId( void );
+    CookieIdLayout( void );
 
     /**
      * \brief   Copies data from given source.
      * \param   src     The source of data to copy.
      **/
-    CookieLayoutId( const CookieLayoutId& src );
+    CookieIdLayout( const CookieIdLayout& src );
 
     /**
      * \brief   Moves data from given source.
      * \param   src     The source of data to move.
      **/
-    CookieLayoutId(CookieLayoutId&& src ) noexcept;
+    CookieIdLayout(CookieIdLayout&& src ) noexcept;
 
     /**
      * \brief   Destructor
      **/
-    virtual ~CookieLayoutId( void ) = default;
+    virtual ~CookieIdLayout( void ) = default;
 
 //////////////////////////////////////////////////////////////////////////
 // Operators
@@ -973,79 +972,13 @@ public:
      * \brief   Copies data from given source.
      * \param   src     The source of data to copy.
      **/
-    inline CookieLayoutId & operator = ( const CookieLayoutId& src );
+    inline CookieIdLayout & operator = ( const CookieIdLayout& src );
 
     /**
      * \brief   Moves data from given source.
      * \param   src     The source of data to move.
      **/
-    inline CookieLayoutId & operator = ( CookieLayoutId&& src ) noexcept;
-
-//////////////////////////////////////////////////////////////////////////
-// Operations
-//////////////////////////////////////////////////////////////////////////
-
-/************************************************************************/
-// IELayout interface overrides
-/************************************************************************/
-
-    /**
-     * \brief   Makes layout specific formated text output of give message to the streaming object.
-     * \param   msgLog  The log message data structure that contains information to output message.
-     * \param   stream  The streaming object, where the text message should be written.
-     **/
-    virtual void logMessage( const NETrace::sLogMessage & msgLog, IEOutStream & stream ) const override;
-};
-
-//////////////////////////////////////////////////////////////////////////
-// CookieLayoutName class declaration
-//////////////////////////////////////////////////////////////////////////
-/**
- * \brief   This layout outputs the name of the source log message module.
- **/
-class CookieLayoutName : public IELayout
-{
-//////////////////////////////////////////////////////////////////////////
-// Constructors / Destructor
-//////////////////////////////////////////////////////////////////////////
-public:
-    /**
-     * \brief   Sets layout type value.
-     **/
-    CookieLayoutName( void );
-
-    /**
-     * \brief   Copies data from given source.
-     * \param   src     The source of data to copy.
-     **/
-    CookieLayoutName( const AnyTextLayout & src );
-
-    /**
-     * \brief   Moves data from given source.
-     * \param   src     The source of data to move.
-     **/
-    CookieLayoutName( AnyTextLayout && src ) noexcept;
-
-    /**
-     * \brief   Destructor
-     **/
-    virtual ~CookieLayoutName( void ) = default;
-
-//////////////////////////////////////////////////////////////////////////
-// Operators
-//////////////////////////////////////////////////////////////////////////
-public:
-    /**
-     * \brief   Copies data from given source.
-     * \param   src     The source of data to copy.
-     **/
-    inline CookieLayoutName& operator = ( const CookieLayoutName& src );
-
-    /**
-     * \brief   Moves data from given source.
-     * \param   src     The source of data to move.
-     **/
-    inline CookieLayoutName& operator = (CookieLayoutName&& src ) noexcept;
+    inline CookieIdLayout & operator = ( CookieIdLayout&& src ) noexcept;
 
 //////////////////////////////////////////////////////////////////////////
 // Operations
@@ -1269,29 +1202,15 @@ inline AnyTextLayout & AnyTextLayout::operator = ( AnyTextLayout && src ) noexce
 }
 
 //////////////////////////////////////////////////////////////////////////
-// CookieLayoutId class inline methods
+// CookieIdLayout class inline methods
 //////////////////////////////////////////////////////////////////////////
 
-inline CookieLayoutId& CookieLayoutId::operator=(const CookieLayoutId& src)
+inline CookieIdLayout& CookieIdLayout::operator=(const CookieIdLayout& src)
 {
     return (*this);
 }
 
-inline CookieLayoutId& CookieLayoutId::operator=(CookieLayoutId&& src) noexcept
-{
-    return (*this);
-}
-
-//////////////////////////////////////////////////////////////////////////
-// CookieLayoutId class inline methods
-//////////////////////////////////////////////////////////////////////////
-
-inline CookieLayoutName& CookieLayoutName::operator=(const CookieLayoutName& src)
-{
-    return (*this);
-}
-
-inline CookieLayoutName& CookieLayoutName::operator=(CookieLayoutName&& src) noexcept
+inline CookieIdLayout& CookieIdLayout::operator=(CookieIdLayout&& src) noexcept
 {
     return (*this);
 }

--- a/framework/areg/trace/private/NELogging.hpp
+++ b/framework/areg/trace/private/NELogging.hpp
@@ -76,7 +76,6 @@ namespace NELogging
         , LayoutAnyText         = 1     //!< Create any text layout to output message without formating
 
         , LayoutCookieId        = 'a'   //!< Create layout to output the cookie id of the log message source module
-        , LayoutCookieName      = 'b'   //!< Create layout to output the name of the log message source module
         , LayoutTickCount       = 'c'   //!< Create layout to output tick-count value since process start
         , LayoutDayTime         = 'd'   //!< Create layout to output day and time data
         , LayoutExecutableId    = 'e'   //!< Create layout to output module ID

--- a/framework/areg/trace/private/NetTcpLogger.cpp
+++ b/framework/areg/trace/private/NetTcpLogger.cpp
@@ -68,7 +68,7 @@ bool NetTcpLogger::openLogger(void)
         }
         else
         {
-            mRingStack.reserve(0);
+            mRingStack.discard();
         }
     }
     else

--- a/framework/areg/trace/private/NetTcpLogger.hpp
+++ b/framework/areg/trace/private/NetTcpLogger.hpp
@@ -186,11 +186,6 @@ private:
     //!< Wrapper of 'this' pointer.
     inline NetTcpLogger& self(void);
 
-    //! Resize the ring stack, set new capacity.
-    //! The newCapacity capacity value 0 will delete the ring stack
-    //! and disable queuing the messages.
-    inline void resizeStack(uint32_t newCapacity);
-
 //////////////////////////////////////////////////////////////////////////
 // Member variables
 //////////////////////////////////////////////////////////////////////////

--- a/framework/areg/trace/private/TraceManager.cpp
+++ b/framework/areg/trace/private/TraceManager.cpp
@@ -276,6 +276,11 @@ void TraceManager::readyForEvents( bool isReady )
     {
         DispatcherThread::readyForEvents( false );
         TraceEvent::removeListener( static_cast<IETraceEventConsumer &>(self( )), static_cast<DispatcherThread &>(self( )) );
+
+        // When we are here, all loggers should be already closed.
+        ASSERT(mLoggerFile.isLoggerOpened() == false);
+        ASSERT(mLoggerDebug.isLoggerOpened() == false);
+        ASSERT(mLoggerTcp.isLoggerOpened() == false);
     }
 }
 

--- a/framework/areg/trace/private/TraceManager.cpp
+++ b/framework/areg/trace/private/TraceManager.cpp
@@ -276,10 +276,6 @@ void TraceManager::readyForEvents( bool isReady )
     {
         DispatcherThread::readyForEvents( false );
         TraceEvent::removeListener( static_cast<IETraceEventConsumer &>(self( )), static_cast<DispatcherThread &>(self( )) );
-
-        mLoggerFile.closeLogger( );
-        mLoggerDebug.closeLogger( );
-        mLoggerTcp.closeLogger( );
     }
 }
 

--- a/framework/areg/trace/private/TraceManager.hpp
+++ b/framework/areg/trace/private/TraceManager.hpp
@@ -65,7 +65,6 @@ class TraceManager  : public    DispatcherThread
                     , private   IETraceEventConsumer
 {
     friend class TraceEventProcessor;
-    friend class CookieLayoutName;
 
 //////////////////////////////////////////////////////////////////////////
 // Internal types and constants


### PR DESCRIPTION
Made multiple fixes of bugs:
1. Fixed logic of reading configuration and resizing ring stack of the messages in the NetLogger;
2. Fixed segmentation fault issue happening after reserving space in the ring stack.
3. Fixed issue of exiting read and receive threads when run NetLogger. After closing the threads where not ending.
4. Fixed issue of delaying exit threads.
5. Made changes in the layouts to be able to log cookies and module name.