### PR TITLE
Fixed reconnect to the logger.

### DIFF
--- a/framework/areg/appbase/Application.hpp
+++ b/framework/areg/appbase/Application.hpp
@@ -79,6 +79,7 @@ public:
         , AppStateInitializing  //!< Application is initializing
         , AppStateReady         //!< Application is ready. The application is ready only when Service Manager runs.
         , AppStateReleasing     //!< Application is releasing.
+        , AppStateFailure       //!< Application is failure state and cannot be continued
     } eAppState;
 
     /**

--- a/framework/areg/appbase/private/Application.cpp
+++ b/framework/areg/appbase/private/Application.cpp
@@ -93,6 +93,11 @@ void Application::initApplication(  bool startTracing   /*= true */
         Application::startMessageRouting( static_cast<unsigned int>(NERemoteService::eConnectionTypes::ConnectTcpip) );
     }
 
+    if (Application::getInstance().mAppState == Application::eAppState::AppStateInitializing)
+    {
+        Application::_setAppState(Application::eAppState::AppStateReady);
+    }
+
     Application::getInstance().mAppQuit.resetEvent();
 }
 
@@ -246,6 +251,7 @@ bool Application::startServiceManager( void )
         else
         {
             OUTPUT_ERR("Failed to start service manager!");
+            Application::_setAppState(Application::eAppState::AppStateFailure);
         }
     }
     else

--- a/framework/areg/ipc/ServiceClientConnectionBase.hpp
+++ b/framework/areg/ipc/ServiceClientConnectionBase.hpp
@@ -60,7 +60,7 @@ protected:
         , ConnectionStopped     = 3     //!< 0000 0011, The connection is stopped, i.e. not connected.
         , ConnectionStopping    = 5     //!< 0000 0101, The connection is stopping, because of manual request.
         , ConnectState          = 16    //!< 0001 0000, the connect state
-        , ConnectionStarting    = 16    //!< 0011 0000, The connection is initiated, but the status is not known.
+        , ConnectionStarting    = 48    //!< 0011 0000, The connection is initiated, but the status is not known.
         , ConnectionStarted     = 80    //!< 0101 0000, The connection is established and accepted by server.
     };
 
@@ -501,7 +501,7 @@ inline bool ServiceClientConnectionBase::isCalculateDataRateEnabled(void) const
 
 inline bool ServiceClientConnectionBase::isConnectState( void ) const
 {
-    return (static_cast<uint16_t>(mConnectionState) & static_cast<uint16_t>(ServiceClientConnectionBase::eConnectionState::ConnectState));
+    return (static_cast<uint16_t>(mConnectionState) & static_cast<uint16_t>(ServiceClientConnectionBase::eConnectionState::ConnectState)) != 0;
 }
 
 inline bool ServiceClientConnectionBase::isConnectedState( void ) const
@@ -511,7 +511,7 @@ inline bool ServiceClientConnectionBase::isConnectedState( void ) const
 
 inline bool ServiceClientConnectionBase::isDisconnectState( void ) const
 {
-    return (static_cast<uint16_t>(mConnectionState) & static_cast<uint16_t>(ServiceClientConnectionBase::eConnectionState::DisconnectState));
+    return ((static_cast<uint16_t>(mConnectionState) & static_cast<uint16_t>(ServiceClientConnectionBase::eConnectionState::DisconnectState)) != 0);
 }
 
 inline void ServiceClientConnectionBase::registerForServiceClientCommands(void)

--- a/framework/areg/ipc/private/ServiceClientConnectionBase.cpp
+++ b/framework/areg/ipc/private/ServiceClientConnectionBase.cpp
@@ -237,10 +237,7 @@ void ServiceClientConnectionBase::onServiceStop(void)
     mTimerConnect.stopTimer( );
 
     Channel channel{ mChannel };
-
-    mChannel.setCookie( NEService::COOKIE_UNKNOWN );
-    mChannel.setSource( NEService::SOURCE_UNKNOWN );
-    mChannel.setTarget( NEService::TARGET_UNKNOWN );
+    mChannel.invalidate();
 
     mThreadReceive.triggerExit( );
 
@@ -290,9 +287,7 @@ void ServiceClientConnectionBase::onServiceConnectionStopped(void)
     mTimerConnect.stopTimer( );
 
     Channel channel = mChannel;
