### PR TITLE
Single unit test executable.

### DIFF
--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -450,3 +450,46 @@ macro(macro_declare_project project_name project_alias)
     macro_declare_project_ex(${project_name} ${project_alias} ${project_alias})
 endmacro(macro_declare_project)
 
+# ---------------------------------------------------------------------------
+# Description : Creates an unit test executable from specified list of sources
+#               and libraries. If the target with the same name exist, the sources
+#               are added to the existing executable. Otherwise, the new executable
+#               is created using specified source and linked with specified libraries.
+# Function ...: addUnitTestEx
+# Parameters .: ${test_project}     -- The name unit test executable.
+#               ${test_sources}     -- The list of unit test sources to include in executable.
+#               ${library_list}     -- The list of libraries to link the unit test executable.
+#                                      The 'gtest' and 'areg' libraries is automatically included,
+#                                      so that there is no need to specify them.
+#                                      The list of libraries can be empty.
+# Usage ......: addUnitTestEx( <name of executable> "<list of sources>" "<list of libraries>")
+# ---------------------------------------------------------------------------
+function(addUnitTestEx test_project test_sources library_list)
+    if (DEFINED GOOGLE_TEST_BASE)
+        if (TARGET ${test_project})
+            target_sources(${test_project} PRIVATE "${test_sources}")
+        else()
+            list(APPEND google_test_libs "GTest::gtest_main" "GTest::gtest" "${library_list}")
+            addExecutableEx(${test_project} "${test_sources}" "${google_test_libs}")
+            gtest_discover_tests(${test_project} DISCOVERY_TIMEOUT 60)
+        endif()
+    endif()
+endfunction(addUnitTestEx)
+
+# ---------------------------------------------------------------------------
+# Description : Creates an unit test executable from specified list of sources
+#               linked with 'areg' and 'gtest' libraries. If the target with the
+#               same name exist, the sources are added to the existing executable.
+#               Otherwise, the new executable is created using specified source.
+# Function ...: addUnitTest
+# Parameters .: ${test_project}     -- The name unit test executable.
+#               ${test_sources}     -- The list of unit test sources to include in executable.
+# Usage ......: addUnitTest( <name of executable> <list of sources>)
+# ---------------------------------------------------------------------------
+function(addUnitTest test_project test_sources)
+    set(source_list "${ARGN}")
+    foreach(item IN LISTS source_list)
+        list(APPEND test_sources "${item}")
+    endforeach()
+    addUnitTestEx("${test_project}" "${test_sources}" "")
+endfunction(addUnitTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ endfunction(addTest testName)
 if (DEFINED GOOGLE_TEST_BASE)
 
     set(AREG_UNIT_TEST_BASE "${AREG_TESTS}/units")
+    set(AREG_UNIT_TEST_PROJECT "areg-unit-tests")
     include_directories(${AREG_TESTS})
 
     # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/tests/units/CMakeLists.txt
+++ b/tests/units/CMakeLists.txt
@@ -1,9 +1,9 @@
 include(GoogleTest)
-
-# add each file as a separate test.
-addTest(DemoTest.cpp)
-addTest(DateTimeTest.cpp)
-addTest(FileTest.cpp)
-addTest(StringUtilsTest.cpp)
-addTest(LogScopesTest.cpp)
-addTest(OptionParserTest.cpp)
+addUnitTest("${AREG_UNIT_TEST_PROJECT}"
+    ${AREG_UNIT_TEST_BASE}/DemoTest.cpp
+    ${AREG_UNIT_TEST_BASE}/DateTimeTest.cpp
+    ${AREG_UNIT_TEST_BASE}/FileTest.cpp
+    ${AREG_UNIT_TEST_BASE}/StringUtilsTest.cpp
+    ${AREG_UNIT_TEST_BASE}/LogScopesTest.cpp
+    ${AREG_UNIT_TEST_BASE}/OptionParserTest.cpp
+)


### PR DESCRIPTION
Instead of multiple unit test executables, now create one executable that includes multiple tests. Same as it is done in MSVC.