### PR TITLE
Delete events in sorted event stack.

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # ###########################################################################
-# User sepcific settings
+# User specific settings
 # ###########################################################################
 include("${AREG_BASE}/areg/CMakeLists.txt")
 include("${AREG_BASE}/extend/CMakeLists.txt")

--- a/framework/areg/component/private/SortedEventStack.cpp
+++ b/framework/areg/component/private/SortedEventStack.cpp
@@ -23,6 +23,11 @@
 
 SortedEventStack::~SortedEventStack(void)
 {
+    for (auto evt : mValueList)
+    {
+        evt->destroy();
+    }
+
     mValueList.clear();
 }
 

--- a/framework/logger/app/Logger.hpp
+++ b/framework/logger/app/Logger.hpp
@@ -391,7 +391,7 @@ private:
     bool _osRegisterService( void );
 
     /**
-     * \brief   OS specific implementation of changing the state of the mcrouter service.
+     * \brief   OS specific implementation of changing the state of the logger service.
      **/
     bool _osSetState( NESystemService::eSystemServiceState newState );
 

--- a/framework/logger/app/private/Logger.cpp
+++ b/framework/logger/app/private/Logger.cpp
@@ -61,7 +61,7 @@ namespace
 
     constexpr std::string_view _msgHelp []
     {
-          {"Usage of AREG Message Router (mcrouter) :"}
+          {"Usage of AREG Log collector (logger) :"}
         , NESystemService::MSG_SEPARATOR
         , {"-a, --save      : Command to save logs in the file. Used in console application. Usage: --save"}
         , {"-c, --console   : Command to run logger as a console application (default option). Usage: \'logger --console\'"}


### PR DESCRIPTION
Brought back the calls to delete events in the destructor of the sorted stack and made tests. The original bug seems is fixed.