### PR TITLE
bugfix/372 cmake make fails after a clean

### DIFF
--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -182,8 +182,11 @@ message(STATUS ">>> Java ${Java_VERSION_STRING} at location ${Java_JAVA_EXECUTAB
 message(STATUS "-------------------- CMakeLists Status Report End ----------------------")
 message(STATUS CMAKE_SOURCE_DIR = ${CMAKE_SOURCE_DIR})
 
-add_custom_target(dummy ALL COMMAND ${CMAKE_COMMAND} VERBATIM)
-add_custom_command( TARGET dummy PRE_BUILD
+# add a custom command to create output build folders if they are not existing.
+# create a dummy project to add as a dependency in all other projects.
+# this ensures that the commands to create directories are called first.
+add_custom_target(areg-dummy ALL COMMAND ${CMAKE_COMMAND} VERBATIM)
+add_custom_command( TARGET areg-dummy PRE_BUILD
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${AREG_OUTPUT_DIR}"
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${AREG_OUTPUT_BIN}"
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${AREG_OUTPUT_LIB}"

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -181,3 +181,10 @@ message(STATUS ">>> Build examples is '${AREG_BUILD_EXAMPLES}', build tests is '
 message(STATUS ">>> Java ${Java_VERSION_STRING} at location ${Java_JAVA_EXECUTABLE} is required by code generator. Minimum version 17")
 message(STATUS "-------------------- CMakeLists Status Report End ----------------------")
 message(STATUS CMAKE_SOURCE_DIR = ${CMAKE_SOURCE_DIR})
+
+add_custom_target(dummy ALL COMMAND ${CMAKE_COMMAND} VERBATIM)
+add_custom_command( TARGET dummy PRE_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${AREG_OUTPUT_DIR}"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${AREG_OUTPUT_BIN}"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${AREG_OUTPUT_LIB}"
+                    VERBATIM)

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -39,7 +39,7 @@ function(addExecutableEx target_name source_list library_list)
     add_executable(${target_name} ${source_list})
     setAppOptions(${target_name} "${library_list}")
     target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})
-    add_dependencies(${target_name} dummy)
+    add_dependencies(${target_name} areg-dummy)
 endfunction(addExecutableEx)
 
 # ---------------------------------------------------------------------------
@@ -101,7 +101,7 @@ function(addStaticLibEx target_name source_list library_list)
     add_library(${target_name} STATIC ${source_list})
     setStaticLibOptions(${target_name} "${library_list}")
     target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})    
-    add_dependencies(${target_name} dummy)
+    add_dependencies(${target_name} areg-dummy)
 endfunction(addStaticLibEx)
 
 # ---------------------------------------------------------------------------
@@ -148,7 +148,7 @@ function(addStaticLibEx_C target_name source_list library_list)
     # set_target_properties(${target_name} PROPERTIES CXX_STANDARD ${AREG_CXX_STANDARD} CXX_STANDARD_REQUIRED ON )
     set_property(TARGET ${target_name} PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${AREG_OUTPUT_LIB})
     target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})    
-    add_dependencies(${target_name} dummy)
+    add_dependencies(${target_name} areg-dummy)
 endfunction(addStaticLibEx_C)
 
 # ---------------------------------------------------------------------------
@@ -208,7 +208,7 @@ function(addSharedLibEx target_name source_list library_list)
     add_library(${target_name} SHARED ${source_list})
     setSharedLibOptions(${target_name} "${library_list}")
     target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})    
-    add_dependencies(${target_name} dummy)
+    add_dependencies(${target_name} areg-dummy)
 endfunction(addSharedLibEx)
 
 # ---------------------------------------------------------------------------

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -38,7 +38,8 @@ function(addExecutableEx target_name source_list library_list)
     endforeach()
     add_executable(${target_name} ${source_list})
     setAppOptions(${target_name} "${library_list}")
-    target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})    
+    target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+    add_dependencies(${target_name} dummy)
 endfunction(addExecutableEx)
 
 # ---------------------------------------------------------------------------