-    mChannel.setCookie( NEService::COOKIE_UNKNOWN );
-    mChannel.setSource( NEService::SOURCE_UNKNOWN );
-    mChannel.setTarget( NEService::TARGET_UNKNOWN );
+    mChannel.invalidate();
 
     cancelConnection( );
 

--- a/framework/areg/trace/private/NetTcpLogger.cpp
+++ b/framework/areg/trace/private/NetTcpLogger.cpp
@@ -90,9 +90,8 @@ void NetTcpLogger::logMessage(const NETrace::sLogMessage& logMessage)
 {
     if (mIsEnabled)
     {
-        if (isConnectedState())
+        if (mChannel.isValid() && isConnectState())
         {
-            ASSERT(mChannel.isValid());
             sendMessage(NETrace::createLogMessage(logMessage, NETrace::eLogDataType::LogDataRemote, mChannel.getCookie()), Event::eEventPriority::EventPriorityNormal);
         }
         else if (mRingStack.capacity() != 0)

--- a/framework/logger/app/private/Logger.cpp
+++ b/framework/logger/app/private/Logger.cpp
@@ -581,7 +581,7 @@ void Logger::_outputInstances( const ServiceCommunicatonBase::MapInstances & ins
             instances.getAtPosition( pos, cookie, instance);
             unsigned int id{ static_cast<unsigned int>(cookie) };
 
-            console.outputMsg( coord, " %4d. |  %11u  |    %u     |  %s ", i ++, id, static_cast<uint32_t>(instance.ciBitness), instance.ciInstance.getString( ) );
+            console.outputMsg(coord, " %4d. |  %11u  |    %u     |  %s ", i++, id, static_cast<uint32_t>(instance.ciBitness), instance.ciInstance.getString());
             ++ coord.posY;
         }
     }

--- a/framework/mcrouter/app/private/MulticastRouter.cpp
+++ b/framework/mcrouter/app/private/MulticastRouter.cpp
@@ -43,18 +43,17 @@ namespace
 
         // define console service thread.
         BEGIN_REGISTER_THREAD( "RouterConsoleServiceThread", NECommon::WATCHDOG_IGNORE )
-        // Define the console service
-        BEGIN_REGISTER_COMPONENT(RouterConsoleService::SERVICE_NAME, RouterConsoleService)
-        // register dummy 'empty service'.
-        REGISTER_IMPLEMENT_SERVICE( NEService::EmptyServiceName, NEService::EmptyServiceVersion )
-        // end of component description
-        END_REGISTER_COMPONENT(RouterConsoleService::SERVICE_NAME )
+            // Define the console service
+            BEGIN_REGISTER_COMPONENT(RouterConsoleService::SERVICE_NAME, RouterConsoleService)
+                // register dummy 'empty service'.
+                REGISTER_IMPLEMENT_SERVICE( NEService::EmptyServiceName, NEService::EmptyServiceVersion )
+            // end of component description
+            END_REGISTER_COMPONENT(RouterConsoleService::SERVICE_NAME )
         // end of thread description
         END_REGISTER_THREAD( "RouterConsoleServiceThread" )
 
-        // end of model description
-        END_MODEL(_modelName)
-
+    // end of model description
+    END_MODEL(_modelName)
 
     constexpr std::string_view _msgHelp []
     {

--- a/msvc_setup.props
+++ b/msvc_setup.props
@@ -57,7 +57,7 @@
         <!-- Property to compile the extended features of AREG SDK. By default, it is not compiled with extended features.                      -->
         <!-- Set 1 to compile with extended features. Set 0 or ignore setting to compile without extended features.                             -->
         <!-- ********************************************************************************************************************************** -->
-        <AregExtended>1</AregExtended>
+        <AregExtended>0</AregExtended>
         <!-- ********************************************************************************************************************************** -->
         <!-- Property to compile the source codes with logging. By default, the sources are compiled with logs.                                 -->
         <!-- Set 0 to compile sources codes without logs. Set 1 or ignore setting to compile with logs.                                         -->


### PR DESCRIPTION
- On disconnect and connection failure, trigger 'connection lost';
- Fixed an assertion when the state is still connected, but the cookie is invalid;
- Reverted by default build with extended console feature.