### PR TITLE
384 Use SQLite3 installed package in the build.

### DIFF
--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -50,6 +50,9 @@ set(AREG_EXTENDED_LIBS)
 # set areg compiler version
 set(AREG_COMPILER_VERSION)
 set(AREG_TARGET_COMPILER_OPTIONS)
+# Set the SQLite library reference
+set(AREG_SQLITE_LIB_REF sqlite3)
+option(AREG_FOUND_SQLITE3_PACKAGE "SQLite3 package" OFF)
 
 # Adding common definition
 add_definitions(-DUNICODE -D_UNICODE)

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -709,3 +709,27 @@ function(addUnitTest test_project test_sources)
     endforeach()
     addUnitTestEx("${test_project}" "${test_sources}" "")
 endfunction(addUnitTest)
+
+# ---------------------------------------------------------------------------
+# Description : This macro searches the specified package and if found,
+#               on output the variable passed as 'package_found' parameter is set 'ON'.
+#               Additionally, 
+#                   - the variable passed as 'package_includes' indicates the location of package includes;
+#                   - the variable passed as 'package_libraries' indicate the location of package libraries to link.
+# Macro ......: macro_find_package
+# Parameters .: ${package_name}     -- On input should contain the name of package to search.
+#               ${package_found}    -- On output contains flag indicating whether package found or not.
+#               ${package_includes} -- If package found, on output contains the locations of include headers of the package.
+#               ${package_libraries}-- if package found, on output contains the locations of libraries to use.
+# Example ....: macro_find_package(SQLite3 SQLITE_FOUND SQLITE_INCLUDE SQLITE_LIB)
+# ---------------------------------------------------------------------------
+macro(macro_find_package package_name package_found package_includes package_libraries)
+    find_package(${package_name})
+    if (${package_name}_FOUND)
+        set(${package_found} ON)
+        set(${package_includes} "${${package_name}_INCLUDE_DIR}")
+        set(${package_libraries} "${${package_name}_LIBRARY}")
+    else()
+        option(${package_found} OFF)
+    endif()
+endmacro(macro_find_package)

--- a/conf/cmake/install.cmake
+++ b/conf/cmake/install.cmake
@@ -65,24 +65,27 @@ if (AREG_INSTALL)
     # Check and install thirdparty dependencies if needed
     if (AREG_INSTALL_DEPENDS)
 
-        # copy compiled binaries in the bin and lib directories
-        install( TARGETS sqlite3
-            ARCHIVE DESTINATION lib         COMPONENT Development   COMPONENT ${AREG_PACKAGE_NAME}
-                    PERMISSIONS OWNER_READ OWNER_WRITE               GROUP_READ WORLD_READ
-        )
+        # Check how SQLite was built
+        if (NOT AREG_FOUND_SQLITE3_PACKAGE)
+            # copy compiled binaries in the bin and lib directories
+            install( TARGETS sqlite3
+                ARCHIVE DESTINATION lib         COMPONENT Development   COMPONENT ${AREG_PACKAGE_NAME}
+                        PERMISSIONS OWNER_READ OWNER_WRITE               GROUP_READ WORLD_READ
+            )
 
-        # Copy thirdparty sources with headers
-        install(DIRECTORY thirdparty/
-                    DESTINATION thirdparty COMPONENT Development   COMPONENT ${AREG_PACKAGE_NAME}
-                            PATTERN "*.vcxproj*" EXCLUDE
-        )
+            # Copy thirdparty sources with headers
+            install(DIRECTORY thirdparty/
+                        DESTINATION thirdparty COMPONENT Development   COMPONENT ${AREG_PACKAGE_NAME}
+                                PATTERN "*.vcxproj*" EXCLUDE
+            )
     
-        # Copy thirdparty licenses
-        install(FILES ${AREG_THIRDPARTY}/sqlite3/LICENSE.txt
-                    DESTINATION licenses    COMPONENT Development   COMPONENT Runtime     COMPONENT ${AREG_PACKAGE_NAME}
-                        RENAME SQLITE.copyright
-                        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-        )
+            # Copy thirdparty licenses
+            install(FILES ${AREG_THIRDPARTY}/sqlite3/LICENSE.txt
+                        DESTINATION licenses    COMPONENT Development   COMPONENT Runtime     COMPONENT ${AREG_PACKAGE_NAME}
+                            RENAME SQLITE.copyright
+                            PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+            )
+        endif(NOT AREG_FOUND_SQLITE3_PACKAGE)
 
     endif(AREG_INSTALL_DEPENDS)
 

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -16,12 +16,13 @@
 #   9. AREG_LOGS            -- Flag to enable or disable compilation with logs. By default, it is enabled.
 #  10. AREG_INSTALL         -- Flag to enable or disable AREG SDK installation. By default, it is enabled.
 #  11. AREG_INSTALL_DEPENDS -- Flag to enable or disable AREG SDK to install thirdparty dependencies. The flag is ignored if AREG_INSTALL is 'OFF'. By default, it is disabled.
