### PR TITLE
343 Fixed warnings and the bug related with missed switch-case

### DIFF
--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -34,8 +34,10 @@ set(AREG_DEVELOP_ENV)
 set(AREG_LDFLAGS)
 # The compiler options
 set(AREG_COMPILER_OPTIONS)
-#set areg extended static library dependencies
+# set areg extended static library dependencies
 set(AREG_EXTENDED_LIBS)
+# set areg compiler version
+set(AREG_COMPILER_VERSION)
 
 # Adding common definition
 add_definitions(-DUNICODE -D_UNICODE)
@@ -71,7 +73,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     endif()
 
     # Clang compile options
-    list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -stdlib=libstdc++ ${AREG_USER_DEFINES})
+    list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 ${AREG_USER_DEFINES})
+    set(AREG_COMPILER_VERSION  -stdlib=libstdc++)
     # Linker flags (-l is not necessary)
     list(APPEND AREG_LDFLAGS stdc++ m pthread rt)
 
@@ -98,9 +101,11 @@ elseif (CMAKE_COMPILER_IS_GNUCXX )
     # GNU compile options
     if (CYGWIN)
         message(STATUS ">>> CYGWIN is detected")
-        list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -MMD -std=gnu++17 ${AREG_USER_DEFINES})
+        list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -MMD ${AREG_USER_DEFINES})
+        set(AREG_COMPILER_VERSION  -std=gnu++17)
     else()
-        list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -MMD -std=c++17 ${AREG_USER_DEFINES})
+        list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -MMD ${AREG_USER_DEFINES})
+        set(AREG_COMPILER_VERSION -std=c++17)
     endif()
     # Linker flags (-l is not necessary)
     list(APPEND AREG_LDFLAGS stdc++ m pthread rt)
@@ -147,7 +152,8 @@ else()
     endif()
 
     # Compile options
-    list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -MMD -std=c++17 ${AREG_USER_DEFINES})
+    list(APPEND AREG_COMPILER_OPTIONS -pthread -Wall -c -fmessage-length=0 -MMD ${AREG_USER_DEFINES})
+    set(AREG_COMPILER_VERSION -std=c++17)
     # Linker flags (-l is not necessary)
     list(APPEND AREG_LDFLAGS stdc++ m pthread rt)
 
@@ -235,7 +241,7 @@ else()
     set(COMMON_COMPILE_DEF IMP_AREG_DLL)
 endif()
 
-set(FETCHCONTENT_BASE_DIR "${AREG_PACKAGES}" CACHE PATH "Location of AREG thirdpary packages" FORCE)
+set(FETCHCONTENT_BASE_DIR "${AREG_PACKAGES}" CACHE PATH "Location of AREG thirdparty packages" FORCE)
 
 find_package(Java COMPONENTS Runtime)
 if (NOT ${Java_FOUND})

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -65,6 +65,7 @@ function(setStaticLibOptions item library_list)
 
     # Set common compile definition
     target_compile_definitions(${item} PRIVATE ${COMMON_COMPILE_DEF} _LIB)
+        target_compile_options(${item} PRIVATE  ${AREG_COMPILER_VERSION})
 
     if (NOT ${AREG_DEVELOP_ENV} MATCHES "Win32")
         target_compile_options(${item} PRIVATE "-Bstatic")
@@ -110,6 +111,51 @@ endfunction(addStaticLibEx)
 function(addStaticLib target_name source_list)
     addStaticLibEx(${target_name} "${source_list}" "")
 endfunction(addStaticLib)
