### PR TITLE
396 demo build fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,12 @@ include(${AREG_CMAKE_CONFIG_DIR}/setup.cmake)
 # If compiler family name is not empty.
 # Otherwise, use system default compiler.
 # See in 'common.cmake'
+#[[================
 if (NOT "${AREG_COMPILER_FAMILY}" STREQUAL "")
     set(CMAKE_CXX_COMPILER  "${AREG_CXX_COMPILER}")
     set(CMAKE_C_COMPILER    "${AREG_C_COMPILER}")
 endif()
+#==============]]
 
 # set CMake tool settings
 set(CMAKE_BUILD_TYPE        ${AREG_BUILD_TYPE} CACHE STRING "Configuration Type" FORCE)
@@ -54,7 +56,7 @@ add_custom_command( TARGET areg-dummy PRE_BUILD
                     COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}"
                     VERBATIM)
 
-include_directories(${AREG_BASE})
+include_directories(${AREG_FRAMEWORK})
 include_directories(${AREG_THIRDPARTY})
 
 # build AREG Framework thirdparty software
@@ -64,7 +66,7 @@ if (NOT AREG_SQLITE_FOUND)
 endif()
 
 # build AREG Framework software
-include(${AREG_BASE}/CMakeLists.txt)
+include(${AREG_FRAMEWORK}/CMakeLists.txt)
 add_dependencies(areg areg-dummy)
 
 # build optional AREG project examples, if required
@@ -87,21 +89,9 @@ elseif(AREG_INSTALL)
 endif()
 
 # Print the configuration status