-#  11. AREG_BUILD_ROOT      -- The root directory to build or create generated files. By default is the './product' directory of areg-sdk root.
-#  12. AREG_OUTPUT_DIR      -- The output directory of build binaries.
-#  13. AREG_OUTPUT_BIN      -- The output directory of build executables or runtime binaries (shared libraries).
-#  14. AREG_OUTPUT_LIB      -- The output directory of static libraries.
-#  15. AREG_PACKAGES        -- The location to install thirdparty packages.
-#  16. AREG_INSTALL_PATH    -- The location to install AREG SDK binaries, headers, configuration files and tools. By default, it is created in the user home directory.
+#  12. AREG_SQLITE_PACKAGE  -- Flag, indicating whether should use SQLite3 package available in the system or compile the source available in the 'thirdparty'
+#  13. AREG_BUILD_ROOT      -- The root directory to build or create generated files. By default is the './product' directory of 'areg-sdk' root.
+#  14. AREG_OUTPUT_DIR      -- The output directory of build binaries.
+#  15. AREG_OUTPUT_BIN      -- The output directory of build executables or runtime binaries (shared libraries).
+#  16. AREG_OUTPUT_LIB      -- The output directory of static libraries.
+#  17. AREG_PACKAGES        -- The location to install thirdparty packages.
+#  18. AREG_INSTALL_PATH    -- The location to install AREG SDK binaries, headers, configuration files and tools. By default, it is created in the user home directory.
 #
 # The default values are:
 #   1. AREG_COMPILER_FAMILY = <default> (possible values: gnu, cygwin, llvm, msvc)
@@ -35,12 +36,13 @@
 #   9. AREG_LOGS            = ON        (possible values: ON, OFF)
 #  10. AREG_INSTALL         = ON        (possible values: ON, OFF)
 #  11. AREG_INSTALL_DEPENDS = OFF       (possible values: ON, OFF)
-#  11. AREG_BUILD_ROOT      = '<areg-sdk>/product'                                                              (possible values: any valid path for outputs for product and generated files)
-#  12. AREG_OUTPUT_DIR      = '<areg-sdk>/product/build/gnu-gcc/<os>-<bitness>-<cpu>-release-<areg-lib>'        (possible values: any valid path for build outputs)
-#  13. AREG_OUTPUT_BIN      = '<areg-sdk>/product/build/gnu-gcc/<os>-<bitness>-<cpu>-release-<areg-lib>/bin'    (possible values: any valid path for binary outputs)
-#  14. AREG_OUTPUT_LIB      = '<areg-sdk>/product/build/gnu-gcc/<os>-<bitness>-<cpu>-release-<areg-lib>/lib'    (possible values: any valid path for library outputs)
-#  15. AREG_PACKAGES        = '${AREG_BUILD_ROOT}/packages'                                                     (possible values: any valid path for package location)
-#  16. AREG_INSTALL_PATH    = '${HOOME}/areg-sdk'; if '${HOOME}' is empty, use '${USERPROFILE}' or current dir. (possible values: any valid path to install AREG SDK outputs)   
+#  12. AREG_SQLITE_PACKAGE  = ON        (possible values: ON, OFF)
+#  13. AREG_BUILD_ROOT      = '<areg-sdk>/product'                                                              (possible values: any valid path for outputs for product and generated files)
+#  14. AREG_OUTPUT_DIR      = '<areg-sdk>/product/build/gnu-gcc/<os>-<bitness>-<cpu>-release-<areg-lib>'        (possible values: any valid path for build outputs)
+#  15. AREG_OUTPUT_BIN      = '<areg-sdk>/product/build/gnu-gcc/<os>-<bitness>-<cpu>-release-<areg-lib>/bin'    (possible values: any valid path for binary outputs)
+#  16. AREG_OUTPUT_LIB      = '<areg-sdk>/product/build/gnu-gcc/<os>-<bitness>-<cpu>-release-<areg-lib>/lib'    (possible values: any valid path for library outputs)
+#  17. AREG_PACKAGES        = '${AREG_BUILD_ROOT}/packages'                                                     (possible values: any valid path for package location)
+#  18. AREG_INSTALL_PATH    = '${HOOME}/areg-sdk'; if '${HOOME}' is empty, use '${USERPROFILE}' or current dir. (possible values: any valid path to install AREG SDK outputs)
 #
 # Hints:
 #