@@ -100,6 +101,7 @@ function(addStaticLibEx target_name source_list library_list)
     add_library(${target_name} STATIC ${source_list})
     setStaticLibOptions(${target_name} "${library_list}")
     target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})    
+    add_dependencies(${target_name} dummy)
 endfunction(addStaticLibEx)
 
 # ---------------------------------------------------------------------------
@@ -146,6 +148,7 @@ function(addStaticLibEx_C target_name source_list library_list)
     # set_target_properties(${target_name} PROPERTIES CXX_STANDARD ${AREG_CXX_STANDARD} CXX_STANDARD_REQUIRED ON )
     set_property(TARGET ${target_name} PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${AREG_OUTPUT_LIB})
     target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})    
+    add_dependencies(${target_name} dummy)
 endfunction(addStaticLibEx_C)
 
 # ---------------------------------------------------------------------------
@@ -205,6 +208,7 @@ function(addSharedLibEx target_name source_list library_list)
     add_library(${target_name} SHARED ${source_list})
     setSharedLibOptions(${target_name} "${library_list}")
     target_include_directories(${target_name}  BEFORE PRIVATE ${CMAKE_CURRENT_LIST_DIR})    
+    add_dependencies(${target_name} dummy)
 endfunction(addSharedLibEx)
 
 # ---------------------------------------------------------------------------

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -29,6 +29,7 @@ else(AREG_BINARY MATCHES "static")
     set_property(TARGET areg PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${AREG_OUTPUT_LIB})
 
 endif()
+add_dependencies(areg dummy)
 
 if (NOT ${AREG_DEVELOP_ENV} MATCHES "Win32")
     target_compile_options(areg PRIVATE -fPIC)
@@ -95,16 +96,29 @@ else (AREG_LOGOBSERVER_LIB MATCHES "static")
 endif()
 target_compile_options(logobserver PRIVATE "${AREG_OPT_DISABLE_WARN_TOOLS}")
 
-# copying log and router init files to 'bin/config'
-file(MAKE_DIRECTORY ${AREG_OUTPUT_BIN}/config)
-file(COPY ${AREG_BASE}/areg/resources/areg.init DESTINATION ${AREG_OUTPUT_BIN}/config)
+if (NOT EXISTS "${AREG_OUTPUT_BIN}/config/areg.init")
+    # copying log and router init files to 'bin/config'
+    add_custom_command( TARGET areg POST_BUILD 
+                        COMMAND ${CMAKE_COMMAND} -E make_directory ${AREG_OUTPUT_BIN}/config
+                        COMMAND ${CMAKE_COMMAND} -E copy ${AREG_BASE}/areg/resources/areg.init ${AREG_OUTPUT_BIN}/config/areg.init
+                        VERBATIM)
+endif()
 
-if("${AREG_DEVELOP_ENV}" STREQUAL "Win32")
-    file(COPY ${mcrouter_RESOURCE}/mcrouter_install.bat DESTINATION ${AREG_OUTPUT_BIN}/)
-    file(COPY ${mcrouter_RESOURCE}/mcrouter_uninstall.bat DESTINATION ${AREG_OUTPUT_BIN}/)
-    file(COPY ${logger_RESOURCE}/logger_install.bat DESTINATION ${AREG_OUTPUT_BIN}/)
-    file(COPY ${logger_RESOURCE}/logger_uninstall.bat DESTINATION ${AREG_OUTPUT_BIN}/)
+if("${AREG_DEVELOP_ENV}" STREQUAL "Win32" OR ${CYGWIN})
+    add_custom_command( TARGET mcrouter POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy ${mcrouter_RESOURCE}/mcrouter_install.bat  ${AREG_OUTPUT_BIN}/mcrouter_install.bat
+                        COMMAND ${CMAKE_COMMAND} -E copy ${mcrouter_RESOURCE}/mcrouter_uninstall.bat ${AREG_OUTPUT_BIN}/mcrouter_uninstall.bat
+                        VERBATIM)
+
+    add_custom_command( TARGET logger POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy ${logger_RESOURCE}/logger_install.bat  ${AREG_OUTPUT_BIN}/logger_install.bat
+                        COMMAND ${CMAKE_COMMAND} -E copy ${logger_RESOURCE}/logger_uninstall.bat ${AREG_OUTPUT_BIN}/logger_uninstall.bat
+                        VERBATIM)
 else()
