### PR TITLE
Fixed inserting instances after logger reconnect.

### DIFF
--- a/framework/areg/component/NEService.hpp
+++ b/framework/areg/component/NEService.hpp
@@ -222,9 +222,9 @@ namespace NEService
     typedef enum class E_DisconnectReason : uint16_t
     {
           ReasonUndefined               = 0     //!< Undefined disconnect reason.
-        , ReasonRouterDisconnected      = 1     //!< The router is disconnected.
-        , ReasonRouterLost              = 2     //!< The router connection is lost.
-        , ReasonRouterRejected          = 4     //!< The router rejected connection.
+        , ReasonServiceDisconnected     = 1     //!< The service is disconnected.
+        , ReasonServiceLost             = 2     //!< The service connection is lost.
+        , ReasonServiceRejected         = 4     //!< The service rejected connection.
         , ReasonProviderDisconnected    = 8     //!< The service provider disconnected.
         , ReasonProviderLost            = 16    //!< The connection with service provider is lost.
         , ReasonProviderRejected        = 32    //!< The service provider rejected the service consumer.
@@ -232,6 +232,8 @@ namespace NEService
         , ReasonConsumerLost            = 128   //!< The connection with service consumer is lost.
         , ReasonConsumerNotSupported    = 256   //!< The service consumer is rejected because is not supported (wrong version, for example).
         , ReasonSystemShutdown          = 512   //!< The system is shutting down.
+        , ReasonClientConnectionLost    = 1024  //!< The system lost connection with the client. General reason.
+        , ReasonClientConnectionClosed  = 2048  //!< The client requested to disconnect. General reason.
     } eDisconnectReason;
 
     inline const char * getString( NEService::eDisconnectReason reason );