@@ -199,6 +201,10 @@ endif()
 
 if (NOT DEFINED AREG_INSTALL_DEPENDS)
     option(AREG_INSTALL_DEPENDS "Disable installation of thirdparty dependencies" OFF)
+endif()
+
+if (NOT DEFINED AREG_SQLITE_PACKAGE)
+    option(AREG_SQLITE_PACKAGE "Use SQLite3 installed package" ON)
 endif()
 
 # Set the areg-sdk build root folder to output files.

--- a/framework/areg/component/private/EventDispatcherBase.cpp
+++ b/framework/areg/component/private/EventDispatcherBase.cpp
@@ -49,9 +49,9 @@ EventDispatcherBase::~EventDispatcherBase( void )
 // EventDispatcherBase class, methods
 //////////////////////////////////////////////////////////////////////////
 
-bool EventDispatcherBase::isExitEvent( Event * anEvent ) const
+bool EventDispatcherBase::isExitEvent( const Event * anEvent ) const
 {
-    return (anEvent == static_cast<Event *>(&ExitEvent::getExitEvent( )));
+    return (anEvent == static_cast<const Event *>(&ExitEvent::getExitEvent( )));
 }
 
 void EventDispatcherBase::signalEvent( uint32_t eventCount )

--- a/framework/areg/component/private/EventDispatcherBase.hpp
+++ b/framework/areg/component/private/EventDispatcherBase.hpp
@@ -131,10 +131,10 @@ public:
 
     /**
      * \brief   Returns true if the specified event object is a special reserved event indicating to exit the thread.
-     * \brief   anEvent     A pointer to the event object to check.
+     * \param   anEvent     A pointer to the event object to check.
      * \return  Returns true, if dispatcher should complete the job and exit the thread.
      **/
-    bool isExitEvent( Event * anEvent ) const;
+    bool isExitEvent( const Event * anEvent ) const;
 
 /************************************************************************/
 // IEEventDispatcher overrides

--- a/framework/extend/db/LogSqliteDatabase.hpp
+++ b/framework/extend/db/LogSqliteDatabase.hpp
@@ -19,8 +19,6 @@
  ************************************************************************/
 #include "areg/base/GEGlobal.h"
 #include "areg/trace/IELogDatabaseEngine.hpp"
-#include "sqlite3/amalgamation/sqlite3.h"
-
 #include "areg/base/String.hpp"
 
 //////////////////////////////////////////////////////////////////////////
@@ -233,7 +231,7 @@ protected:
     String      mDbPath;
 
     //!< The SQLite database object.
-    sqlite3*    mDbObject;
+    void *      mDbObject;
 
     //!< Flag, indicating whether the database and data tables are initialized or not.
     bool        mIsInitialized;

--- a/framework/extend/db/SqliteDatabase.hpp
+++ b/framework/extend/db/SqliteDatabase.hpp
@@ -19,8 +19,6 @@
  ************************************************************************/
 #include "areg/base/GEGlobal.h"
 #include "areg/persist/IEDatabaseEngine.hpp"
-#include "sqlite3/amalgamation/sqlite3.h"
-
 #include "areg/base/String.hpp"
 
 //////////////////////////////////////////////////////////////////////////
@@ -139,7 +137,7 @@ protected:
     String      mDbPath;
 
     //!< The SQLite database object.
-    sqlite3*    mDbObject;
+    void *      mDbObject;
 
 //////////////////////////////////////////////////////////////////////////
 // Forbidden calls.

--- a/framework/extend/db/private/LogSqliteDatabase.cpp
+++ b/framework/extend/db/private/LogSqliteDatabase.cpp
@@ -26,6 +26,13 @@
 #include "areg/trace/NETrace.hpp"
 #include "areg/trace/private/NELogging.hpp"
 
