### PR TITLE
Fixed bug: when logger crashes, the client should reconnect.

### DIFF
--- a/framework/areg/trace/private/NetTcpLogger.cpp
+++ b/framework/areg/trace/private/NetTcpLogger.cpp
@@ -140,10 +140,18 @@ void NetTcpLogger::lostRemoteServiceChannel(const Channel & channel)
 
 void NetTcpLogger::failedSendMessage(const RemoteMessage & msgFailed, Socket & whichTarget)
 {
+    ASSERT(mIsEnabled);
+    if (mLogConfiguration.getStackSize() > 0)
+    {
+        mRingStack.pushLast(msgFailed);
+    }
+
+    sendCommand(ServiceEventData::eServiceEventCommands::CMD_ServiceLost);
 }
 
 void NetTcpLogger::failedReceiveMessage(Socket & whichSource)
 {
+    sendCommand(ServiceEventData::eServiceEventCommands::CMD_ServiceLost);
 }
 
 void NetTcpLogger::failedProcessMessage(const RemoteMessage & msgUnprocessed)


### PR DESCRIPTION
When logger crashes, the client socket connection did not request to re-connect, so that the client application should be restarted as well. Fixed the issue by triggering 'connection lost' event when failed to receive or send data.