### PR TITLE
Fixed bug in example and in inputting string from console

### DIFF
--- a/examples/14_pubtraffic/pubclient/src/TrafficLightClient.cpp
+++ b/examples/14_pubtraffic/pubclient/src/TrafficLightClient.cpp
@@ -72,17 +72,17 @@ inline void TrafficLightClient::outputState(NESimpleTrafficLight::eTrafficLight 
     switch (lightState)
     {
     case NESimpleTrafficLight::eTrafficLight::LightRed:
-        std::cout << "Light: RED ..." << std::endl;
+        printf("Light: RED ...\r\n");
         break;
     case NESimpleTrafficLight::eTrafficLight::LightYellow:
-        std::cout << "Light: Yellow ..." << std::endl;
+        printf("Light: Yellow ...\r\n");
         break;
     case NESimpleTrafficLight::eTrafficLight::LightGreen:
-        std::cout << "Light: GREEN ..." << std::endl;
+        printf("Light: GREEN ...\r\n");
         break;
     case NESimpleTrafficLight::eTrafficLight::LightOff:
     default:
-        std::cout << "Light: OFF ..." << std::endl;
+        printf("Light: OFF ...\r\n");
         break;
     }
 }

--- a/examples/14_pubtraffic/pubclient/src/main.cpp
+++ b/examples/14_pubtraffic/pubclient/src/main.cpp
@@ -30,7 +30,7 @@
     #pragma comment(lib, "14_generated.lib")
 #endif // WIN32
 
-//! A demo of dynamic model and client with data update subsription.
+//! A demo of dynamic model and client with data update subscription.
 int main()
 {
     constexpr char const _modelName[]{ "TheModel" };
@@ -48,7 +48,7 @@ int main()
 
     Console & console = Console::getInstance( );
     console.enableConsoleInput( true );
-    console.outputTxt( { 0, 0 }, "A demo of dynamic model and client with data update subsription..." );
+    console.outputTxt( { 0, 0 }, "A demo of dynamic model and client with data update subscription..." );
 
     // At first, determine which traffic direction should be set.
     // This is used to react on the right attribute.

--- a/framework/extend/console/private/ansi/ConsoleAnsi.cpp
+++ b/framework/extend/console/private/ansi/ConsoleAnsi.cpp
@@ -158,14 +158,18 @@ bool Console::_osWaitInputString(char* buffer, uint32_t size) const
     ASSERT(buffer != nullptr);
 #if !defined(__STDC_WANT_LIB_EXT1__) || !(__STDC_WANT_LIB_EXT1__)
     #if defined(WINDOWS)
-        return (::gets_s(buffer, size) != nullptr);
+        if (::gets_s(buffer, size) == nullptr)
+            return false;
     #else   // defined(WINDOWS)
-        return (::fgets(buffer, size, stdin) != nullptr);
+        if (::fgets(buffer, size, stdin) == nullptr)
+            return false;
     #endif  // defined(WINDOWS)
 #else
-        return (::gets_s(buffer, size) != nullptr);
+        if (::gets_s(buffer, size) == nullptr)
+            return false;
 #endif // WINDOWS
 
+    return (NEString::trimRight<char>(buffer) > 0);
 }
 
 void Console::_osRefreshScreen(void) const

--- a/framework/extend/console/private/ncurses/ConsoleNcurses.cpp
+++ b/framework/extend/console/private/ncurses/ConsoleNcurses.cpp
@@ -143,7 +143,10 @@ void Console::_osSetCursorCurPosition(Console::Coord pos) const
 bool Console::_osWaitInputString(char* buffer, uint32_t size) const
 {
     ASSERT(buffer != nullptr);
-    return ((mContext != 0) && (wgetnstr(reinterpret_cast<WINDOW*>(mContext), buffer, static_cast<int>(size)) == OK));
+    if ((mContext == 0) || (wgetnstr(reinterpret_cast<WINDOW*>(mContext), buffer, static_cast<int>(size)) != OK))
+        return false;
+
+    return (NEString::trimRight<char>(buffer) > 0);
 }
 
 void Console::_osRefreshScreen(void) const

--- a/framework/extend/console/private/win32/ConsoleWin32.cpp
+++ b/framework/extend/console/private/win32/ConsoleWin32.cpp
@@ -168,7 +168,10 @@ void Console::_osSetCursorCurPosition(Console::Coord pos) const
 bool Console::_osWaitInputString(char* buffer, uint32_t size) const
 {
     ASSERT(buffer != nullptr);
-    return (gets_s(buffer, static_cast<int>(size)) != nullptr);
+    if (gets_s(buffer, static_cast<int>(size)) == nullptr)
+        return false;
+
+    return (NEString::trimRight<char>(buffer) > 0);
 }
 
 void Console::_osRefreshScreen(void) const


### PR DESCRIPTION
1. Fixed the bug in the example 14. For any reason, the C++ call `std::cout` did not output the string on console properly. Replaced that with the `printf()` and added `\n\r` at the end of every output message to align properly.
2. Improved method `Console::_osWaitInputString` by removing `\n` at the end of the string left by `gets_s() / fgets()` methods. Otherwise, the comparison of strings didn't work properly, because  for example `"ew" != "ew\n"`, where `"ew\n"` is a string returned by `gets_s() \ fgets()`.