+#if defined(USE_SQLITE_PACKAGE) && (USE_SQLITE_PACKAGE != 0)
+    #include <sqlite3.h>
+#else   // defined(USE_SQLITE_PACKAGE) && (USE_SQLITE_PACKAGE != 0)
+    #include "sqlite3/amalgamation/sqlite3.h"
+#endif  // defined(USE_SQLITE_PACKAGE) && (USE_SQLITE_PACKAGE != 0)
+
+
 namespace
 {
     //////////////////////////////////////////////////////////////////////////
@@ -243,7 +250,7 @@ inline bool LogSqliteDatabase::_open(const String& dbPath)
         File::createDirCascaded(folder);
     }
 
-    if (SQLITE_OK != sqlite3_open(mDbPath.getString(), &mDbObject))
+    if (SQLITE_OK != ::sqlite3_open(mDbPath.getString(), reinterpret_cast<sqlite3 **>(&mDbObject)))
     {
         _close();
         result = false;
@@ -256,7 +263,7 @@ inline void LogSqliteDatabase::_close(void)
 {
     if (mDbObject != nullptr)
     {
-        sqlite3_close(mDbObject);
+        ::sqlite3_close(reinterpret_cast<sqlite3*>(mDbObject));
         mDbObject = nullptr;
         mIsInitialized = false;
     }
@@ -319,7 +326,7 @@ inline bool LogSqliteDatabase::_execute(const char* sql)
     if (mDbLogEnabled)
     {
         ASSERT(NEString::isEmpty<char>(sql) == false);
-        return (mDbObject != nullptr ? SQLITE_OK == sqlite3_exec(mDbObject, sql, nullptr, nullptr, nullptr) : false);
+        return (mDbObject != nullptr ? SQLITE_OK == ::sqlite3_exec(reinterpret_cast<sqlite3*>(mDbObject), sql, nullptr, nullptr, nullptr) : false);
     }
 
     return false;

--- a/framework/logobserver/CMakeLists.txt
+++ b/framework/logobserver/CMakeLists.txt
@@ -10,7 +10,7 @@ include("${logobserver_BASE}/app/CMakeLists.txt")
 if (AREG_LOGOBSERVER_LIB MATCHES "shared")
 
     # build log observer API shared library
-    addSharedLibEx(logobserverapi "${logobserverapi_SRC}" sqlite3)
+    addSharedLibEx(logobserverapi "${logobserverapi_SRC}" ${AREG_SQLITE_LIB_REF})
     target_compile_options(logobserverapi PRIVATE "${AREG_OPT_DISABLE_WARN_TOOLS}")
 
     if (NOT ${AREG_DEVELOP_ENV} MATCHES "Win32")
@@ -45,7 +45,7 @@ if (AREG_LOGOBSERVER_LIB MATCHES "shared")
     addExecutableEx(logobserver "${logobserverapp_SRC}" logobserverapi)
     target_compile_definitions(logobserver PRIVATE IMP_LOGOBSERVER_DLL)
 else (AREG_LOGOBSERVER_LIB MATCHES "static")
-    addExecutableEx(logobserver "${logobserverapp_SRC}" logobserverapi sqlite3)
+    addExecutableEx(logobserver "${logobserverapp_SRC}" logobserverapi ${AREG_SQLITE_LIB_REF})
     target_compile_definitions(logobserver PRIVATE IMP_LOGOBSERVER_LIB)
 endif()
 target_compile_options(logobserver PRIVATE "${AREG_OPT_DISABLE_WARN_TOOLS}")

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,4 +1,6 @@
 # ###########################################################################
-# build sqlite3 library
+# Thirdparty libraries
+# ###########################################################################
 
+# build sqlite3 library or use SQLite3 package
 include(${AREG_THIRDPARTY}/sqlite3/CMakeLists.txt)

--- a/thirdparty/sqlite3/CMakeLists.txt
+++ b/thirdparty/sqlite3/CMakeLists.txt
@@ -1,9 +1,32 @@
-set(sqlite_BASE "${AREG_THIRDPARTY}/sqlite3")
-list(APPEND sqlite_SRC
-    ${sqlite_BASE}/amalgamation/sqlite3.c
-)
+# ###########################################################################
+# Either build 'sqlite3' static library or use system available build
+# ###########################################################################
 
-include_directories(${sqlite_BASE})
 
-addStaticLib_C(sqlite3 "${sqlite_SRC}")
-target_compile_options(sqlite3 PRIVATE "${AREG_OPT_DISABLE_WARN_THIRDPARTY}")
+set(AREG_SQLITE_INCLUDES)
+set(AREG_SQLITE_LIBRARY)
+
+if (AREG_SQLITE_PACKAGE)
+    macro_find_package(SQLite3 AREG_FOUND_SQLITE3_PACKAGE AREG_SQLITE_INCLUDES AREG_SQLITE_LIBRARY)
+endif()
+
+if (AREG_FOUND_SQLITE3_PACKAGE)
+
+    set(AREG_SQLITE_LIB_REF SQLite::SQLite3)
+    include_directories(AFTER "${AREG_SQLITE_INCLUDES}")
+    add_definitions(-DUSE_SQLITE_PACKAGE=1)
+    
+else(AREG_FOUND_SQLITE3_PACKAGE)
+
+    set(sqlite_BASE "${AREG_THIRDPARTY}/sqlite3")
+    list(APPEND sqlite_SRC
+        ${sqlite_BASE}/amalgamation/sqlite3.c
+    )
+
+    include_directories(${sqlite_BASE})
+
+    set(AREG_SQLITE_LIB_REF sqlite3)
+    addStaticLib_C(${AREG_SQLITE_LIB_REF} "${sqlite_SRC}")
+    target_compile_options(${AREG_SQLITE_LIB_REF} PRIVATE -DUSE_SQLITE_PACKAGE=0 "${AREG_OPT_DISABLE_WARN_THIRDPARTY}")
+
+endif()

--- a/thirdparty/sqlite3/Readme.md
+++ b/thirdparty/sqlite3/Readme.md
@@ -75,9 +75,9 @@ For further details, refer to Microsoft's [tutorial on using vcpkg with CMake](h
   ./vcpkg install sqlite3:x64-linux
   ```
 
-> [!NOTE} 
+> [!NOTE]
 > For 32-bit systems, replace `x64` with `x86` in the command (`sqlite3:x86-windows` or `sqlite3:x86-linux`).
-<br/>
+
 > [!IMPORTANT]
 > You may be prompted to install additional dependencies during the package installation. Follow the recommendations provided.
 
@@ -107,7 +107,7 @@ cmake -B ./build -DAREG_SQLITE_PACKAGE=ON -DCMAKE_TOOLCHAIN_FILE="$env{VCPKG_ROO
 
 If the SQLite3 package is found, CMake will display an output similar to:
 ```txt
--- Found SQLite3: /home/dev/vcpkg/installed/x64-linux/include (found version "3.46.1")
+-- Found SQLite3: /path/to/vcpkg/installed/x64-linux/include (found version "3.46.1")
 ```
 
 In this case, CMake will link to the existing SQLite3 library instead of building a new one.

--- a/thirdparty/sqlite3/Readme.md
+++ b/thirdparty/sqlite3/Readme.md
@@ -1,3 +1,15 @@
 # SQLite sources
 
 These are _amalgamation_ sources of the SQLite database, which are taken from the [_Download_](https://sqlite.org/download.html) page of the [SQLite](https://sqlite.org/) site and not owned by Aregtech. For more information about the SQLite and licenses, please visit the official web site.
+
+## Using SQLite package
+
+Example for 64-bit Windows
+```bash
+
+vcpkg> ./vcpkg install sqlite3:x64-windows
+vcpkg> ./vcpkg integrate install
+vcpkg> cd areg-sdk
+areg-sdk> cmake -B ./build -DAREG_SQLITE_PACKAGE=ON -DCMAKE_TOOLCHAIN_FILE=C:/DevTools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows
+
+```

--- a/thirdparty/sqlite3/Readme.md
+++ b/thirdparty/sqlite3/Readme.md
@@ -1,15 +1,113 @@
-# SQLite sources
+# SQLite Sources in AREG SDK
 
-These are _amalgamation_ sources of the SQLite database, which are taken from the [_Download_](https://sqlite.org/download.html) page of the [SQLite](https://sqlite.org/) site and not owned by Aregtech. For more information about the SQLite and licenses, please visit the official web site.
+The AREG SDK uses SQLite to save log files in both the `logobserver` executable and the `logobserverapi` library. SQLite is used to create the database file and save logs. You can link SQLite in your application in two ways:
 
-## Using SQLite package
+1. Build a **static** library from the SQLite source provided in the AREG SDK.
+2. Use an SQLite package already available in your system.
 
-Example for 64-bit Windows
+By default, the AREG SDK will attempt to compile with the SQLite3 package found in the system.
+
+---
+
+## Using SQLite Source
+
+The `sqlite3/amalgamation` directory contains the SQLite source code, which is downloaded from the [SQLite Download Page](https://sqlite.org/download.html). These sources are not owned by Aregtech. For more details on SQLite and its licenses, refer to the [official SQLite website](https://sqlite.org/).
+
+If no SQLite3 package is found during the build process, the SDK automatically builds the static `sqlite3` library. However, you can force the use of the SQLite source by setting the `AREG_SQLITE_PACKAGE=OFF` compiler option.
+
+- By default, `AREG_SQLITE_PACKAGE` is set to `ON`, meaning CMake will try to locate the SQLite3 package in your system. 
+- If the package is not found, the SDK will build and link against the static `sqlite3` library from the provided sources.
+
+---
+
+## Using SQLite Package
+
+Alternatively, you can link to a pre-installed SQLite package available in your system or through [vcpkg](https://github.com/microsoft/vcpkg).
+
+### Using vcpkg
+
+To use `vcpkg` for installing SQLite3:
+
+1. Ensure SQLite3 is installed through `vcpkg`.
+2. Set the correct path to the `vcpkg.cmake` file in the `CMAKE_TOOLCHAIN_FILE` option.
+
+If the path to `vcpkg.cmake` is unknown, you can retrieve it by running:
+
 ```bash
-
-vcpkg> ./vcpkg install sqlite3:x64-windows
-vcpkg> ./vcpkg integrate install
-vcpkg> cd areg-sdk
-areg-sdk> cmake -B ./build -DAREG_SQLITE_PACKAGE=ON -DCMAKE_TOOLCHAIN_FILE=C:/DevTools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows
-
+./vcpkg integrate install
 ```
+
+Below is a five-step guide for installing `vcpkg` and the SQLite3 binary to use with AREG SDK.
+
+### Installation Guide
+
+**Step 1: Install vcpkg**
+
+Follow the [vcpkg official instructions](https://github.com/microsoft/vcpkg) to install `vcpkg`. Basic steps:
+
+1. Clone the vcpkg repository:
+   ```bash
+   git clone https://github.com/microsoft/vcpkg.git
+   ```
+2. Navigate to the `vcpkg` directory and run the bootstrap script:
+   - On Linux:
+     ```bash
+     ./bootstrap-vcpkg.sh
+     ```
+   - On Windows:
+     ```bash
+     ./bootstrap-vcpkg.bat
+     ```
+
+> [!NOTE]
+> Additional dependencies may be required during the process. Follow any prompts.
+
+For further details, refer to Microsoft's [tutorial on using vcpkg with CMake](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-powershell).
+
+**Step 2: Install SQLite3**
+
+- **For Windows (64-bit)**:
+  ```bash
+  ./vcpkg install sqlite3:x64-windows
+  ```
+- **For Linux (64-bit)**:
+  ```bash
+  ./vcpkg install sqlite3:x64-linux
+  ```
+
+> [!NOTE} 
+> For 32-bit systems, replace `x64` with `x86` in the command (`sqlite3:x86-windows` or `sqlite3:x86-linux`).
+<br/>
+> [!IMPORTANT]
+> You may be prompted to install additional dependencies during the package installation. Follow the recommendations provided.
+
+**Step 3: Integrate vcpkg**
+
+After installing the package, integrate it by running:
+```bash
+./vcpkg integrate install
+```
+
+**Step 4: Use the Toolchain File**
+
+Once integration is complete, a message will appear with the `CMAKE_TOOLCHAIN_FILE` path. It should look like this:
+```txt
+CMake projects should use: "-DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake"
+```
+Save this path for later use.
+
+Optionally, set the `VCPKG_ROOT` environment variable to point to the `vcpkg` directory, and include it in your `PATH` for easier access.
+
+**Step 5: Build AREG SDK with SQLite3**
+
+To build the AREG SDK with the installed SQLite3 package, use the following CMake options (example for Windows):
+```bash
+cmake -B ./build -DAREG_SQLITE_PACKAGE=ON -DCMAKE_TOOLCHAIN_FILE="$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows
+```
+
+If the SQLite3 package is found, CMake will display an output similar to:
+```txt
+-- Found SQLite3: /home/dev/vcpkg/installed/x64-linux/include (found version "3.46.1")
+```
+
+In this case, CMake will link to the existing SQLite3 library instead of building a new one.


### PR DESCRIPTION
Made changes in the cmake files to use existing SQLite3 package instead of compiling static library in the project. Up from now it is possible to use either existing in the system sqlite3 library or compile the existing in the project source. 