@@ -1126,19 +1128,21 @@ inline NEService::eServiceConnection NEService::serviceConnection( NEService::eD
     case NEService::eDisconnectReason::ReasonUndefined:
         return NEService::eServiceConnection::ServiceConnectionUnknown;
     
-    case NEService::eDisconnectReason::ReasonRouterDisconnected:
-    case NEService::eDisconnectReason::ReasonRouterLost:
+    case NEService::eDisconnectReason::ReasonServiceDisconnected:
+    case NEService::eDisconnectReason::ReasonServiceLost:
     case NEService::eDisconnectReason::ReasonProviderLost:
     case NEService::eDisconnectReason::ReasonConsumerLost:
+    case NEService::eDisconnectReason::ReasonClientConnectionLost:
         return NEService::eServiceConnection::ServiceConnectionLost;
 
-    case NEService::eDisconnectReason::ReasonRouterRejected:
+    case NEService::eDisconnectReason::ReasonServiceRejected:
     case NEService::eDisconnectReason::ReasonProviderRejected:
-    case NEService::eDisconnectReason::ReasonConsumerDisconnected:
     case NEService::eDisconnectReason::ReasonConsumerNotSupported:
         return NEService::eServiceConnection::ServiceRejected;
 
+    case NEService::eDisconnectReason::ReasonConsumerDisconnected:
     case NEService::eDisconnectReason::ReasonProviderDisconnected:
+    case NEService::eDisconnectReason::ReasonClientConnectionClosed:
         return NEService::eServiceConnection::ServiceDisconnected;
 
     case NEService::eDisconnectReason::ReasonSystemShutdown:
@@ -1495,12 +1499,12 @@ inline const char * NEService::getString( NEService::eDisconnectReason reason )
     {
     case NEService::eDisconnectReason::ReasonUndefined:
         return "NEService::eDisconnectReason::ReasonUndefined";
-    case NEService::eDisconnectReason::ReasonRouterDisconnected:
-        return "NEService::eDisconnectReason::ReasonRouterDisconnected";
-    case NEService::eDisconnectReason::ReasonRouterLost:
-        return "NEService::eDisconnectReason::ReasonRouterLost";
-    case NEService::eDisconnectReason::ReasonRouterRejected:
-        return "NEService::eDisconnectReason::ReasonRouterRejected";
+    case NEService::eDisconnectReason::ReasonServiceDisconnected:
+        return "NEService::eDisconnectReason::ReasonServiceDisconnected";
+    case NEService::eDisconnectReason::ReasonServiceLost:
+        return "NEService::eDisconnectReason::ReasonServiceLost";
+    case NEService::eDisconnectReason::ReasonServiceRejected:
+        return "NEService::eDisconnectReason::ReasonServiceRejected";
     case NEService::eDisconnectReason::ReasonProviderDisconnected:
         return "NEService::eDisconnectReason::ReasonProviderDisconnected";
     case NEService::eDisconnectReason::ReasonProviderLost:
@@ -1515,6 +1519,10 @@ inline const char * NEService::getString( NEService::eDisconnectReason reason )
         return "NEService::eDisconnectReason::ReasonConsumerNotSupported";
     case NEService::eDisconnectReason::ReasonSystemShutdown:
         return "NEService::eDisconnectReason::ReasonSystemShutdown";
+    case NEService::eDisconnectReason::ReasonClientConnectionLost:
+        return "NEService::eDisconnectReason::ReasonClientConnectionLost";
+    case NEService::eDisconnectReason::ReasonClientConnectionClosed:
+        return "NEService::eDisconnectReason::ReasonClientConnectionClosed";
     default:
         ASSERT( false );
         return "ERR: Undefined NEService::eDisconnectReason value!";

--- a/framework/areg/component/private/ServiceManagerEventProcessor.cpp
+++ b/framework/areg/component/private/ServiceManagerEventProcessor.cpp
@@ -238,7 +238,7 @@ void ServiceManagerEventProcessor::processServiceEvent(   ServiceManagerEventDat
             NEService::eDisconnectReason reason { NEService::eDisconnectReason::ReasonProviderDisconnected };
             if ( cmdService == ServiceManagerEventData::eServiceManagerCommands::CMD_LostConnection )
             {
-                reason = NEService::eDisconnectReason::ReasonRouterLost;
+                reason = NEService::eDisconnectReason::ReasonServiceLost;
             }
 
             for ( uint32_t i = 0; i < stubList.getSize( ); ++i )

--- a/framework/areg/resources/areg.init
+++ b/framework/areg/resources/areg.init
@@ -123,7 +123,6 @@ log::*::remote::service     = logger                        # The service name o
 # ---------------------------------------------------------------------------
 log::*::db::name            =                               # The database name
 log::*::db::location        =                               # Database location
-log::*::db::append          =                               # Append logs
 log::*::db::driver          =                               # Database driver
 log::*::db::address         =                               # Database connection IP-address
 log::*::db::port            =                               # Database connection IP-port
@@ -147,17 +146,21 @@ log::logobserver::layout::exit      = %d: [ %a.%x.%t.%z: Exit <-- ]%n   # Exit s
 # ---------------------------------------------------------------------------
 # Log observer specific database logging settings
 # ---------------------------------------------------------------------------
-log::logobserver::enable::db        = true                          # Database logging enable / disable flag
-log::logobserver::db::name          = sqlite3                       # The database name
-log::logobserver::db::location      = ./logs/log_%time%.sqlite3     # Database location
-log::logobserver::db::append        = false                         # Append logs
+log::logobserver::enable::file      = true                          # Logobserver: File logging enable / disable flag
+log::logobserver::enable::db        = true                          # Logobserver: Database logging enable / disable flag
+log::logobserver::db::name          = sqlite3                       # Logobserver: The database name
+log::logobserver::db::location      = ./logs/log_%time%.sqlite3     # Logobserver: Database location
 
 # ---------------------------------------------------------------------------
-# Messaging enable states for the logger
+# Messaging enable states for the logger and mcrouter services.
 # ---------------------------------------------------------------------------
-log::logger::enable::file   = false     # Logger service: do not output log messages in the file
-log::logger::enable::debug  = false     # Logger service: do not output logs in the debug output
-log::logger::enable::db     = false     # Logger service: do not output in the database
+log::logger::enable::file       = false     # Logger service: do not output log messages in the file
+log::logger::enable::debug      = false     # Logger service: do not output logs in the debug output
+log::logger::enable::db         = false     # Logger service: do not output in the database
+log::mcrouter::enable::file     = false     # MC Router: File logging enable / disable flag
+log::mcrouter::enable::db       = false     # MC Router: Database logging enable / disable flag
+log::mcrouter::enable::debug    = false     # MC Router: Debug output console logging enable / disable flag
+log::mcrouter::enable::remote   = true      # MC Router: Remote logging enable / disable flag
 
 # ###########################################################################
 # Remote services

--- a/framework/logobserver/lib/LogObserverApi.h
+++ b/framework/logobserver/lib/LogObserverApi.h
@@ -96,21 +96,25 @@ enum eLogType
  **/
 enum eLogPriority
 {
-    /* No priority, should not log any message */
-      PrioNotSet    = 0x0001
-    /* Logs scope enter and scope exit messages */
+    /* Invalid priority log message. */
+      PrioInvalid   = 0x0000
+    /* No priority, should not log any message. */
+    , PrioNotSet    = 0x0001
+    /* Logs scope enter and scope exit messages. */
     , PrioScope     = 0x0010
-    /* Logs fatal error messages. Can be in combination with PrioScope */
+    /* Logs fatal error messages. Can be in combination with PrioScope. */
     , PrioFatal     = 0x0020
-    /* Logs fatal error and error messages. Can be in combination with PrioScope */
+    /* Logs fatal error and error messages. Can be in combination with PrioScope. */
     , PrioError     = 0x0040
-    /* Logs fatal error, error and warning messages. Can be in combination with PrioScope */
+    /* Logs fatal error, error and warning messages. Can be in combination with PrioScope. */
     , PrioWarning   = 0x0080
-    /* Logs fatal error, error, warning and info messages. Can be in combination with PrioScope */
+    /* Logs fatal error, error, warning and info messages. Can be in combination with PrioScope. */
     , PrioInfo      = 0x0100
-    /* Logs fatal error, error, warning, info and debug messages. Can be in combination with PrioScope */
+    /* Logs fatal error, error, warning, info and debug messages. Can be in combination with PrioScope. */
     , PrioDebug     = 0x0200
-    /* Logs a message without priority. Can be in combination with PrioScope */
+    /* Ignore the message priority, force to log. */
+    , PrioIgnore    = 0x0400
+    /* Logs a message without priority. Can be in combination with PrioScope. */
     , PrioAny       = 0x0FF0
 };
 

--- a/framework/mcrouter/tcp/private/RouterServerService.cpp
+++ b/framework/mcrouter/tcp/private/RouterServerService.cpp
@@ -245,12 +245,12 @@ void RouterServerService::disconnectServices(void)
 
     for ( uint32_t i = 0; i < stubList.getSize(); ++ i )
     {
-        unregisteredRemoteServiceProvider( stubList[i], NEService::eDisconnectReason::ReasonRouterDisconnected, NEService::COOKIE_ANY );
+        unregisteredRemoteServiceProvider( stubList[i], NEService::eDisconnectReason::ReasonServiceDisconnected, NEService::COOKIE_ANY );
     }
 
     for ( uint32_t i = 0; i < proxyList.getSize(); ++ i )
     {
-        unregisteredRemoteServiceConsumer( proxyList[i], NEService::eDisconnectReason::ReasonRouterDisconnected, NEService::COOKIE_ANY );
+        unregisteredRemoteServiceConsumer( proxyList[i], NEService::eDisconnectReason::ReasonServiceDisconnected, NEService::COOKIE_ANY );
     }
 
     mServiceRegistry.clear( );

--- a/msvc_setup.props
+++ b/msvc_setup.props
@@ -57,7 +57,7 @@
         <!-- Property to compile the extended features of AREG SDK. By default, it is not compiled with extended features.                      -->
         <!-- Set 1 to compile with extended features. Set 0 or ignore setting to compile without extended features.                             -->
         <!-- ********************************************************************************************************************************** -->
-        <AregExtended>0</AregExtended>
+        <AregExtended>1</AregExtended>
         <!-- ********************************************************************************************************************************** -->
         <!-- Property to compile the source codes with logging. By default, the sources are compiled with logs.                                 -->
         <!-- Set 0 to compile sources codes without logs. Set 1 or ignore setting to compile with logs.                                         -->


### PR DESCRIPTION
- Fixed SQL scripts to update instances after `logger` reconnect;
- Slight changes in constants and slight cleanups.
- Enabled AREG extended library features by default when compile with MSVC.