### PR TITLE
Fixed cursor position in extended console mode.

### DIFF
--- a/framework/logger/app/private/Logger.cpp
+++ b/framework/logger/app/private/Logger.cpp
@@ -136,7 +136,10 @@ void Logger::printStatus(const String& status)
 
     if (Logger::getInstance().getCurrentOption() == NESystemService::eServiceOption::CMD_Console)
     {
+        Console& console{ Console::getInstance() };
+        Console::Coord curPos{ console.getCursorCurPosition() };
         Logger::_outputInfo(status);
+        console.setCursorCurPosition(curPos);
     }
 
 #endif // AREG_EXTENDED

--- a/framework/logobserver/app/private/LogObserver.cpp
+++ b/framework/logobserver/app/private/LogObserver.cpp
@@ -469,7 +469,7 @@ void LogObserver::_processPrintHelp(void)
 void LogObserver::_processInfoInstances(void)
 {
     static constexpr std::string_view _table{ "   Nr. |  Inst. ID  |  Bits |  Scopes  |  Name " };
-    static constexpr std::string_view _formt{ "  %3u. |%11u |  x%u  |   %5u  | %s " };
+    static constexpr std::string_view _formt{ "  %3u. |%11u |  x%u  |   %5u  |  %s " };
     static constexpr std::string_view _empty{ "There are no connected instances ..." };
 
     Console& console = Console::getInstance();


### PR DESCRIPTION
- Restored cursor position after printing the status in extended console mode.
- Slight beaty change to align the names when printing information in log observer.