-    file(COPY ${mcrouter_RESOURCE}/mcrouter.service DESTINATION ${AREG_OUTPUT_BIN}/)
-    file(COPY ${logger_RESOURCE}/logger.service DESTINATION ${AREG_OUTPUT_BIN}/)
+    add_custom_command( TARGET mcrouter POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy ${mcrouter_RESOURCE}/mcrouter.service ${AREG_OUTPUT_BIN}/mcrouter.service
+                        VERBATIM)
+    add_custom_command( TARGET logger POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E copy ${logger_RESOURCE}/logger.service  ${AREG_OUTPUT_BIN}/logger.service
+                        VERBATIM)
 endif()

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -97,15 +97,13 @@ else (AREG_LOGOBSERVER_LIB MATCHES "static")
 endif()
 target_compile_options(logobserver PRIVATE "${AREG_OPT_DISABLE_WARN_TOOLS}")
 
-if (NOT EXISTS "${AREG_OUTPUT_BIN}/config/areg.init")
-    # copying log and router init files to 'bin/config'
-    add_custom_command( TARGET areg POST_BUILD 
-                        COMMAND ${CMAKE_COMMAND} -E make_directory ${AREG_OUTPUT_BIN}/config
-                        COMMAND ${CMAKE_COMMAND} -E copy ${AREG_BASE}/areg/resources/areg.init ${AREG_OUTPUT_BIN}/config/areg.init
-                        VERBATIM)
-endif()
+# copying log and router init files to 'bin/config'
+add_custom_command( TARGET areg POST_BUILD 
+                    COMMAND ${CMAKE_COMMAND} -E make_directory ${AREG_OUTPUT_BIN}/config
+                    COMMAND ${CMAKE_COMMAND} -E copy ${AREG_BASE}/areg/resources/areg.init ${AREG_OUTPUT_BIN}/config/areg.init
+                    VERBATIM)
 
-if("${AREG_DEVELOP_ENV}" STREQUAL "Win32" OR ${CYGWIN})
+if("${AREG_DEVELOP_ENV}" STREQUAL "Win32" OR CYGWIN)
     add_custom_command( TARGET mcrouter POST_BUILD
                         COMMAND ${CMAKE_COMMAND} -E copy ${mcrouter_RESOURCE}/mcrouter_install.bat  ${AREG_OUTPUT_BIN}/mcrouter_install.bat
                         COMMAND ${CMAKE_COMMAND} -E copy ${mcrouter_RESOURCE}/mcrouter_uninstall.bat ${AREG_OUTPUT_BIN}/mcrouter_uninstall.bat

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -29,7 +29,8 @@ else(AREG_BINARY MATCHES "static")
     set_property(TARGET areg PROPERTY ARCHIVE_OUTPUT_DIRECTORY ${AREG_OUTPUT_LIB})
 
 endif()
-add_dependencies(areg dummy)
+# add a dependency to make sure that output folders exist during build time.
+add_dependencies(areg areg-dummy)
 
 if (NOT ${AREG_DEVELOP_ENV} MATCHES "Win32")
     target_compile_options(areg PRIVATE -fPIC)


### PR DESCRIPTION
- created a target named `areg-dummy`, which contains pre-build commands to create directories;
- in the `functions.cmake` file in the functions `addExecutable`, `addStaticLibrary`, `addSharedLibrary` added dependency from `areg-dummy`, that the project `areg-dummy` is started and executed first;
- made `areg` library dependent on `areg-dummy`.

These all makes sure that the build of `areg-dummy` starts first and the directory structure is created before any binary is built.

Tested on WSL with Ubuntu by calling `make clean` and `make -j 8`. When call `make clean`, the output directory is deleted, so that all files with logs and testing files are deleted. And when call `make -j 8`5 it re-creates the directory structure.