+
+# ---------------------------------------------------------------------------
+# Description : Adds static library compiled with C-compiler, sets the sources and 
+#               the options of library links with the passed list of libraries.
+#               No need to specify the AREG library, it is automatically added.
+# Function ...: addStaticLibEx_C
+# Parameters .: ${target_name}  -- The name of the static library to build.
+#               ${source_list}  -- The list of the sources to build the static library.
+#               ${library_list} -- The list of libraries to link the static library.
+# usage ......: addStaticLibEx_C( <name of static library> <list of C-sources> <list of libraries> ) 
+# ---------------------------------------------------------------------------
+function(addStaticLibEx_C target_name source_list library_list)
+    set(exList "${ARGN}")
+    foreach(item IN LISTS exList)
+        list(APPEND library_list "${item}")
+    endforeach()
+    add_library(${target_name} STATIC ${source_list})
+
+    # Set common compile definition
+    target_compile_definitions(${target_name} PRIVATE ${COMMON_COMPILE_DEF} _LIB)
+
+    if (NOT ${AREG_DEVELOP_ENV} MATCHES "Win32")
+        target_compile_options(${target_name} PRIVATE "-Bstatic")
+        target_compile_options(${target_name} PRIVATE -fPIC)
+    endif()
+
+    target_link_libraries(${target_name} ${library_list} areg ${AREG_LDFLAGS})
+
+    # Adjusting CPP standard for target
+    # set_target_properties(${target_name} PROPERTIES CXX_STANDARD ${AREG_CXX_STANDARD} CXX_STANDARD_REQUIRED ON )
+    set_property(TARGET ${target_name} PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${AREG_OUTPUT_LIB})
+    target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})    
+endfunction(addStaticLibEx_C)
+
+# ---------------------------------------------------------------------------
+# Description : Adds static library compiled with C-compiler, sets the sources and
+#               the options of library. The AREG library is automatically added.
+# Function ...: addStaticLib_C
+# Parameters .: ${target_name}  -- The name of the static library to build.
+#               ${source_list}  -- The list of the sources to build the static library.
+# usage ......: addStaticLib_C( <name of static library> <list of C-sources> ) 
+# ---------------------------------------------------------------------------
+function(addStaticLib_C target_name source_list)
+    addStaticLibEx_C(${target_name} "${source_list}" "")
+endfunction(addStaticLib_C)
 
 # ---------------------------------------------------------------------------
 # Description : Sets the compiler and the linker options of the shared library.

--- a/framework/extend/service/ServiceCommunicatonBase.hpp
+++ b/framework/extend/service/ServiceCommunicatonBase.hpp
@@ -238,13 +238,13 @@ public:
      * \brief   Triggered when remote service connection and communication channel is established.
      * \param   channel     The connection and communication channel of remote service.
      **/
-    virtual void connectedRemoteServiceChannel(const Channel& channel) = 0;
+    virtual void connectedRemoteServiceChannel(const Channel& channel) override = 0;
 
     /**
      * \brief   Triggered when disconnected remote service connection and communication channel.
      * \param   channel     The connection and communication channel of remote service.
      **/
-    virtual void disconnectedRemoteServiceChannel(const Channel& channel) = 0;
+    virtual void disconnectedRemoteServiceChannel(const Channel& channel) override = 0;
 
     /**
      * \brief   Triggered when remote service connection and communication channel is lost.
@@ -252,7 +252,7 @@ public:
      *          receive data, and it was not stopped by API call.
      * \param   channel     The connection and communication channel of remote service.
      **/
-    virtual void lostRemoteServiceChannel(const Channel& channel) = 0;
+    virtual void lostRemoteServiceChannel(const Channel& channel) override = 0;
 
 /************************************************************************/
 // IEServiceConnectionProvider interface overrides

--- a/framework/extend/service/SystemServiceBase.hpp
+++ b/framework/extend/service/SystemServiceBase.hpp
@@ -9,7 +9,7 @@
  * If not, please contact to info[at]aregtech.com
  *
  * \copyright   (c) 2017-2023 Aregtech UG. All rights reserved.
- * \file        extend/service/private/SystemServiceBase.cpp
+ * \file        extend/service/SystemServiceBase.hpp
  * \ingroup     AREG SDK, Automated Real-time Event Grid Software Development Kit
  * \author      Artak Avetyan
  * \brief       AREG Platform, base class to create system services.

--- a/framework/extend/service/private/SystemServiceBase.cpp
+++ b/framework/extend/service/private/SystemServiceBase.cpp
@@ -176,7 +176,7 @@ void SystemServiceBase::controlService(SystemServiceBase::eServiceControl contro
     switch (control)
     {
     case SystemServiceBase::eServiceControl::ServiceStop:
-        SystemServiceBase::eServiceControl::ServiceShutdown;
+    case SystemServiceBase::eServiceControl::ServiceShutdown:
         serviceStop();
         break;
 

--- a/thirdparty/sqlite3/CMakeLists.txt
+++ b/thirdparty/sqlite3/CMakeLists.txt
@@ -5,4 +5,4 @@ list(APPEND sqlite_SRC
 
 include_directories(${sqlite_BASE})
 
-addStaticLib(sqlite3 "${sqlite_SRC}")
+addStaticLib_C(sqlite3 "${sqlite_SRC}")


### PR DESCRIPTION
- Fixed the missed `case` in switch-case;
- Fixed warnings with the missed keyword `override`;
- Fixed `cmake` script to avoid a warning (as well linker error) when compiling sqlite3 library.