-message(STATUS "=======================================================================================")
-message(STATUS "----------------------> AREG project CMake Status Report Begin <-----------------------")
-message(STATUS "=======================================================================================")
-message(STATUS "AREG: >>> CMAKE_SOURCE_DIR = \'${CMAKE_SOURCE_DIR}\', build type \'${CMAKE_BUILD_TYPE}\'")
-message(STATUS "AREG: >>> Build ...........: \'${CMAKE_SYSTEM_NAME}\' system, \'${AREG_BITNESS}\'-bit platform, \'${AREG_PROCESSOR}\' CPU")
-message(STATUS "AREG: >>> Compiler ........: \'${CMAKE_CXX_COMPILER}\'")
-message(STATUS "AREG: >>> Compiler Version : C++ standard \'c++${CMAKE_CXX_STANDARD}\', compiler family \'${AREG_COMPILER_FAMILY}\'")
-message(STATUS "AREG: >>> Binary output ...: \'${CMAKE_RUNTIME_OUTPUT_DIRECTORY}\', extension '${CMAKE_EXECUTABLE_SUFFIX}'")
-message(STATUS "AREG: >>> Generated files .: \'${AREG_GENERATE_DIR}\' directory")
-message(STATUS "AREG: >>> Packages ........: \'${FETCHCONTENT_BASE_DIR}\' directory")
-message(STATUS "AREG: >>> Build libraries .: areg is \'${AREG_BINARY}\', aregextend is static, areglogger is \'${AREG_LOGGER_LIB}\' library")
-message(STATUS "AREG: >>> Java version ....: \'${Java_VERSION_STRING}\' of version \'${Java_JAVA_EXECUTABLE}\'. Minimum should be 17")
-message(STATUS "AREG: >>> Use of packages .: SQLite3 package use is \'${AREG_SQLITE_PACKAGE}\', GTest package use is \'${AREG_GTEST_PACKAGE}\' ")
-message(STATUS "AREG: >>> Other options ...: Examples = \'${AREG_BUILD_EXAMPLES}\', Unit Tests = \'${AREG_BUILD_TESTS}\', AREG Extended = \'${AREG_EXTENDED}\', Logs = \'${AREG_LOGS}\'")
-message(STATUS "AREG: >>> Installation ....: is '${AREG_INSTALL}', location \'${CMAKE_INSTALL_PREFIX}\'")
-message(STATUS "=======================================================================================")
-message(STATUS "-----------------------> AREG project CMake Status Report End <------------------------")
-message(STATUS "=======================================================================================")
+printAregStatus(
+    TRUE
+    "AREG"
+    "----------------------> AREG project CMake Status Report Begin <-----------------------"
+    "-----------------------> AREG project CMake Status Report End <------------------------"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,16 +14,6 @@ set(AREG_CMAKE_CONFIG_DIR   "${AREG_SDK_ROOT}/conf/cmake")
 # before 'project' call.
 include(${AREG_CMAKE_CONFIG_DIR}/setup.cmake)
 
-# If compiler family name is not empty.
-# Otherwise, use system default compiler.
-# See in 'common.cmake'
-#[[================
-if (NOT "${AREG_COMPILER_FAMILY}" STREQUAL "")
-    set(CMAKE_CXX_COMPILER  "${AREG_CXX_COMPILER}")
-    set(CMAKE_C_COMPILER    "${AREG_C_COMPILER}")
-endif()
-#==============]]
-
 # set CMake tool settings
 set(CMAKE_BUILD_TYPE        ${AREG_BUILD_TYPE} CACHE STRING "Configuration Type" FORCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,21 @@ set(AREG_CMAKE_CONFIG_DIR   "${AREG_SDK_ROOT}/conf/cmake")
 # before 'project' call.
 include(${AREG_CMAKE_CONFIG_DIR}/setup.cmake)
 
+# If compiler family name is not empty.
+# Otherwise, use system default compiler.
+# See in 'common.cmake'
+if (NOT "${AREG_COMPILER_FAMILY}" STREQUAL "")
+    set(CMAKE_CXX_COMPILER  "${AREG_CXX_COMPILER}")
+    set(CMAKE_C_COMPILER    "${AREG_C_COMPILER}")
+endif()
+
+# set CMake tool settings
+set(CMAKE_BUILD_TYPE        ${AREG_BUILD_TYPE} CACHE STRING "Configuration Type" FORCE)
+
+if (${AREG_COMPILER_FAMILY} MATCHES "llvm" AND WIN32)
+    set(CMAKE_GENERATOR_TOOLSET ClangCL)
+endif()
+
 # AREG SDK project name and version
 set(AREG_PROJECT_NAME "areg-sdk")
 set(AREG_PROJECT_VERSION "1.9.99.111")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ elseif(AREG_INSTALL)
 endif()
 
 # Print the configuration status
-printAregStatus(
+printAregConfigStatus(
     TRUE
     "AREG"
     "----------------------> AREG project CMake Status Report Begin <-----------------------"

--- a/conf/cmake/clang.cmake
+++ b/conf/cmake/clang.cmake
@@ -3,7 +3,7 @@
 # Copyright 2022-2023 Aregtech
 # ###########################################################################
 
-message(STATUS "AREG: >>> Preparing settings for CLang compiler and with '${AREG_OS}' API")
+message(STATUS "AREG: >>> Preparing settings for CLang compiler under \'${AREG_OS}\' platform, WIN32 = \'${WIN32}\'")
 
 if (AREG_OS STREQUAL "Windows")
 
@@ -22,7 +22,7 @@ if (AREG_OS STREQUAL "Windows")
     list(APPEND AREG_LDFLAGS advapi32 psapi shell32 ws2_32)
     set(AREG_LDFLAGS_STR "-ladvapi32 -lpsapi -lshell32 -lws2_32")
 
-else(AREG_OS STREQUAL "Posix")
+else()
 
     if(CMAKE_BUILD_TYPE MATCHES Release)
     # if Release
@@ -42,7 +42,7 @@ else(AREG_OS STREQUAL "Posix")
     set(AREG_LDFLAGS_STR "-lstdc++ -lm -lpthread -lrt")
     set(AREG_COMPILER_VERSION -stdlib=libstdc++)
 
-endif(AREG_OS STREQUAL "Windows")
+endif()
 
 if(${AREG_BITNESS} EQUAL 32)
     list(APPEND AREG_COMPILER_OPTIONS -m32)

--- a/conf/cmake/clang.cmake
+++ b/conf/cmake/clang.cmake
@@ -27,10 +27,10 @@ else()
     if(CMAKE_BUILD_TYPE MATCHES Release)
     # if Release
         list(APPEND AREG_COMPILER_OPTIONS -O2)
-    else(Debug)
+    else()
     # if Debug
         list(APPEND AREG_COMPILER_OPTIONS -O0 -g3)
-    endif(CMAKE_BUILD_TYPE MATCHES Release)
+    endif()
 
     # POSIX API
     set(AREG_DEVELOP_ENV "Posix")

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -10,17 +10,24 @@ if (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "")
 endif()
 
 # Identify compiler short name
-set(AREG_COMPILER_SHORT)
 if ("${AREG_COMPILER_FAMILY}" STREQUAL "")
-    macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" AREG_COMPILER_FAMILY AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _found)
 
-    message(STATUS "AREG: >>> Use system default settings:")
-    message(STATUS "AREG: ... Compiler family = \'${AREG_COMPILER_FAMILY}\'")
-    message(STATUS "AREG: ... CXX compiler = \'${AREG_CXX_COMPILER}\'")
-    message(STATUS "AREG: ... CC  compiler = \'${AREG_C_COMPILER}\'")
-else()
-    macro_find_compiler_short_name("${CMAKE_CXX_COMPILER}" AREG_COMPILER_SHORT)
+    macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" AREG_COMPILER_FAMILY AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _compiler_found)
+    if (_compiler_found)
+        message(STATUS "AREG: >>> Use system default settings:")
+        message(STATUS "AREG: ... Compiler family = \'${AREG_COMPILER_FAMILY}\'")
+        message(STATUS "AREG: ... CXX compiler = \'${AREG_CXX_COMPILER}\'")
+        message(STATUS "AREG: ... CC  compiler = \'${AREG_C_COMPILER}\'")
+    else()
+        message(WARNING "AREG: >>> The compiler \'${${CMAKE_CXX_COMPILER}}\' i unknown, the compilation result is unpredictable")
+    endif(_compiler_found)
+
+elseif("${AREG_COMPILER_SHORT}" STREQUAL "")
+
+    message(FATAL_ERROR "AREG: >>> The cmake file \'${AREG_CMAKE_CONFIG_DIR}/setup.cmake\' should be included before \'common.cmake\', fix it and retry again.")
+
 endif()
+
 # Identify the OS
 set(AREG_OS ${CMAKE_SYSTEM_NAME})
 # Identify CPU platform
@@ -177,7 +184,7 @@ add_compile_options(${AREG_COMPILER_OPTIONS})
 set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES ${AREG_OUTPUT_DIR})
 
 # Add include search paths
-include_directories(BEFORE "${AREG_BASE}" "${AREG_BUILD_ROOT}" "${AREG_GENERATE_DIR}" "${AREG_THIRDPARTY}")
+include_directories(BEFORE "${AREG_FRAMEWORK}" "${AREG_BUILD_ROOT}" "${AREG_GENERATE_DIR}" "${AREG_THIRDPARTY}")
 
 # Adding library search paths
 link_directories(BEFORE "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}")

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -19,7 +19,7 @@ if ("${AREG_COMPILER_FAMILY}" STREQUAL "")
         message(STATUS "AREG: ... CXX compiler = \'${AREG_CXX_COMPILER}\'")
         message(STATUS "AREG: ... CC  compiler = \'${AREG_C_COMPILER}\'")
     else()
-        message(WARNING "AREG: >>> The compiler \'${${CMAKE_CXX_COMPILER}}\' i unknown, the compilation result is unpredictable")
+        message(WARNING "AREG: >>> The compiler \'${${CMAKE_CXX_COMPILER}}\' is unknown, the compilation result is unpredictable")
     endif(_compiler_found)
 
 elseif("${AREG_COMPILER_SHORT}" STREQUAL "")

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -9,20 +9,18 @@ if (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "")
     set(AREG_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
 endif()
 
+# Identify compiler short name
+set(AREG_COMPILER_SHORT)
 if ("${AREG_COMPILER_FAMILY}" STREQUAL "")
-    set(AREG_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
-    set(AREG_C_COMPILER   "${CMAKE_C_COMPILER}")
-    findCompilerFamilyName("${CMAKE_CXX_COMPILER}" AREG_COMPILER_FAMILY)
+    macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" AREG_COMPILER_FAMILY AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _found)
 
     message(STATUS "AREG: >>> Use system default settings:")
     message(STATUS "AREG: ... Compiler family = \'${AREG_COMPILER_FAMILY}\'")
     message(STATUS "AREG: ... CXX compiler = \'${AREG_CXX_COMPILER}\'")
     message(STATUS "AREG: ... CC  compiler = \'${AREG_C_COMPILER}\'")
+else()
+    macro_find_compiler_short_name("${CMAKE_CXX_COMPILER}" AREG_COMPILER_SHORT)
 endif()
-
-# Identify compiler short name
-findCompilerShortName("${CMAKE_CXX_COMPILER}" AREG_COMPILER_SHORT)
-
 # Identify the OS
 set(AREG_OS ${CMAKE_SYSTEM_NAME})
 # Identify CPU platform

--- a/conf/cmake/common.cmake
+++ b/conf/cmake/common.cmake
@@ -20,7 +20,7 @@ if ("${AREG_COMPILER_FAMILY}" STREQUAL "")
         message(STATUS "AREG: ... CC  compiler = \'${AREG_C_COMPILER}\'")
     else()
         message(WARNING "AREG: >>> The compiler \'${${CMAKE_CXX_COMPILER}}\' is unknown, the compilation result is unpredictable")
-    endif(_compiler_found)
+    endif()
 
 elseif("${AREG_COMPILER_SHORT}" STREQUAL "")
 

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -576,7 +576,7 @@ endfunction(removeEmptyDirs)
 #               ${ARGN}         -- The list of source files (relative to the base directory).
 # Macro ......: macro_add_source
 # Usage ......: set(aregextend_SRC)
-#               macro_add_source(aregextend_SRC "${AREG_BASE}" aregextend/db/private/LogSqliteDatabase.cpp ...)
+#               macro_add_source(aregextend_SRC "${AREG_FRAMEWORK}" aregextend/db/private/LogSqliteDatabase.cpp ...)
 # ---------------------------------------------------------------------------
 macro(macro_add_source result_list src_base_dir)
     set(_list "${ARGN}")
@@ -847,9 +847,7 @@ endmacro(macro_setup_compiler_family)
 
 macro(macro_setup_compilers_data compiler_path compiler_family compiler_short compiler_cxx compiler_c compiler_found)
 
-    # Set the family to 'unknown' if no match was found.
-    set(${family_var} "unknown")
-
+    set(${compiler_found} FALSE)
     # Search for specific compiler families based on known compiler names.
     foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "c++;gnu;cc" "cc;gnu;cc" "cl;msvc;cl")
         list(GET _entry 0 _compiler)
@@ -879,3 +877,50 @@ macro(macro_setup_compilers_data compiler_path compiler_family compiler_short co
     endforeach()
 
 endmacro(macro_setup_compilers_data)
+
+macro(macro_setyp_compilers_data_by_family compiler_family compiler_short compiler_cxx compiler_c compiler_found)
+
+    set(${compiler_found} FALSE)
+    # Search for specific compiler families based on known compiler names.
+    foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "c++;gnu;cc" "cc;gnu;cc" "cl;msvc;cl" "g++;cygwin;gcc")
+        list(GET _entry 0 _compiler)
+        list(GET _entry 1 _family)
+        list(GET _entry 2 _c_compiler)
+
+        if (${_family} STREQUAL ${compiler_family})
+            set(${compiler_short}   ${_compiler})
+            set(${compiler_cxx}     ${_compiler})
+            set(${compiler_c}       ${_compiler})
+            set(${compiler_found}   TRUE)
+
+            break()
+        endif()
+    endforeach()
+
+endmacro(macro_setyp_compilers_data_by_family)
+
+function(printAregStatus var_make_print var_prefix var_header var_footer)
+    if (NOT var_make_print)
+        return()
+    endif()
+
+    message(STATUS "=======================================================================================")
+    message(STATUS "${var_header}")
+    message(STATUS "=======================================================================================")
+    message(STATUS "${var_prefix}: >>> CMAKE_SOURCE_DIR = \'${CMAKE_SOURCE_DIR}\', build type \'${CMAKE_BUILD_TYPE}\'")
+    message(STATUS "${var_prefix}: >>> Build ...........: \'${CMAKE_SYSTEM_NAME}\' system, \'${AREG_BITNESS}\'-bit platform, \'${AREG_PROCESSOR}\' CPU")
+    message(STATUS "${var_prefix}: >>> Compiler ........: \'${CMAKE_CXX_COMPILER}\'")
+    message(STATUS "${var_prefix}: >>> Compiler Version : C++ standard \'c++${CMAKE_CXX_STANDARD}\', compiler family \'${AREG_COMPILER_FAMILY}\'")
+    message(STATUS "${var_prefix}: >>> Binary output ...: \'${CMAKE_RUNTIME_OUTPUT_DIRECTORY}\', extension '${CMAKE_EXECUTABLE_SUFFIX}'")
+    message(STATUS "${var_prefix}: >>> Generated files .: \'${AREG_GENERATE_DIR}\' directory")
+    message(STATUS "${var_prefix}: >>> Packages ........: \'${FETCHCONTENT_BASE_DIR}\' directory")
+    message(STATUS "${var_prefix}: >>> Build libraries .: areg is \'${AREG_BINARY}\', aregextend is static, areglogger is \'${AREG_LOGGER_LIB}\' library")
+    message(STATUS "${var_prefix}: >>> Java version ....: \'${Java_VERSION_STRING}\' of version \'${Java_JAVA_EXECUTABLE}\'. Minimum should be 17")
+    message(STATUS "${var_prefix}: >>> Use of packages .: SQLite3 package use is \'${AREG_SQLITE_PACKAGE}\', GTest package use is \'${AREG_GTEST_PACKAGE}\' ")
+    message(STATUS "${var_prefix}: >>> Other options ...: Examples = \'${AREG_BUILD_EXAMPLES}\', Unit Tests = \'${AREG_BUILD_TESTS}\', AREG Extended = \'${AREG_EXTENDED}\', Logs = \'${AREG_LOGS}\'")
+    message(STATUS "${var_prefix}: >>> Installation ....: is '${AREG_INSTALL}', location \'${CMAKE_INSTALL_PREFIX}\'")
+    message(STATUS "=======================================================================================")
+    message(STATUS "${var_footer}")
+    message(STATUS "=======================================================================================")
+
+endfunction(printAregStatus)

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -21,8 +21,9 @@ macro(macro_check_fix_areg_cxx_standard)
 
     # If 'CMAKE_CXX_STANDARD' is not set, assign 'AREG_CXX_STANDARD' to it.
     if (NOT DEFINED CMAKE_CXX_STANDARD)
-        set(CMAKE_CXX_STANDARD  ${AREG_CXX_STANDARD})
-    
+        set(CMAKE_CXX_STANDARD          ${AREG_CXX_STANDARD})
+        set(CMAKE_CXX_EXTENSIONS        OFF)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)    
     # If the current C++ standard is less than the required 'AREG_CXX_STANDARD', issue a warning.
     elseif(${CMAKE_CXX_STANDARD} LESS ${AREG_CXX_STANDARD})
         message(WARNING "AREG: >>> AREG requires C++${AREG_CXX_STANDARD} or higher, \
@@ -767,7 +768,7 @@ macro(macro_setup_compilers_data compiler_path compiler_family compiler_short co
     set(${compiler_found} FALSE)
     
     # Iterate over known compilers to identify the compiler type
-    foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "cl;msvc;cl")
+    foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "c++;gnu;cc" "cc;gnu;cc" "cl;msvc;cl")
         list(GET _entry 0 _cxx_compiler)
         list(GET _entry 1 _family)
         list(GET _entry 2 _c_compiler)
@@ -895,10 +896,10 @@ function(printAregConfigStatus var_make_print var_prefix var_header var_footer)
     message(STATUS "${var_prefix}: >>> Build Environment ..: System '${CMAKE_SYSTEM_NAME}', ${AREG_BITNESS}-bit platform, '${AREG_PROCESSOR}' CPU")
     message(STATUS "${var_prefix}: >>> Compiler ...........: '${CMAKE_CXX_COMPILER}'")
     message(STATUS "${var_prefix}: >>> Compiler Version ...: C++ standard 'c++${CMAKE_CXX_STANDARD}', compiler family '${AREG_COMPILER_FAMILY}'")
-    message(STATUS "${var_prefix}: >>> Binary Output Dir ..: '${CMAKE_RUNTIME_OUTPUT_DIRECTORY}', executable extension '${CMAKE_EXECUTABLE_SUFFIX}'")
+    message(STATUS "${var_prefix}: >>> Binary Output Dir ..: '${CMAKE_RUNTIME_OUTPUT_DIRECTORY}'")
     message(STATUS "${var_prefix}: >>> Generated Files Dir : '${AREG_GENERATE_DIR}'")
     message(STATUS "${var_prefix}: >>> Packages Dir .......: '${FETCHCONTENT_BASE_DIR}'")
-    message(STATUS "${var_prefix}: >>> Build Libraries ....: areg = '${AREG_BINARY}', aregextend = static, areglogger = '${AREG_LOGGER_LIB}'")
+    message(STATUS "${var_prefix}: >>> Build Modules ......: areg = '${AREG_BINARY}', aregextend = static, areglogger = '${AREG_LOGGER_LIB}', executable extension '${CMAKE_EXECUTABLE_SUFFIX}'")
     message(STATUS "${var_prefix}: >>> Java Version .......: '${Java_VERSION_STRING}', Java executable = '${Java_JAVA_EXECUTABLE}', minimum version required = 17")
     message(STATUS "${var_prefix}: >>> Packages Use .......: SQLite3 package use = '${AREG_SQLITE_PACKAGE}', GTest package use = '${AREG_GTEST_PACKAGE}'")
     message(STATUS "${var_prefix}: >>> Other Options ......: Examples = '${AREG_BUILD_EXAMPLES}', Unit Tests = '${AREG_BUILD_TESTS}', AREG Extended = '${AREG_EXTENDED}', Logs = '${AREG_LOGS}'")

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -22,9 +22,17 @@ macro(macro_check_fix_areg_cxx_standard)
     # If 'CMAKE_CXX_STANDARD' is not set, assign 'AREG_CXX_STANDARD' to it.
     if (NOT DEFINED CMAKE_CXX_STANDARD)
         set(CMAKE_CXX_STANDARD          ${AREG_CXX_STANDARD})
-        set(CMAKE_CXX_EXTENSIONS        OFF)
-        set(CMAKE_CXX_STANDARD_REQUIRED ON)    
-    # If the current C++ standard is less than the required 'AREG_CXX_STANDARD', issue a warning.
+
+        # ###################################################################
+        # Do not disable extensions if googletest compilation is included.
+        # It causes googletest compilation due to using non-standard POSIX API use
+        # like 'fileno', 'fdopen' and 'mkstemp' method calls.
+        # ###################################################################
+        # set(CMAKE_CXX_EXTENSIONS        OFF)
+        # set(CMAKE_CXX_STANDARD_REQUIRED ON)    
+        # ###################################################################
+
+        # If the current C++ standard is less than the required 'AREG_CXX_STANDARD', issue a warning.
     elseif(${CMAKE_CXX_STANDARD} LESS ${AREG_CXX_STANDARD})
         message(WARNING "AREG: >>> AREG requires C++${AREG_CXX_STANDARD} or higher, \
                         current version is C++${CMAKE_CXX_STANDARD}. \

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -812,7 +812,7 @@ endmacro(macro_setup_compilers_data)
 #
 # Note .......: The "cygwin" family is supported for GNU compilers on the CYGWIN platform in Windows.
 #
-# Macro ......: macro_setyp_compilers_data_by_family
+# Macro ......: macro_setup_compilers_data_by_family
 # Parameters .: 
 #               - ${compiler_family} -- Input: The name of the compiler family (e.g., "gnu", "msvc").
 #               - ${compiler_short}  -- Output: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
@@ -820,14 +820,14 @@ endmacro(macro_setup_compilers_data)
 #               - ${compiler_c}      -- Output: Variable to hold the corresponding C compiler name.
 #               - ${compiler_found}  -- Output: Boolean flag indicating whether the compiler was successfully identified ("TRUE" or "FALSE").
 #
-# Usage ......: macro_setyp_compilers_data_by_family("gnu"
+# Usage ......: macro_setup_compilers_data_by_family("gnu"
 #                                                    AREG_COMPILER_SHORT 
 #                                                    AREG_CXX_COMPILER 
 #                                                    AREG_C_COMPILER 
 #                                                    _compiler_found
 #                                                   )
 # ---------------------------------------------------------------------------
-macro(macro_setyp_compilers_data_by_family compiler_family compiler_short compiler_cxx compiler_c compiler_found)
+macro(macro_setup_compilers_data_by_family compiler_family compiler_short compiler_cxx compiler_c compiler_found)
 
     set(${compiler_found} FALSE)
     
@@ -839,10 +839,10 @@ macro(macro_setyp_compilers_data_by_family compiler_family compiler_short compil
 
         if ("${_family}" STREQUAL "${compiler_family}")
             # Special case for Windows
-            if ("${_family}" STREQUAL "llvm" and WIN32)
+            if (WIN32 AND "${_family}" STREQUAL "llvm")
                 set(${compiler_short} "clang-cl")
                 set(${compiler_cxx}   "clang-cl")
-                set(${compiler_c}     "$clang-cl")
+                set(${compiler_c}     "clang-cl")
             else()
                 set(${compiler_short} "${_compiler}")
                 set(${compiler_cxx}   "${_compiler}")
@@ -857,7 +857,7 @@ macro(macro_setyp_compilers_data_by_family compiler_family compiler_short compil
         endif()
     endforeach()
 
-endmacro(macro_setyp_compilers_data_by_family)
+endmacro(macro_setup_compilers_data_by_family)
 
 # ---------------------------------------------------------------------------
 # Description : This function prints a detailed status report for the AREG project's CMake configuration.

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -346,16 +346,16 @@ endmacro(macro_normalize_path)
 #               source files for HelloWorld and includes them in the static library. 
 #               A subsequent call for WeHaveFun adds it to the same library.
 # 
-# macro name  : macro_add_service_interface
-# Parameters  : ${lib_name}         -- Name of the static library.
+# Macro ......: macro_add_service_interface
+# Parameters .: ${lib_name}         -- Name of the static library.
 #               ${interface_doc}    -- Full path to the Service Interface document file. 
 #               ${interface_name}   -- Name of the Service Interface (without '.siml').
 #               ${codegen_root}     -- Root directory for generating files.
 #               ${output_path}      -- Relative path for generated files.
 #               ${codegen_tool}     -- Full path to the code generator tool.
 # 
-# Usage       : macro_add_service_interface(<library name> <documend dir><interface name>.siml <interface name> <codegen root> <sub-path> <codegen tool>)
-# Example     : macro_add_service_interface("fun_library" "~/project/my-fun/sources/service/interfaces/FunInterface.siml" FunInterface "~/project/my-fun/" "generate/service/interfaces" /tools/areg/codegen.jar)
+# Usage ......: macro_add_service_interface(<library name> <documend dir><interface name>.siml <interface name> <codegen root> <sub-path> <codegen tool>)
+# Example ....: macro_add_service_interface("fun_library" "~/project/my-fun/sources/service/interfaces/FunInterface.siml" FunInterface "~/project/my-fun/" "generate/service/interfaces" /tools/areg/codegen.jar)
 # ---------------------------------------------------------------------------
 macro(macro_add_service_interface lib_name interface_doc interface_name codegen_root output_path codegen_tool)
 
@@ -401,12 +401,12 @@ endmacro(macro_add_service_interface)
 # ---------------------------------------------------------------------------
 # Description : Generates code for a service interface using a code generator and includes
 #               the generated files in a static library.
-# Parameters  : ${lib_name}       -- The static library name.
+# Function ...: addServiceInterfaceEx
+# Parameters .: ${lib_name}       -- The static library name.
 #               ${source_root}    -- The root directory of the source files.
 #               ${relative_path}  -- The relative path to the Service Interface files.
 #               ${sub_dir}        -- Optional sub-directory within relative_path (can be empty).
 #               ${interface_name} -- The name of the Service Interface (without the '.siml' extension).
-# Function ...: addServiceInterfaceEx
 # Usage ......: addServiceInterfaceEx(<static library> <source root> <relative path> <sub-directory> <interface name>)
 # Example ....: addServiceInterfaceEx("fun_library" "/home/develop/project/my-fun/sources" "my/service/interfaces" "" FunInterface)
 # ---------------------------------------------------------------------------
@@ -433,10 +433,10 @@ endfunction(addServiceInterfaceEx)
 # ---------------------------------------------------------------------------
 # Description : Wrapper for addServiceInterfaceEx, with the source root assumed
 #               to be ${CMAKE_SOURCE_DIR} and the relative path ${CMAKE_CURRENT_LIST_DIR}.
-# Parameters  : ${lib_name}       -- The name of the static library.
+# Function ...: addServiceInterface
+# Parameters .: ${lib_name}       -- The name of the static library.
 #               ${sub_dir}        -- The sub-directory of the service interface files.
 #               ${interface_name} -- The name of the Service Interface (without the '.siml' extension).
-# Function ...: addServiceInterface
 # Usage ......: addServiceInterface(<static library> <sub-directory> <Service Interface name>)
 # ---------------------------------------------------------------------------
 function(addServiceInterface lib_name sub_dir interface_name)
@@ -447,11 +447,11 @@ endfunction(addServiceInterface)
 # ---------------------------------------------------------------------------
 # Description : Searches for a package and sets output variables to indicate the package's
 #               include directories and libraries if found.
-# Parameters  : ${package_name}      -- The package name to search.
+# Macro ......: macro_find_package
+# Parameters .: ${package_name}      -- The package name to search.
 #               ${package_found}     -- Output variable, set to TRUE if the package is found.
 #               ${package_includes}  -- Output variable, set to the package's include directories (if any).
 #               ${package_libraries} -- Output variable, set to the package's libraries (if any).
-# Macro ......: macro_find_package
 # Usage ......: macro_find_package(<package> <found flag> <includes> <libraries>)
 # Example ....: macro_find_package(SQLite3 SQLITE_FOUND SQLITE_INCLUDE SQLITE_LIB)
 # ---------------------------------------------------------------------------
@@ -470,10 +470,10 @@ endmacro(macro_find_package)
 
 # ---------------------------------------------------------------------------
 # Description : Creates or updates a boolean cache variable in CMake, ensuring it is defined and set correctly.
-# Parameters  : ${var_name}     -- The name of the boolean variable.
+# Macro ......: macro_create_option
+# Parameters .: ${var_name}     -- The name of the boolean variable.
 #               ${var_value}    -- The default value if the variable is not yet defined.
 #               ${var_describe} -- A brief description of the variable for CMake cache.
-# Macro ......: macro_create_option
 # Usage ......: macro_create_option(<var_name> <default_value> <description>)
 # Example ....: macro_create_option(AREG_LOGS ON "Compile with logs")
 # ---------------------------------------------------------------------------
@@ -487,8 +487,8 @@ endmacro(macro_create_option)
 
 # ---------------------------------------------------------------------------
 # Description : Recursively removes empty directories.
-# Parameters  : ${dir_name} -- The directory path to check and potentially remove.
 # Function ...: removeEmptyDirs
+# Parameters .: ${dir_name} -- The directory path to check and potentially remove.
 # Usage ......: removeEmptyDirs(<directory path>)
 # ---------------------------------------------------------------------------
 function(removeEmptyDirs dir_name)
@@ -512,10 +512,10 @@ endfunction(removeEmptyDirs)
 
 # ---------------------------------------------------------------------------
 # Description : Adds source files to a list, checking if the files exist relative to the base directory.
-# Parameters  : ${result_list}  -- The output list of source files.
+# Macro ......: macro_add_source
+# Parameters .: ${result_list}  -- The output list of source files.
 #               ${src_base_dir} -- The base directory for the source files.
 #               ${ARGN}         -- The list of source files (relative to the base directory).
-# Macro ......: macro_add_source
 # Usage ......: set(aregextend_SRC)
 #               macro_add_source(aregextend_SRC "${AREG_FRAMEWORK}" aregextend/db/private/LogSqliteDatabase.cpp ...)
 # ---------------------------------------------------------------------------
@@ -546,16 +546,17 @@ endmacro(macro_add_source)
 #                   3. **Resource files list**: Filters out .rc files, specifically for Windows,
 #                      and stores them in a separate list.
 #
-# Parameters  : ${res_sources}   -- Output: A list containing the parsed source files.
-#               ${res_libs}      -- Output: A list containing the recognized CMake targets (libraries).
-#               ${res_resources} -- Output: A list containing the identified resource files (*.rc).
-#               ${ARGN}          -- Input: A list of files, libraries, or resources to be categorized.
-#
 # Behavior ...: 
 #               - If a file does not exist, either as a full path or relative to the current directory, 
 #                 the macro throws a fatal error.
 #               - On Windows, it specifically identifies and appends resource files (*.rc) to the 
 #                 resources list.
+#
+# Macro ......: macro_parse_arguments
+# Parameters .: ${res_sources}   -- Output: A list containing the parsed source files.
+#               ${res_libs}      -- Output: A list containing the recognized CMake targets (libraries).
+#               ${res_resources} -- Output: A list containing the identified resource files (*.rc).
+#               ${ARGN}          -- Input: A list of files, libraries, or resources to be categorized.
 #
 # Usage ......: macro_parse_arguments(<var sources> <var libs> <var resources> my_target my/app/main.cpp my/lib/object.cpp my/resource/resource.rc)
 #               Example: macro_parse_arguments(src_files lib_targets res_files my_lib src/main.cpp src/object.cpp res/resource.rc)
@@ -598,14 +599,15 @@ endmacro(macro_parse_arguments)
 #               The macro declares a static library target using the collected source files and linked libraries.
 #               It also handles resource file configuration on Windows platforms.
 #
-# Parameters  : ${lib_name}  -- The name of the static library to be declared.
-#               ${ARGN}      -- The list of source files, libraries, and resource files.
-#                               The files can be specified with full or relative paths.
-#
 # Notes ......: 
 #               - Throws a fatal error if no source files are provided.
 #               - On Windows, resource files (*.rc) are set to use the RC language automatically.
 # 
+# Macro ......: macro_declare_static_library
+# Parameters .: ${lib_name}  -- The name of the static library to be declared.
+#               ${ARGN}      -- The list of source files, libraries, and resource files.
+#                               The files can be specified with full or relative paths.
+#
 # Usage ......: macro_declare_static_library(<lib_name> <list_of_sources_libraries_and_resources>)
 #               Example: macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
 # ---------------------------------------------------------------------------
@@ -646,14 +648,15 @@ endmacro(macro_declare_static_library)
 #               The macro declares a shared library target using the collected source files and linked libraries.
 #               It also handles resource file configuration on Windows platforms.
 #
-# Parameters  : ${lib_name}  -- The name of the shared library to be declared.
-#               ${ARGN}      -- The list of source files, libraries, and resource files.
-#                               The files can be specified with full or relative paths.
-#
 # Notes ......: 
 #               - Throws a fatal error if no source files are provided.
 #               - On Windows, resource files (*.rc) are set to use the RC language automatically.
 # 
+# Macro ......: macro_declare_shared_library
+# Parameters .: ${lib_name}  -- The name of the shared library to be declared.
+#               ${ARGN}      -- The list of source files, libraries, and resource files.
+#                               The files can be specified with full or relative paths.
+#
 # Usage ......: macro_declare_static_library(<lib_name> <list_of_sources_libraries_and_resources>)
 #               Example: macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
 # ---------------------------------------------------------------------------
@@ -694,14 +697,15 @@ endmacro(macro_declare_shared_library)
 #               The macro declares a executable target using the collected source files and linked libraries.
 #               It also handles resource file configuration on Windows platforms.
 #
-# Parameters  : ${lib_name}  -- The name of the executable to be declared.
-#               ${ARGN}      -- The list of source files, libraries, and resource files.
-#                               The files can be specified with full or relative paths.
-#
 # Notes ......: 
 #               - Throws a fatal error if no source files are provided.
 #               - On Windows, resource files (*.rc) are set to use the RC language automatically.
 # 
+# Macro ......: macro_declare_executable
+# Parameters  : ${lib_name}  -- The name of the executable to be declared.
+#               ${ARGN}      -- The list of source files, libraries, and resource files.
+#                               The files can be specified with full or relative paths.
+#
 # Usage ......: macro_declare_static_library(<lib_name> <list_of_sources_libraries_and_resources>)
 #               Example: macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
 # ---------------------------------------------------------------------------
@@ -731,114 +735,178 @@ macro(macro_declare_executable exe_name)
 endmacro(macro_declare_executable)
 
 # ---------------------------------------------------------------------------
-# Description : Identifies compiler family, compiler short name,
-#               and guess the similar C-compiler by given
-#               C++ compiler. The C++ compiler may contain only
-#               name or the full path. If only name is specified,
-#               the path should be included in PATH environment variable.
-# Parameters .: ${compiler_path}    --  Input: the name of compiler executable or
-#                                       the full path of compiler.
-#               ${compiler_family}  --  Output: the name of variable that on output
-#                                       will contain the name of compiler family.
-#               ${compiler_short}   --  Output: the name of variable that on output
-#                                       will contain the short name of compiler.
-#               ${compiler_cxx}     --  Output: the name of variable that on output
-#                                       will contain the name of compiler. This value
-#                                       may be same as ${compiler_path}.
-#               ${compiler_c}       --  Output: the name of variable that on output
-#                                       will contain the name of C-compiler. The name
-#                                       or path may differ from ${CMAKE_C_COMPILER}.
-#               ${compiler_found}   --  Output: the name of variable that on output
-#                                       contains the flag, indicating whether the all
-#                                       other output values are valid or not. If
-#                                       the value is 'TRUE', compiler was identified
-#                                       and the value where set. Otherwise, the values
-#                                       in output variables should be ignored.
-# Macro ......: macro_setup_compilers_data
-# Usage ......: macro_setup_compilers_data("${CMAKE_CXX_COMPILER}"
-#                                           AREG_COMPILER_FAMILY
-#                                           AREG_COMPILER_SHORT
-#                                           AREG_CXX_COMPILER
-#                                           AREG_C_COMPILER
+# Description : This macro identifies the compiler family (e.g., GNU, Clang, MSVC),
+#               extracts a short name for the compiler, and attempts to guess the corresponding
+#               C compiler based on the provided C++ compiler path or name. It handles cases
+#               where only the compiler name is provided (assuming it is available in the system's PATH).
+#               If a match is found, it sets the output variables for the compiler family, short name,
+#               C++ compiler path, and C compiler path, and marks the process as successful.
+#               Otherwise, the output flag indicates failure.
+#
+# Note .......: Beside "gnu", "llvm", "msvc", the compilers for CYGWIN are included in the family "cygwin"
+#               to identify that the application is compiled in Windows under CYGWIN platform with GNU compilers.
+# Macro ......: macro_declare_executable
+# Parameters .: 
+#               - ${compiler_path}   -- Input: The name or full path of the C++ compiler executable.
+#               - ${compiler_family} -- Output: Variable to hold the identified compiler family (e.g., "gnu", "msvc").
+#               - ${compiler_short}  -- Output: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
+#               - ${compiler_cxx}    -- Output: Variable to hold the C++ compiler path (usually same as ${compiler_path}).
+#               - ${compiler_c}      -- Output: Variable to hold the corresponding C compiler name or path.
+#               - ${compiler_found}  -- Output: Boolean flag indicating if the compiler was successfully identified ("TRUE" or "FALSE").
+#
+# Usage ......: macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" 
+#                                           AREG_COMPILER_FAMILY 
+#                                           AREG_COMPILER_SHORT 
+#                                           AREG_CXX_COMPILER 
+#                                           AREG_C_COMPILER 
 #                                           _compiler_found
 #                                         )
 # ---------------------------------------------------------------------------
 macro(macro_setup_compilers_data compiler_path compiler_family compiler_short compiler_cxx compiler_c compiler_found)
 
     set(${compiler_found} FALSE)
-    # Search for specific compiler families based on known compiler names.
-    foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "c++;gnu;cc" "cc;gnu;cc" "cl;msvc;cl")
-        list(GET _entry 0 _compiler)
+    
+    # Iterate over known compilers to identify the compiler type
+    foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "cl;msvc;cl")
+        list(GET _entry 0 _cxx_compiler)
         list(GET _entry 1 _family)
         list(GET _entry 2 _c_compiler)
 
-        string(FIND "${compiler_path}" "${_compiler}" FOUND_POS REVERSE)
-        if (${FOUND_POS} GREATER -1)
-            if (CYGWIN AND ("${family_name}" STREQUAL "gnu"))
+        # Check if the provided compiler matches the known C++ compiler
+        string(FIND "${compiler_path}" "${_cxx_compiler}" _found_pos REVERSE)
+        if (_found_pos GREATER -1)
+            # Handle special case for CYGWIN and GNU family compilers
+            if (CYGWIN AND ("${_family}" STREQUAL "gnu"))
                 set(${compiler_family} "cygwin")
             else()
                 set(${compiler_family} "${_family}")
             endif()
 
-            set(${compiler_short}   "${_compiler}")
-            set(${compiler_cxx}     "${compiler_path}")
-            if ("${_compiler}" STREQUAL "${_c_compiler}")
-                set(${compiler_c}     "${compiler_path}")
-            else()    
-                string(REPLACE "${_compiler}" "${_c_compiler}" ${compiler_c} "${compiler_path}")
+            set(${compiler_short} "${_cxx_compiler}")
+            set(${compiler_cxx}   "${compiler_path}")
+
+            # Determine the corresponding C compiler path or name
+            if ("${_cxx_compiler}" STREQUAL "${_c_compiler}")
+                set(${compiler_c} "${compiler_path}")
+            else()
+                string(REPLACE "${_cxx_compiler}" "${_c_compiler}" ${compiler_c} "${compiler_path}")
             endif()
 
+            # Mark compiler as found
             set(${compiler_found} TRUE)
 
+            # break the loop, we have found
             break()
         endif()
     endforeach()
 
 endmacro(macro_setup_compilers_data)
 
+# ---------------------------------------------------------------------------
+# Description : This macro identifies the short name of the C++ and C compilers
+#               based on the provided compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
+#               It assumes that the compiler executables are available in the system's PATH.
+#               Once a match is found for the compiler family, it sets the output variables 
+#               for the short name, C++ compiler name, and C compiler name, and marks the process as successful.
+#               If no match is found, it sets the output flag to "FALSE".
+#
+# Note .......: The "cygwin" family is supported for GNU compilers on the CYGWIN platform in Windows.
+#
+# Macro ......: macro_setyp_compilers_data_by_family
+# Parameters .: 
+#               - ${compiler_family} -- Input: The name of the compiler family (e.g., "gnu", "msvc").
+#               - ${compiler_short}  -- Output: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
+#               - ${compiler_cxx}    -- Output: Variable to hold the C++ compiler name.
+#               - ${compiler_c}      -- Output: Variable to hold the corresponding C compiler name.
+#               - ${compiler_found}  -- Output: Boolean flag indicating whether the compiler was successfully identified ("TRUE" or "FALSE").
+#
+# Usage ......: macro_setyp_compilers_data_by_family("gnu"
+#                                                    AREG_COMPILER_SHORT 
+#                                                    AREG_CXX_COMPILER 
+#                                                    AREG_C_COMPILER 
+#                                                    _compiler_found
+#                                                   )
+# ---------------------------------------------------------------------------
 macro(macro_setyp_compilers_data_by_family compiler_family compiler_short compiler_cxx compiler_c compiler_found)
 
     set(${compiler_found} FALSE)
-    # Search for specific compiler families based on known compiler names.
-    foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "c++;gnu;cc" "cc;gnu;cc" "cl;msvc;cl" "g++;cygwin;gcc")
+    
+    # Iterate over known compilers and match the family
+    foreach(_entry "clang++;llvm;clang" "g++;gnu;gcc" "cl;msvc;cl" "g++;cygwin;gcc")
         list(GET _entry 0 _compiler)
         list(GET _entry 1 _family)
         list(GET _entry 2 _c_compiler)
 
-        if (${_family} STREQUAL ${compiler_family})
-            set(${compiler_short}   ${_compiler})
-            set(${compiler_cxx}     ${_compiler})
-            set(${compiler_c}       ${_compiler})
-            set(${compiler_found}   TRUE)
+        if ("${_family}" STREQUAL "${compiler_family}")
+            # Special case for Windows
+            if ("${_family}" STREQUAL "llvm" and WIN32)
+                set(${compiler_short} "clang-cl")
+                set(${compiler_cxx}   "clang-cl")
+                set(${compiler_c}     "$clang-cl")
+            else()
+                set(${compiler_short} "${_compiler}")
+                set(${compiler_cxx}   "${_compiler}")
+                set(${compiler_c}     "${_c_compiler}")
+            endif()
 
+            # Mark compiler as found
+            set(${compiler_found} TRUE)
+
+            # break the loop, we have found
             break()
         endif()
     endforeach()
 
 endmacro(macro_setyp_compilers_data_by_family)
 
-function(printAregStatus var_make_print var_prefix var_header var_footer)
-    if (NOT var_make_print)
+# ---------------------------------------------------------------------------
+# Description : This function prints a detailed status report for the AREG project's CMake configuration.
+#               It provides an overview of the build environment, compiler, output directories, 
+#               and relevant configuration options such as installed packages and libraries.
+#
+# Function ...: printAregConfigStatus
+# Parameters .: 
+#               - ${var_make_print} -- Boolean flag indicating whether to print the status message. 
+#                                      If FALSE, the function exits without printing.
+#               - ${var_prefix}     -- A prefix added to each line of the status message (e.g., project name or custom label).
+#               - ${var_header}     -- A custom header message displayed at the beginning of the status report.
+#               - ${var_footer}     -- A custom footer message displayed at the end of the status report.
+#
+# Usage ......: printAregConfigStatus(
+#                                   TRUE
+#                                   "AREG"
+#                                   "----------------------> AREG project CMake Status Report Begin <-----------------------"
+#                                   "-----------------------> AREG project CMake Status Report End <------------------------"
+#                                   )
+# ---------------------------------------------------------------------------
+function(printAregConfigStatus var_make_print var_prefix var_header var_footer)
+    # If the flag is false, skip printing the status
+    if (NOT ${var_make_print})
         return()
     endif()
 
+    # Print the header section with separators
     message(STATUS "=======================================================================================")
     message(STATUS "${var_header}")
     message(STATUS "=======================================================================================")
-    message(STATUS "${var_prefix}: >>> CMAKE_SOURCE_DIR = \'${CMAKE_SOURCE_DIR}\', build type \'${CMAKE_BUILD_TYPE}\'")
-    message(STATUS "${var_prefix}: >>> Build ...........: \'${CMAKE_SYSTEM_NAME}\' system, \'${AREG_BITNESS}\'-bit platform, \'${AREG_PROCESSOR}\' CPU")
-    message(STATUS "${var_prefix}: >>> Compiler ........: \'${CMAKE_CXX_COMPILER}\'")
-    message(STATUS "${var_prefix}: >>> Compiler Version : C++ standard \'c++${CMAKE_CXX_STANDARD}\', compiler family \'${AREG_COMPILER_FAMILY}\'")
-    message(STATUS "${var_prefix}: >>> Binary output ...: \'${CMAKE_RUNTIME_OUTPUT_DIRECTORY}\', extension '${CMAKE_EXECUTABLE_SUFFIX}'")
-    message(STATUS "${var_prefix}: >>> Generated files .: \'${AREG_GENERATE_DIR}\' directory")
-    message(STATUS "${var_prefix}: >>> Packages ........: \'${FETCHCONTENT_BASE_DIR}\' directory")
-    message(STATUS "${var_prefix}: >>> Build libraries .: areg is \'${AREG_BINARY}\', aregextend is static, areglogger is \'${AREG_LOGGER_LIB}\' library")
-    message(STATUS "${var_prefix}: >>> Java version ....: \'${Java_VERSION_STRING}\' of version \'${Java_JAVA_EXECUTABLE}\'. Minimum should be 17")
-    message(STATUS "${var_prefix}: >>> Use of packages .: SQLite3 package use is \'${AREG_SQLITE_PACKAGE}\', GTest package use is \'${AREG_GTEST_PACKAGE}\' ")
-    message(STATUS "${var_prefix}: >>> Other options ...: Examples = \'${AREG_BUILD_EXAMPLES}\', Unit Tests = \'${AREG_BUILD_TESTS}\', AREG Extended = \'${AREG_EXTENDED}\', Logs = \'${AREG_LOGS}\'")
-    message(STATUS "${var_prefix}: >>> Installation ....: is '${AREG_INSTALL}', location \'${CMAKE_INSTALL_PREFIX}\'")
+
+    # Print detailed configuration status, each with the defined prefix
+    message(STATUS "${var_prefix}: >>> CMAKE_SOURCE_DIR    = '${CMAKE_SOURCE_DIR}', build type '${CMAKE_BUILD_TYPE}'")
+    message(STATUS "${var_prefix}: >>> Build Environment ..: System '${CMAKE_SYSTEM_NAME}', ${AREG_BITNESS}-bit platform, '${AREG_PROCESSOR}' CPU")
+    message(STATUS "${var_prefix}: >>> Compiler ...........: '${CMAKE_CXX_COMPILER}'")
+    message(STATUS "${var_prefix}: >>> Compiler Version ...: C++ standard 'c++${CMAKE_CXX_STANDARD}', compiler family '${AREG_COMPILER_FAMILY}'")
+    message(STATUS "${var_prefix}: >>> Binary Output Dir ..: '${CMAKE_RUNTIME_OUTPUT_DIRECTORY}', executable extension '${CMAKE_EXECUTABLE_SUFFIX}'")
+    message(STATUS "${var_prefix}: >>> Generated Files Dir : '${AREG_GENERATE_DIR}'")
+    message(STATUS "${var_prefix}: >>> Packages Dir .......: '${FETCHCONTENT_BASE_DIR}'")
+    message(STATUS "${var_prefix}: >>> Build Libraries ....: areg = '${AREG_BINARY}', aregextend = static, areglogger = '${AREG_LOGGER_LIB}'")
+    message(STATUS "${var_prefix}: >>> Java Version .......: '${Java_VERSION_STRING}', Java executable = '${Java_JAVA_EXECUTABLE}', minimum version required = 17")
+    message(STATUS "${var_prefix}: >>> Packages Use .......: SQLite3 package use = '${AREG_SQLITE_PACKAGE}', GTest package use = '${AREG_GTEST_PACKAGE}'")
+    message(STATUS "${var_prefix}: >>> Other Options ......: Examples = '${AREG_BUILD_EXAMPLES}', Unit Tests = '${AREG_BUILD_TESTS}', AREG Extended = '${AREG_EXTENDED}', Logs = '${AREG_LOGS}'")
+    message(STATUS "${var_prefix}: >>> Installation .......: Enabled = '${AREG_INSTALL}', location = '${CMAKE_INSTALL_PREFIX}'")
+
+    # Print the footer section with separators
     message(STATUS "=======================================================================================")
     message(STATUS "${var_footer}")
     message(STATUS "=======================================================================================")
 
-endfunction(printAregStatus)
+endfunction(printAregConfigStatus)

--- a/conf/cmake/gnu.cmake
+++ b/conf/cmake/gnu.cmake
@@ -3,7 +3,7 @@
 # Copyright 2022-2023 Aregtech
 # ###########################################################################
 
-message(STATUS "AREG: >>> Preparing settings for GNU compiler and POSIX API, Cygwin = '${CYGWIN}'")
+message(STATUS "AREG: >>> Preparing settings for GNU compiler under \'${AREG_OS}\' platform, Cygwin = \'${CYGWIN}\'")
 
 if (CYGWIN)
     set(AREG_COMPILER_FAMILY "cygwin")  

--- a/conf/cmake/install.cmake
+++ b/conf/cmake/install.cmake
@@ -49,7 +49,7 @@ install(TARGETS areg aregextend areglogger
 )
 
 # Copy AREG configuration file
-install(FILES "${AREG_BASE}/areg/resources/areg.init"
+install(FILES "${AREG_FRAMEWORK}/areg/resources/areg.init"
             DESTINATION share/${AREG_PACKAGE_NAME}
             COMPONENT Development   COMPONENT Runtime
             PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ
@@ -97,7 +97,7 @@ install(TARGETS areg areglogger
 )
 
 # Copy AREG configuration file
-install(FILES "${AREG_BASE}/areg/resources/areg.init"
+install(FILES "${AREG_FRAMEWORK}/areg/resources/areg.init"
             DESTINATION tools/${AREG_PACKAGE_NAME}/config
             COMPONENT Development   COMPONENT Runtime
             PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ

--- a/conf/cmake/msvc.cmake
+++ b/conf/cmake/msvc.cmake
@@ -3,7 +3,7 @@
 # Copyright 2022-2023 Aregtech
 # ###########################################################################
 
-message(STATUS "AREG: >>> Preparing settings for MSVC compiler and with Win32 API")
+message(STATUS "AREG: >>> Preparing settings for MSVC compiler under \'${AREG_OS}\' platform, WIN32 = \'${WIN32}\'")
 
 # Visual Studio C++, Windows / Win32 API
 set(AREG_DEVELOP_ENV "Win32")

--- a/conf/cmake/setup.cmake
+++ b/conf/cmake/setup.cmake
@@ -49,20 +49,8 @@ include(${AREG_CMAKE_CONFIG_DIR}/functions.cmake)
 # setup user configurations
 include(${AREG_CMAKE_CONFIG_DIR}/user.cmake)
 
-# If compiler family name is not empty.
-# Otherwise, use system default compiler.
-# See in 'common.cmake'
-if (NOT "${AREG_COMPILER_FAMILY}" STREQUAL "")
-    set(CMAKE_CXX_COMPILER  "${AREG_CXX_COMPILER}")
-    set(CMAKE_C_COMPILER    "${AREG_C_COMPILER}")
-endif()
-
-# set CMake tool settings
-set(CMAKE_BUILD_TYPE        ${AREG_BUILD_TYPE})
-set(CMAKE_BUILD_TYPE        ${AREG_BUILD_TYPE} CACHE STRING "Configuration Type" FORCE)
-
 # check and fix CXX standard
-macro_check_fix_cxx_standard()
+macro_check_fix_areg_cxx_standard()
 
 if (NOT "${AREG_PACKAGES}" STREQUAL "")
     set(FETCHCONTENT_BASE_DIR   "${AREG_PACKAGES}" CACHE PATH "Location of AREG thirdparty packages" FORCE)

--- a/conf/cmake/setup.cmake
+++ b/conf/cmake/setup.cmake
@@ -6,7 +6,7 @@
 #
 # The variable 'AREG_SDK_ROOT' should be already set.
 # 
-# Copyright © 2022-2023 Aregtech
+# Copyright ï¿½ 2022-2023 Aregtech
 # ###########################################################################
 
 if (NOT DEFINED AREG_SDK_ROOT OR "${AREG_SDK_ROOT}" STREQUAL "")
@@ -20,8 +20,8 @@ if (NOT DEFINED AREG_CMAKE_CONFIG_DIR OR "${AREG_CMAKE_CONFIG_DIR}" STREQUAL "")
 endif()
 
 # The location of AREG Framework source codes.
-if (NOT DEFINED AREG_BASE OR "${AREG_BASE}" STREQUAL "")
-    set(AREG_BASE               "${AREG_SDK_ROOT}/framework")
+if (NOT DEFINED AREG_FRAMEWORK OR "${AREG_FRAMEWORK}" STREQUAL "")
+    set(AREG_FRAMEWORK               "${AREG_SDK_ROOT}/framework")
 endif()
 
 # The location of AREG Framework examples
@@ -48,6 +48,20 @@ endif()
 include(${AREG_CMAKE_CONFIG_DIR}/functions.cmake)
 # setup user configurations
 include(${AREG_CMAKE_CONFIG_DIR}/user.cmake)
+
+# Check whether the CMake CXX-compiler is set
+if ("${CMAKE_CXX_COMPILER}" STREQUAL "")
+    set(CMAKE_CXX_COMPILER    "${AREG_CXX_COMPILER}")
+else()
+    set(AREG_CXX_COMPILER     "${CMAKE_CXX_COMPILER}")
+endif()
+
+# Check whether the CMake C-compiler is set
+if ("${CMAKE_C_COMPILER}" STREQUAL "")
+    set(CMAKE_C_COMPILER    "${AREG_C_COMPILER}")
+else()
+    set(AREG_C_COMPILER     "${CMAKE_C_COMPILER}")
+endif()
 
 # check and fix CXX standard
 macro_check_fix_areg_cxx_standard()

--- a/conf/cmake/setup.cmake
+++ b/conf/cmake/setup.cmake
@@ -50,20 +50,26 @@ include(${AREG_CMAKE_CONFIG_DIR}/functions.cmake)
 include(${AREG_CMAKE_CONFIG_DIR}/user.cmake)
 
 # Check whether the CMake CXX-compiler is set
-if ("${CMAKE_CXX_COMPILER}" STREQUAL "")
-    set(CMAKE_CXX_COMPILER    "${AREG_CXX_COMPILER}")
-else()
-    set(AREG_CXX_COMPILER     "${CMAKE_CXX_COMPILER}")
+if (NOT "${AREG_CXX_COMPILER}" STREQUAL "")
+    if ("${CMAKE_CXX_COMPILER}" STREQUAL "")
+        set(CMAKE_CXX_COMPILER  "${AREG_CXX_COMPILER}")
+    else()
+        # Force to set existing compiler
+        set(AREG_CXX_COMPILER   "${CMAKE_CXX_COMPILER}")
+    endif()
 endif()
 
 # Check whether the CMake C-compiler is set
-if ("${CMAKE_C_COMPILER}" STREQUAL "")
-    set(CMAKE_C_COMPILER    "${AREG_C_COMPILER}")
-else()
-    set(AREG_C_COMPILER     "${CMAKE_C_COMPILER}")
+if (NOT "${AREG_C_COMPILER}" STREQUAL "")
+    if ("${CMAKE_C_COMPILER}" STREQUAL "")
+        set(CMAKE_C_COMPILER    "${AREG_C_COMPILER}")
+    else()
+        # Force to set existing compiler
+        set(AREG_C_COMPILER     "${CMAKE_C_COMPILER}")
+    endif()
 endif()
 
-# check and fix CXX standard
+# check and fix CXX standard for AREG Framework sources.
 macro_check_fix_areg_cxx_standard()
 
 if (NOT "${AREG_PACKAGES}" STREQUAL "")

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -109,7 +109,7 @@ elseif(DEFINED AREG_COMPILER_FAMILY AND NOT ${AREG_COMPILER_FAMILY} STREQUAL "")
 
     # Check the compiler option and set compiler family and specific compiler commands accordingly.
     message(STATUS "AREG: >>> User selected C/C++ compiler family \'${AREG_COMPILER_FAMILY}\'")
-    macro_setyp_compilers_data_by_family(${AREG_COMPILER_FAMILY} _compiler_short _cxx_compiler _c_compiler _compiler_found)
+    macro_setup_compilers_data_by_family(${AREG_COMPILER_FAMILY} _compiler_short _cxx_compiler _c_compiler _compiler_found)
     if (_compiler_found)
 
         set(AREG_COMPILER           ${_cxx_compiler})

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -96,12 +96,16 @@ if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
 
         set(AREG_COMPILER_FAMILY    "${_compiler_family}")
         set(AREG_COMPILER           "${_compiler_short}")
-        set(AREG_CXX_COMPILER       "${_compiler_cxx}")
-        set(AREG_C_COMPILER         "${_compiler_c}")
         set(_compiler_setup TRUE)
 
-        set(CMAKE_C_COMPILER    ${AREG_C_COMPILER})
-        set(CMAKE_CXX_COMPILER  ${AREG_CXX_COMPILER})
+        set(AREG_CXX_COMPILER       "${CMAKE_CXX_COMPILER}")
+        if ("${CMAKE_CXX_COMPILER}" STREQUAL "")
+            set(AREG_C_COMPILER     "${_compiler_c}")
+            set(CMAKE_C_COMPILER    "${_compiler_c}")
+        else()
+            set(AREG_C_COMPILER     "${CMAKE_C_COMPILER}")
+        endif()
+
     endif()
 endif()
 

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -71,86 +71,88 @@
 #   - Visit https://github.com/aregtech/areg-sdk-demo repository to see various ways of AREG Framework integration.
 # ---------------------------------------------------------------------------
 
-# CPP compiler, possible values: g++, gcc, c++, cc, clang++, clang, clang-cl, cl
+# Set variables for C++ and C compilers and their short name
 set(AREG_CXX_COMPILER)
-# C compiler, possible values: gcc, clang, clang-cl, cl
 set(AREG_C_COMPILER)
-# The short name of the compiler
 set(AREG_COMPILER_SHORT)
 
-# If the CMAKE_CXX_COMPILER is specified, ignore all others
+# If CMake compilers are specified, use them
 if ((DEFINED CMAKE_CXX_COMPILER OR DEFINED CMAKE_C_COMPILER) AND (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "" OR NOT "${CMAKE_C_COMPILER}" STREQUAL ""))
 
-    set(_sys_compiler "")
+    # Determine the system compiler based on the available CMake variables
     if (DEFINED CMAKE_CXX_COMPILER AND NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
         set(_sys_compiler "${CMAKE_CXX_COMPILER}")
     else()
-        set(_sys_compiler "${CMAKE_CXX_COMPILER}")
+        set(_sys_compiler "${CMAKE_C_COMPILER}")
     endif()
 
-    message(STATUS "AREG: >>> Using CMake specified C++ compiler \'${_sys_compiler}\'")
+    message(STATUS "AREG: >>> Using CMake specified C++ compiler '${_sys_compiler}'")
+
+    # Setup compiler details based on the identified system compiler
     macro_setup_compilers_data("${_sys_compiler}" _compiler_family _compiler_short _cxx_compiler _c_compiler _compiler_found)
+
     if (_compiler_found)
+        # Check for existing compiler family or specific compiler and issue warnings if necessary
         if (DEFINED AREG_COMPILER_FAMILY AND NOT "${AREG_COMPILER_FAMILY}" STREQUAL "${_compiler_family}")
-            message(WARNING "AREG: Compiler family \'${AREG_COMPILER_FAMILY}\' was chosen, but it is ignored since compiling with other compiler")
+            message(WARNING "AREG: Selected compiler family '${AREG_COMPILER_FAMILY}' is ignored; using '${_compiler_family}'")
         endif()
+
+        # Only if AREG_COMPILER is defined, compare the short compiler name to the full path
         if (DEFINED AREG_COMPILER)
             string(FIND "${AREG_COMPILER}" "${_compiler_short}" _found_pos)
             if (_found_pos LESS 0)
-                message(WARNING "AREG: Compiler \'${AREG_COMPILER}\' was chosen, but it is ignored since compiling with compiler with other compiler")
+                message(WARNING "AREG: Selected compiler '${AREG_COMPILER}' is ignored; using '${_compiler_short}'")
             endif()
         endif()
 
+        # Set the relevant variables for the compiler
         set(AREG_COMPILER_FAMILY    "${_compiler_family}")
         set(AREG_COMPILER           "${_sys_compiler}")
         set(AREG_COMPILER_SHORT     "${_compiler_short}")
         set(AREG_CXX_COMPILER       "${_sys_compiler}")
         set(AREG_C_COMPILER         "${_c_compiler}")
-
     else()
-        message(WARNING "AREG: >>> The CMake CXX compiler \'${_sys_compiler}\' is unknown, the results are unpredictable")
-    endif(_compiler_found)
+        message(WARNING "AREG: Unknown C++ compiler '${_sys_compiler}'; results may be unpredictable")
+    endif()
 
-    unset(__sys_compiler)
+    unset(_sys_compiler)
 
-# else if AREG_COMPILER_FAMILY is specified, guess compilers
-elseif(DEFINED AREG_COMPILER_FAMILY AND NOT ${AREG_COMPILER_FAMILY} STREQUAL "")
+# If a specific compiler family is set, use that to determine compilers
+elseif (DEFINED AREG_COMPILER_FAMILY AND NOT "${AREG_COMPILER_FAMILY}" STREQUAL "")
 
-    # Check the compiler option and set compiler family and specific compiler commands accordingly.
-    message(STATUS "AREG: >>> User selected C/C++ compiler family \'${AREG_COMPILER_FAMILY}\'")
-    macro_setup_compilers_data_by_family(${AREG_COMPILER_FAMILY} _compiler_short _cxx_compiler _c_compiler _compiler_found)
+    message(STATUS "AREG: >>> Using user-specified C/C++ compiler family '${AREG_COMPILER_FAMILY}'")
+    macro_setup_compilers_data_by_family("${AREG_COMPILER_FAMILY}" _compiler_short _cxx_compiler _c_compiler _compiler_found)
+
     if (_compiler_found)
-
-        set(AREG_COMPILER           ${_cxx_compiler})
-        set(AREG_COMPILER_SHORT     ${_compiler_short})
-        set(AREG_CXX_COMPILER       ${_cxx_compiler})
-        set(AREG_C_COMPILER         ${_c_compiler})
-
+        # Set the relevant variables for the chosen compiler family
+        set(AREG_COMPILER           "${_cxx_compiler}")
+        set(AREG_COMPILER_SHORT     "${_compiler_short}")
+        set(AREG_CXX_COMPILER       "${_cxx_compiler}")
+        set(AREG_C_COMPILER         "${_c_compiler}")
     else()
-        message(WARNING "AREG: >>> The \'${AREG_COMPILER_FAMILY}\' family compiler is unknown, the results are unpredictable")
-    endif(_compiler_found)
+        message(WARNING "AREG: Unknown compiler family '${AREG_COMPILER_FAMILY}'; results may be unpredictable")
+    endif()
 
-# else if AREG_COMPILER is specified, guess compilers
-elseif(DEFINED AREG_COMPILER AND NOT ${AREG_COMPILER} STREQUAL "")
+# If a specific compiler is set, use that to determine compilers
+elseif (DEFINED AREG_COMPILER AND NOT "${AREG_COMPILER}" STREQUAL "")
 
-    message(STATUS "AREG: >>> User selected C/C++ compiler \'${AREG_COMPILER}\'")
+    message(STATUS "AREG: >>> Using user-specified C/C++ compiler '${AREG_COMPILER}'")
     # Set both C and C++ compilers based on AREG_COMPILER
-    macro_setup_compilers_data(${AREG_COMPILER} _compiler_family _compiler_short _cxx_compiler _c_compiler _compiler_found)
+    macro_setup_compilers_data("${AREG_COMPILER}" _compiler_family _compiler_short _cxx_compiler _c_compiler _compiler_found)
 
     if (_compiler_found)
-
-        set(AREG_COMPILER_FAMILY    ${_compiler_family})
-        set(AREG_COMPILER_SHORT     ${_compiler_short})
-        set(AREG_CXX_COMPILER       ${_cxx_compiler})
-        set(AREG_C_COMPILER         ${_c_compiler})
-
+        # Set the relevant variables for the chosen compiler
+        set(AREG_COMPILER_FAMILY    "${_compiler_family}")
+        set(AREG_COMPILER_SHORT     "${_compiler_short}")
+        set(AREG_CXX_COMPILER       "${_cxx_compiler}")
+        set(AREG_C_COMPILER         "${_c_compiler}")
     else()
-        message(WARNING "AREG: >>> The specified compiler \'${AREG_COMPILER}\' is unknown, the results are unpredictable")
-    endif(_compiler_found)
+        message(WARNING "AREG: Unknown compiler '${AREG_COMPILER}'; results may be unpredictable")
+    endif()
 
-# else, use the system default C/C++ compilers
+# If no specific compiler or family is set, use the system default
 else()
-    message(STATUS "AREG: >>> No compiler is selected, using system default.")
+    message(STATUS "AREG: >>> No compiler specified; using system default compilers.")
 endif()
 
 # Set build configuration. Set "Debug" for debug build, and "Release" for release build.

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -73,61 +73,74 @@
 
 # CPP compiler, possible values: g++, gcc, c++, cc, clang++, clang, clang-cl, cl
 set(AREG_CXX_COMPILER)
-
 # C compiler, possible values: gcc, clang, clang-cl, cl
 set(AREG_C_COMPILER)
-
-set(_compiler_setup FALSE)
+# The short name of the compiler
+set(AREG_COMPILER_SHORT)
 
 if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
-    message(STATUS "AREG: >>> Using defined C++ compiler \'${CMAKE_CXX_COMPILER}\'")
-    macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" _compiler_family _compiler_short _compiler_cxx _compiler_c _compiler_found)
 
+    message(STATUS "AREG: >>> Using CMake specified C++ compiler \'${CMAKE_CXX_COMPILER}\'")
+    macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" _compiler_family _compiler_short _cxx_compiler _c_compiler _compiler_found)
     if (_compiler_found)
         if (DEFINED AREG_COMPILER_FAMILY AND NOT "${AREG_COMPILER_FAMILY}" STREQUAL "${_compiler_family}")
             message(WARNING "AREG: Compiler family \'${AREG_COMPILER_FAMILY}\' was chosen, but it is ignored since compiling with other compiler")
         endif()
         if (DEFINED AREG_COMPILER)
-            string(FIND "${AREG_COMPILER}" "${_COMPILER_SHORT}" _found_pos)
+            string(FIND "${AREG_COMPILER}" "${_compiler_short}" _found_pos)
             if (_found_pos LESS 0)
                 message(WARNING "AREG: Compiler \'${AREG_COMPILER}\' was chosen, but it is ignored since compiling with compiler with other compiler")
             endif()
         endif()
 
         set(AREG_COMPILER_FAMILY    "${_compiler_family}")
-        set(AREG_COMPILER           "${_compiler_short}")
-        set(_compiler_setup TRUE)
-
+        set(AREG_COMPILER           "${CMAKE_CXX_COMPILER}")
+        set(AREG_COMPILER_SHORT     "${_compiler_short}")
         set(AREG_CXX_COMPILER       "${CMAKE_CXX_COMPILER}")
-        if ("${CMAKE_CXX_COMPILER}" STREQUAL "")
-            set(AREG_C_COMPILER     "${_compiler_c}")
-            set(CMAKE_C_COMPILER    "${_compiler_c}")
-        else()
-            set(AREG_C_COMPILER     "${CMAKE_C_COMPILER}")
-        endif()
-
-    endif()
-endif()
-
-if (NOT _compiler_setup)
-    if(DEFINED AREG_COMPILER_FAMILY AND NOT ${AREG_COMPILER_FAMILY} STREQUAL "")
-        # Check the compiler option and set compiler family and specific compiler commands accordingly.
-        message(STATUS "AREG: >>> User selected C/C++ compiler family \'${AREG_COMPILER_FAMILY}\'")
-        macro_setup_compiler(${AREG_COMPILER_FAMILY} AREG_CXX_COMPILER AREG_C_COMPILER)
-    elseif(DEFINED AREG_COMPILER AND NOT ${AREG_COMPILER} STREQUAL "")
-        message(STATUS "AREG: >>> User selected C/C++ compiler \'${AREG_COMPILER}\'")
-
-        # Set both C and C++ compilers based on AREG_COMPILER
-        set(AREG_CXX_COMPILER "${AREG_COMPILER}")
-        set(AREG_C_COMPILER "${AREG_COMPILER}")
-
-        macro_setup_compiler(${AREG_COMPILER} AREG_COMPILER_FAMILY AREG_C_COMPILER)
+        set(AREG_C_COMPILER         "${_c_compiler}")
 
     else()
-        message(STATUS "AREG: >>> No compiler is selected, using system default.")
-    endif()
+        message(WARNING "AREG: >>> The CMake CXX compiler \'${CMAKE_CXX_COMPILER}\' is unknown, the results are unpredictable")
+    endif(_compiler_found)
+
+elseif(DEFINED AREG_COMPILER_FAMILY AND NOT ${AREG_COMPILER_FAMILY} STREQUAL "")
+
+    # Check the compiler option and set compiler family and specific compiler commands accordingly.
+    message(STATUS "AREG: >>> User selected C/C++ compiler family \'${AREG_COMPILER_FAMILY}\'")
+    macro_setyp_compilers_data_by_family(${AREG_COMPILER_FAMILY} _compiler_short _cxx_compiler _c_compiler _compiler_found)
+    if (_compiler_found)
+
+        set(AREG_COMPILER           ${_cxx_compiler})
+        set(AREG_COMPILER_SHORT     ${_compiler_short})
+        set(AREG_CXX_COMPILER       ${_cxx_compiler})
+        set(AREG_C_COMPILER         ${_c_compiler})
+
+    else()
+        message(WARNING "AREG: >>> The \'${AREG_COMPILER_FAMILY}\' family compiler is unknown, the results are unpredictable")
+    endif(_compiler_found)
+
+elseif(DEFINED AREG_COMPILER AND NOT ${AREG_COMPILER} STREQUAL "")
+
+    message(STATUS "AREG: >>> User selected C/C++ compiler \'${AREG_COMPILER}\'")
+    # Set both C and C++ compilers based on AREG_COMPILER
+    macro_setup_compilers_data(${AREG_COMPILER} _compiler_family _compiler_short _cxx_compiler _c_compiler _compiler_found)
+
+    if (_compiler_found)
+
+        set(AREG_COMPILER_FAMILY    ${_compiler_family})
+        set(AREG_COMPILER_SHORT     ${_compiler_short})
+        set(AREG_CXX_COMPILER       ${_cxx_compiler})
+        set(AREG_C_COMPILER         ${_c_compiler})
+
+    else()
+        message(WARNING "AREG: >>> The specified compiler \'${AREG_COMPILER}\' is unknown, the results are unpredictable")
+    endif(_compiler_found)
+
+else()
+
+    message(STATUS "AREG: >>> No compiler is selected, using system default.")
+
 endif()
-unset(_compiler_setup)
 
 # Set build configuration. Set "Debug" for debug build, and "Release" for release build.
 if (NOT "${AREG_BUILD_TYPE}" STREQUAL "Debug")

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -79,10 +79,17 @@ set(AREG_C_COMPILER)
 set(AREG_COMPILER_SHORT)
 
 # If the CMAKE_CXX_COMPILER is specified, ignore all others
-if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
+if ((DEFINED CMAKE_CXX_COMPILER OR DEFINED CMAKE_C_COMPILER) AND (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "" OR NOT "${CMAKE_C_COMPILER}" STREQUAL ""))
 
-    message(STATUS "AREG: >>> Using CMake specified C++ compiler \'${CMAKE_CXX_COMPILER}\'")
-    macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" _compiler_family _compiler_short _cxx_compiler _c_compiler _compiler_found)
+    set(_sys_compiler "")
+    if (DEFINED CMAKE_CXX_COMPILER AND NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
+        set(_sys_compiler "${CMAKE_CXX_COMPILER}")
+    else()
+        set(_sys_compiler "${CMAKE_CXX_COMPILER}")
+    endif()
+
+    message(STATUS "AREG: >>> Using CMake specified C++ compiler \'${_sys_compiler}\'")
+    macro_setup_compilers_data("${_sys_compiler}" _compiler_family _compiler_short _cxx_compiler _c_compiler _compiler_found)
     if (_compiler_found)
         if (DEFINED AREG_COMPILER_FAMILY AND NOT "${AREG_COMPILER_FAMILY}" STREQUAL "${_compiler_family}")
             message(WARNING "AREG: Compiler family \'${AREG_COMPILER_FAMILY}\' was chosen, but it is ignored since compiling with other compiler")
@@ -95,14 +102,16 @@ if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
         endif()
 
         set(AREG_COMPILER_FAMILY    "${_compiler_family}")
-        set(AREG_COMPILER           "${CMAKE_CXX_COMPILER}")
+        set(AREG_COMPILER           "${_sys_compiler}")
         set(AREG_COMPILER_SHORT     "${_compiler_short}")
-        set(AREG_CXX_COMPILER       "${CMAKE_CXX_COMPILER}")
+        set(AREG_CXX_COMPILER       "${_sys_compiler}")
         set(AREG_C_COMPILER         "${_c_compiler}")
 
     else()
-        message(WARNING "AREG: >>> The CMake CXX compiler \'${CMAKE_CXX_COMPILER}\' is unknown, the results are unpredictable")
+        message(WARNING "AREG: >>> The CMake CXX compiler \'${_sys_compiler}\' is unknown, the results are unpredictable")
     endif(_compiler_found)
+
+    unset(__sys_compiler)
 
 # else if AREG_COMPILER_FAMILY is specified, guess compilers
 elseif(DEFINED AREG_COMPILER_FAMILY AND NOT ${AREG_COMPILER_FAMILY} STREQUAL "")
@@ -142,7 +151,6 @@ elseif(DEFINED AREG_COMPILER AND NOT ${AREG_COMPILER} STREQUAL "")
 # else, use the system default C/C++ compilers
 else()
     message(STATUS "AREG: >>> No compiler is selected, using system default.")
-
 endif()
 
 # Set build configuration. Set "Debug" for debug build, and "Release" for release build.
@@ -214,10 +222,10 @@ endif()
 set(AREG_CXX_STANDARD 17)
 
 # Specify default bitness, the system bitness is detected in 'common.cmake'
-set(AREG_BITNESS "64")
+set(AREG_BITNESS 64)
 
 # Specify CPU platform here, the system CPU platform is detected in 'commmon.cmake'
-set(AREG_PROCESSOR "x86_64")
+set(AREG_PROCESSOR x86_64)
 
 
 if (NOT DEFINED AREG_ENABLE_OUTPUTS OR AREG_ENABLE_OUTPUTS)

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -78,6 +78,7 @@ set(AREG_C_COMPILER)
 # The short name of the compiler
 set(AREG_COMPILER_SHORT)
 
+# If the CMAKE_CXX_COMPILER is specified, ignore all others
 if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
 
     message(STATUS "AREG: >>> Using CMake specified C++ compiler \'${CMAKE_CXX_COMPILER}\'")
@@ -103,6 +104,7 @@ if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
         message(WARNING "AREG: >>> The CMake CXX compiler \'${CMAKE_CXX_COMPILER}\' is unknown, the results are unpredictable")
     endif(_compiler_found)
 
+# else if AREG_COMPILER_FAMILY is specified, guess compilers
 elseif(DEFINED AREG_COMPILER_FAMILY AND NOT ${AREG_COMPILER_FAMILY} STREQUAL "")
 
     # Check the compiler option and set compiler family and specific compiler commands accordingly.
@@ -119,6 +121,7 @@ elseif(DEFINED AREG_COMPILER_FAMILY AND NOT ${AREG_COMPILER_FAMILY} STREQUAL "")
         message(WARNING "AREG: >>> The \'${AREG_COMPILER_FAMILY}\' family compiler is unknown, the results are unpredictable")
     endif(_compiler_found)
 
+# else if AREG_COMPILER is specified, guess compilers
 elseif(DEFINED AREG_COMPILER AND NOT ${AREG_COMPILER} STREQUAL "")
 
     message(STATUS "AREG: >>> User selected C/C++ compiler \'${AREG_COMPILER}\'")
@@ -136,8 +139,8 @@ elseif(DEFINED AREG_COMPILER AND NOT ${AREG_COMPILER} STREQUAL "")
         message(WARNING "AREG: >>> The specified compiler \'${AREG_COMPILER}\' is unknown, the results are unpredictable")
     endif(_compiler_found)
 
+# else, use the system default C/C++ compilers
 else()
-
     message(STATUS "AREG: >>> No compiler is selected, using system default.")
 
 endif()

--- a/conf/cmake/user.cmake
+++ b/conf/cmake/user.cmake
@@ -93,12 +93,12 @@ if ((DEFINED CMAKE_CXX_COMPILER OR DEFINED CMAKE_C_COMPILER) AND (NOT "${CMAKE_C
 
     if (_compiler_found)
         # Check for existing compiler family or specific compiler and issue warnings if necessary
-        if (DEFINED AREG_COMPILER_FAMILY AND NOT "${AREG_COMPILER_FAMILY}" STREQUAL "${_compiler_family}")
+        if (DEFINED AREG_COMPILER_FAMILY AND NOT "${AREG_COMPILER_FAMILY}" STREQUAL "" AND NOT "${AREG_COMPILER_FAMILY}" STREQUAL "${_compiler_family}")
             message(WARNING "AREG: Selected compiler family '${AREG_COMPILER_FAMILY}' is ignored; using '${_compiler_family}'")
         endif()
 
         # Only if AREG_COMPILER is defined, compare the short compiler name to the full path
-        if (DEFINED AREG_COMPILER)
+        if (DEFINED AREG_COMPILER AND NOT "${AREG_COMPILER}" STREQUAL "")
             string(FIND "${AREG_COMPILER}" "${_compiler_short}" _found_pos)
             if (_found_pos LESS 0)
                 message(WARNING "AREG: Selected compiler '${AREG_COMPILER}' is ignored; using '${_compiler_short}'")

--- a/conf/exports/config.cmake.in
+++ b/conf/exports/config.cmake.in
@@ -8,7 +8,7 @@ include(CMakeFindDependencyMacro)
 # Root folder of the SDK
 set(AREG_SDK_ROOT           "@CMAKE_INSTALL_PREFIX@")
 # Location of 'areg', 'aregextend' and 'areglogger' header files
-set(AREG_BASE               "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
+set(AREG_FRAMEWORK               "@CMAKE_INSTALL_FULL_INCLUDEDIR@")
 # Location of configuration, initialization and other shared files of AREG SDK
 set(AREG_SHARE_DIR          "@CMAKE_INSTALL_PREFIX@/share/@AREG_PACKAGE_NAME@")
 # Location of initialization file to copy as a template in the processes
@@ -59,8 +59,8 @@ option(AREG_BUILD_EXAMPLES  "No AREG Examples"      OFF)
 # set to 'CMAKE_CURRENT_BINARY_DIR' if it should be in the compiled binaries directory
 set(AREG_BUILD_ROOT         "${CMAKE_SOURCE_DIR}/product")
 
-# Add '${AREG_BASE}' path in the includes
-include_directories(${AREG_BASE})
+# Add '${AREG_FRAMEWORK}' path in the includes
+include_directories(${AREG_FRAMEWORK})
 # Pass the path to the shared 'areg.init' file to the source codes.
 
 # Pass path to the 'areg.init' file as a preprocessor definition

--- a/examples/17_winchat/CMakeLists.txt
+++ b/examples/17_winchat/CMakeLists.txt
@@ -13,7 +13,6 @@ list(APPEND MFC_DEFINES _AFXDLL _BIND_TO_CURRENT_CRT_VERSION _BIND_TO_CURRENT_MF
 
 # ####################################
 # 'chatter' project
-
 macro_declare_executable(17_chatter 
     17_generated
     chatter/res/stdafx.cpp
@@ -52,8 +51,6 @@ target_compile_options(17_chatter PRIVATE "${AREG_OPT_DISABLE_WARN_EXAMPLES}")
 
 # ####################################
 # 'register' project
-
-
 macro_declare_executable(17_register    17_generated
     register/res/stdafx.cpp
     register/res/register.rc

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -2,9 +2,9 @@
 # ###########################################################################
 # User specific settings
 # ###########################################################################
-include("${AREG_BASE}/areg/CMakeLists.txt")
-include("${AREG_BASE}/aregextend/CMakeLists.txt")
-include("${AREG_BASE}/areglogger/CMakeLists.txt")
-include("${AREG_BASE}/logger/CMakeLists.txt")
-include("${AREG_BASE}/logobserver/CMakeLists.txt")
-include("${AREG_BASE}/mcrouter/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/aregextend/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areglogger/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/logger/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/logobserver/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/mcrouter/CMakeLists.txt")

--- a/framework/areg/CMakeLists.txt
+++ b/framework/areg/CMakeLists.txt
@@ -1,15 +1,15 @@
 set(areg_SRC)
 
-include("${AREG_BASE}/areg/appbase/private/CMakeLists.txt")
-include("${AREG_BASE}/areg/base/private/CMakeLists.txt")
-include("${AREG_BASE}/areg/component/private/CMakeLists.txt")
-include("${AREG_BASE}/areg/ipc/private/CMakeLists.txt")
-include("${AREG_BASE}/areg/persist/private/CMakeLists.txt")
-include("${AREG_BASE}/areg/trace/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/appbase/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/base/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/component/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/ipc/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/persist/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/trace/private/CMakeLists.txt")
 
 if (${AREG_DEVELOP_ENV} MATCHES "Win32")
-    set_source_files_properties("${AREG_BASE}/areg/resources/areg.rc" PROPERTIES LANGUAGE RC)
-    list(APPEND areg_SRC ${AREG_BASE}/areg/resources/areg.rc)
+    set_source_files_properties("${AREG_FRAMEWORK}/areg/resources/areg.rc" PROPERTIES LANGUAGE RC)
+    list(APPEND areg_SRC ${AREG_FRAMEWORK}/areg/resources/areg.rc)
 endif()
 
 # build areg library
@@ -52,5 +52,5 @@ target_link_libraries(areg PRIVATE ${AREG_LDFLAGS})
 # copying log and router init files to 'bin/config'
 add_custom_command( TARGET areg POST_BUILD 
                     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/config
-                    COMMAND ${CMAKE_COMMAND} -E copy ${AREG_BASE}/areg/resources/areg.init ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/config/areg.init
+                    COMMAND ${CMAKE_COMMAND} -E copy ${AREG_FRAMEWORK}/areg/resources/areg.init ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/config/areg.init
                     VERBATIM)

--- a/framework/areg/appbase/private/CMakeLists.txt
+++ b/framework/areg/appbase/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(areg_SRC "${AREG_BASE}"
+macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
     areg/appbase/private/Application.cpp
 	areg/appbase/private/configure.cpp
     areg/appbase/private/NEApplication.cpp 

--- a/framework/areg/base/private/CMakeLists.txt
+++ b/framework/areg/base/private/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Adding sources
-macro_add_source(areg_SRC "${AREG_BASE}"
+macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
     areg/base/private/BufferPosition.cpp
 	areg/base/private/BufferStreamBase.cpp
 	areg/base/private/Containers.cpp
@@ -44,5 +44,5 @@ macro_add_source(areg_SRC "${AREG_BASE}"
 	areg/base/private/WriteConverter.cpp
 )
 
-include("${AREG_BASE}/areg/base/private/win32/CMakeLists.txt")
-include("${AREG_BASE}/areg/base/private/posix/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/base/private/win32/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/base/private/posix/CMakeLists.txt")

--- a/framework/areg/base/private/posix/CMakeLists.txt
+++ b/framework/areg/base/private/posix/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(areg_SRC "${AREG_BASE}"
+macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
 	areg/base/private/posix/CriticalSectionIX.cpp
 	areg/base/private/posix/FilePosix.cpp
 	areg/base/private/posix/IESynchObjectBaseIX.cpp

--- a/framework/areg/base/private/win32/CMakeLists.txt
+++ b/framework/areg/base/private/win32/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source( areg_SRC "${AREG_BASE}"
+macro_add_source( areg_SRC "${AREG_FRAMEWORK}"
     areg/base/private/win32/FileWin32.cpp
 	areg/base/private/win32/NEDebugWin32.cpp
 	areg/base/private/win32/NESocketWin32.cpp

--- a/framework/areg/component/private/CMakeLists.txt
+++ b/framework/areg/component/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(areg_SRC "${AREG_BASE}"
+macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
     areg/component/private/Channel.cpp
 	areg/component/private/ClientInfo.cpp
 	areg/component/private/ClientList.cpp
@@ -61,5 +61,5 @@ macro_add_source(areg_SRC "${AREG_BASE}"
 	areg/component/private/WorkerThread.cpp
 )
 
-include("${AREG_BASE}/areg/component/private/posix/CMakeLists.txt")
-include("${AREG_BASE}/areg/component/private/win32/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/component/private/posix/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areg/component/private/win32/CMakeLists.txt")

--- a/framework/areg/component/private/posix/CMakeLists.txt
+++ b/framework/areg/component/private/posix/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(areg_SRC "${AREG_BASE}"
+macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
     areg/component/private/posix/TimerBasePosix.cpp
     areg/component/private/posix/TimerManagerPosix.cpp
 	areg/component/private/posix/TimerPosix.cpp

--- a/framework/areg/component/private/win32/CMakeLists.txt
+++ b/framework/areg/component/private/win32/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(areg_SRC "${AREG_BASE}"
+macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
     areg/component/private/win32/TimerBaseWin32.cpp
     areg/component/private/win32/TimerManagerWin32.cpp
     areg/component/private/win32/WatchdogManagerWin32.cpp

--- a/framework/areg/ipc/private/CMakeLists.txt
+++ b/framework/areg/ipc/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(areg_SRC "${AREG_BASE}"
+macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
 	areg/ipc/private/ClientConnection.cpp
 	areg/ipc/private/ClientReceiveThread.cpp
 	areg/ipc/private/ClientSendThread.cpp

--- a/framework/areg/persist/private/CMakeLists.txt
+++ b/framework/areg/persist/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(areg_SRC "${AREG_BASE}"
+macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
 	areg/persist/private/ConfigManager.cpp
 	areg/persist/private/IEConfigurationListener.cpp
 	areg/persist/private/IEDatabaseEngine.cpp

--- a/framework/areg/trace/private/CMakeLists.txt
+++ b/framework/areg/trace/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(areg_SRC "${AREG_BASE}"
+macro_add_source(areg_SRC "${AREG_FRAMEWORK}"
 	areg/trace/private/DatabaseLogger.cpp
 	areg/trace/private/DebugOutputLogger.cpp
 	areg/trace/private/FileLogger.cpp

--- a/framework/aregextend/CMakeLists.txt
+++ b/framework/aregextend/CMakeLists.txt
@@ -1,12 +1,12 @@
 set(aregextend_SRC)
 
-include("${AREG_BASE}/aregextend/console/private/CMakeLists.txt")
-include("${AREG_BASE}/aregextend/db/private/CMakeLists.txt")
-include("${AREG_BASE}/aregextend/service/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/aregextend/console/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/aregextend/db/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/aregextend/service/private/CMakeLists.txt")
 
 if (${AREG_DEVELOP_ENV} MATCHES "Win32")
-    set_source_files_properties("${AREG_BASE}/aregextend/resources/aregextend.rc" PROPERTIES LANGUAGE RC)
-    list(APPEND aregextend_SRC "${AREG_BASE}/aregextend/resources/aregextend.rc")
+    set_source_files_properties("${AREG_FRAMEWORK}/aregextend/resources/aregextend.rc" PROPERTIES LANGUAGE RC)
+    list(APPEND aregextend_SRC "${AREG_FRAMEWORK}/aregextend/resources/aregextend.rc")
 endif()
 
 # build areg extended static library

--- a/framework/aregextend/console/private/CMakeLists.txt
+++ b/framework/aregextend/console/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(aregextend_SRC "${AREG_BASE}"
+macro_add_source(aregextend_SRC "${AREG_FRAMEWORK}"
     aregextend/console/private/Console.cpp
     aregextend/console/private/OptionParser.cpp
     aregextend/console/private/SystemServiceConsole.cpp

--- a/framework/aregextend/db/private/CMakeLists.txt
+++ b/framework/aregextend/db/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(aregextend_SRC "${AREG_BASE}"
+macro_add_source(aregextend_SRC "${AREG_FRAMEWORK}"
     aregextend/db/private/LogSqliteDatabase.cpp
     aregextend/db/private/SqliteDatabase.cpp
 )

--- a/framework/aregextend/service/private/CMakeLists.txt
+++ b/framework/aregextend/service/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(aregextend_SRC "${AREG_BASE}"
+macro_add_source(aregextend_SRC "${AREG_FRAMEWORK}"
     aregextend/service/private/DataRateHelper.cpp
     aregextend/service/private/IEServiceConnectionHandler.cpp
     aregextend/service/private/NESystemService.cpp

--- a/framework/areglogger/CMakeLists.txt
+++ b/framework/areglogger/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(areglogger_SRC)
 
-include("${AREG_BASE}/areglogger/client/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/areglogger/client/private/CMakeLists.txt")
 
 # add .rc file to the list of sources
 if("${AREG_DEVELOP_ENV}" STREQUAL "Win32")
-    set_source_files_properties("${AREG_BASE}/areglogger/resources/areglogger.rc" PROPERTIES LANGUAGE RC)
-	list(APPEND areglogger_SRC ${AREG_BASE}/areglogger/resources/areglogger.rc)
+    set_source_files_properties("${AREG_FRAMEWORK}/areglogger/resources/areglogger.rc" PROPERTIES LANGUAGE RC)
+	list(APPEND areglogger_SRC ${AREG_FRAMEWORK}/areglogger/resources/areglogger.rc)
 endif()
 
 # ##################################################################
@@ -15,7 +15,7 @@ if (AREG_LOGGER_LIB MATCHES "shared")
 
     # add .def file to the list of sources
     if("${AREG_DEVELOP_ENV}" STREQUAL "Win32")
-	    list(APPEND areglogger_SRC "${AREG_BASE}/areglogger/resources/areglogger.def")
+	    list(APPEND areglogger_SRC "${AREG_FRAMEWORK}/areglogger/resources/areglogger.def")
     endif()
 
     # build log observer API shared library
@@ -31,7 +31,7 @@ if (AREG_LOGGER_LIB MATCHES "shared")
 
     # add MSVC linker option
     if (MSVC)
-        target_link_options(areglogger PRIVATE "/DEF:\"${AREG_BASE}/areglogger/resources/logobserver.def\"")
+        target_link_options(areglogger PRIVATE "/DEF:\"${AREG_FRAMEWORK}/areglogger/resources/logobserver.def\"")
     endif()
 
 else()

--- a/framework/areglogger/client/private/CMakeLists.txt
+++ b/framework/areglogger/client/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(areglogger_SRC "${AREG_BASE}"
+macro_add_source(areglogger_SRC "${AREG_FRAMEWORK}"
 	areglogger/client/private/LogObserverApi.cpp
 	areglogger/client/private/LoggerClient.cpp
 	areglogger/client/private/ObserverMessageProcessor.cpp

--- a/framework/logger/CMakeLists.txt
+++ b/framework/logger/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(logger_SRC)
 
-include("${AREG_BASE}/logger/app/private/CMakeLists.txt")
-include("${AREG_BASE}/logger/service/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/logger/app/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/logger/service/private/CMakeLists.txt")
 
-set(_resourses  "${AREG_BASE}/logger/resources")
+set(_resourses  "${AREG_FRAMEWORK}/logger/resources")
 set(_config     "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/config")
 
 if (${AREG_DEVELOP_ENV} MATCHES "Win32")

--- a/framework/logger/app/private/CMakeLists.txt
+++ b/framework/logger/app/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(logger_SRC "${AREG_BASE}"
+macro_add_source(logger_SRC "${AREG_FRAMEWORK}"
 	logger/app/private/Logger.cpp
     logger/app/private/LoggerConsoleService.cpp
 	logger/app/private/NELoggerSettings.cpp

--- a/framework/logger/service/private/CMakeLists.txt
+++ b/framework/logger/service/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(logger_SRC "${AREG_BASE}"
+macro_add_source(logger_SRC "${AREG_FRAMEWORK}"
 	logger/service/private/LoggerMessageProcessor.cpp
 	logger/service/private/LoggerServerService.cpp
 )

--- a/framework/logobserver/CMakeLists.txt
+++ b/framework/logobserver/CMakeLists.txt
@@ -1,10 +1,10 @@
 set(logobserver_SRC)
 
-include("${AREG_BASE}/logobserver/app/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/logobserver/app/private/CMakeLists.txt")
 
 if (${AREG_DEVELOP_ENV} MATCHES "Win32")
-    set_source_files_properties("${AREG_BASE}/logobserver/resources/logobserver.rc" PROPERTIES LANGUAGE RC)
-    list(APPEND logobserver_SRC "${AREG_BASE}/logobserver/resources/logobserver.rc")
+    set_source_files_properties("${AREG_FRAMEWORK}/logobserver/resources/logobserver.rc" PROPERTIES LANGUAGE RC)
+    list(APPEND logobserver_SRC "${AREG_FRAMEWORK}/logobserver/resources/logobserver.rc")
 endif()
 
 # ##################################################################

--- a/framework/logobserver/app/private/CMakeLists.txt
+++ b/framework/logobserver/app/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(logobserver_SRC "${AREG_BASE}"
+macro_add_source(logobserver_SRC "${AREG_FRAMEWORK}"
 	logobserver/app/private/LogObserver.cpp
 	logobserver/app/private/NELogObserverSettings.cpp
     logobserver/app/private/posix/LogObserverPosix.cpp

--- a/framework/mcrouter/CMakeLists.txt
+++ b/framework/mcrouter/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(mcrouter_SRC)
 
-include("${AREG_BASE}/mcrouter/app/private/CMakeLists.txt")
-include("${AREG_BASE}/mcrouter/service/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/mcrouter/app/private/CMakeLists.txt")
+include("${AREG_FRAMEWORK}/mcrouter/service/private/CMakeLists.txt")
 
-set(_resourses  "${AREG_BASE}/mcrouter/resources")
+set(_resourses  "${AREG_FRAMEWORK}/mcrouter/resources")
 set(_config     "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/config")
 
 if (${AREG_DEVELOP_ENV} MATCHES "Win32")

--- a/framework/mcrouter/app/private/CMakeLists.txt
+++ b/framework/mcrouter/app/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(mcrouter_SRC "${AREG_BASE}"
+macro_add_source(mcrouter_SRC "${AREG_FRAMEWORK}"
 	mcrouter/app/private/MulticastRouter.cpp
 	mcrouter/app/private/NEMulticastRouterSettings.cpp
     mcrouter/app/private/RouterConsoleService.cpp

--- a/framework/mcrouter/service/private/CMakeLists.txt
+++ b/framework/mcrouter/service/private/CMakeLists.txt
@@ -1,4 +1,4 @@
-macro_add_source(mcrouter_SRC "${AREG_BASE}"
+macro_add_source(mcrouter_SRC "${AREG_FRAMEWORK}"
 	mcrouter/service/private/ListServiceProxies.cpp
 	mcrouter/service/private/RouterServerService.cpp
 	mcrouter/service/private/ServiceProxy.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ if (AREG_BUILD_TESTS)
     if (AREG_GTEST_FOUND)
         # Google Test package found, make no actions on it, the libraries can be used.
         option(AREG_GTEST_FOUND  "GTest package found flag"   TRUE)
-        message(STATUS "AREG: >>> Will use existing googletest package")
+        message(STATUS "AREG: >>> Will use existing in the system googletest package")
         if (NOT "${AREG_GTEST_INCLUDES}" STREQUAL "")
             include_directories("${AREG_GTEST_INCLUDES}")
         endif()
@@ -27,7 +27,7 @@ if (AREG_BUILD_TESTS)
     else(AREG_GTEST_FOUND)
 
         option(AREG_GTEST_FOUND  "GTest package found flag"   FALSE)
-        message(STATUS "AREG: >>> Will compile googletest libraries")
+        message(STATUS "AREG: >>> Fetching \'googletest\' sources to compile \'gtest\' libraries")
         # Google Test package did not find, fetch sources from repository.
         set(AREG_GTEST_PACKAGE OFF CACHE BOOL "Use GTest installed package" FORCE)
         include(FetchContent)


### PR DESCRIPTION
There was a problem of overwriting CMake C/C++ compilers. This was causing a problem and had strong dependency whether the compiler was selected before `project()` call or after.
The fix is to ignore overwriting C/C++ compile settings.