### PR TITLE
An option to load config file from command line

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -405,7 +405,7 @@ jobs:
         run: |
           mkdir ./${{matrix.config.name}}/
           cp -R ./${{env.BUILD_DEST}}/bin/ ./${{matrix.config.name}}/
-          cp -R  {{env.INSTALL_DEST}} ./${{matrix.config.name}}/
+          cp -R  ./${{env.INSTALL_DEST}}/  ./${{matrix.config.name}}/
 
       - name: Upload artifacts if tests fail. Ignore if unit tests are not compiled
         if: failure() && matrix.config.test == 'ON'

--- a/framework/aregextend/console/OptionParser.hpp
+++ b/framework/aregextend/console/OptionParser.hpp
@@ -403,7 +403,7 @@ public:
      * \return  Returns true if succeeded to parse without error.
      *          Otherwise, returns false.
      **/
-    bool parseCommandLine( const char ** cmdLine,  uint32_t count);
+    bool parseCommandLine( const char ** cmdLine, uint32_t count );
     bool parseCommandLine( const wchar_t ** cmdLine, uint32_t count );
     bool parseCommandLine( char** IN cmdLine, uint32_t count);
     bool parseCommandLine( wchar_t** IN cmdLine, uint32_t count);
@@ -429,6 +429,16 @@ public:
      *          Otherwise, returns false.
      **/
     bool parseOptions( StrList & optList );
+
+    /**
+     * \brief   Searches in the command list the option of specified ID.
+     *          Returns valid index if found the option.
+     *          Otherwise, returns invalid index (NECommon::INVALID_POSITION).
+     * \param   optId   The ID of an option to search in list.
+     * \return  Returns valid index if found an option with specified ID.
+     *          Otherwise, returns invalid index (NECommon::INVALID_POSITION).
+     **/
+    uint32_t findOption(int optId) const;
 
     /**
      * \ brief  Returns the list of parsed options.

--- a/framework/aregextend/console/private/OptionParser.cpp
+++ b/framework/aregextend/console/private/OptionParser.cpp
@@ -167,7 +167,7 @@ namespace
             optList.push_back( str );
         }
     }
-}
+} // namespace
 
 const OptionParser::sOptionSetup OptionParser::getDefaultOptionSetup( void )
 {
@@ -383,6 +383,21 @@ bool OptionParser::parseOptions( StrList & optList )
         {
             mInputOptions.add( opt );
             result = OptionParser::hasInputError( static_cast<uint32_t>(opt.inField) ) == false;
+        }
+    }
+
+    return result;
+}
+
+uint32_t OptionParser::findOption(int optId) const
+{
+    uint32_t result{ NECommon::INVALID_POSITION };
+    for (uint32_t i = 0; i < mInputOptions.getSize(); ++i)
+    {
+        if (mInputOptions.getAt(i).inCommand == optId)
+        {
+            result = i;
+            break;
         }
     }
 

--- a/framework/aregextend/service/NESystemService.hpp
+++ b/framework/aregextend/service/NESystemService.hpp
@@ -79,7 +79,7 @@ namespace NESystemService
      * \brief   NESystemService::eSystemServiceState
      *          Describes the system service state.
      **/
-    enum class eSystemServiceState
+    enum class eSystemServiceState : int32_t
     {
           ServiceStopped    //!< Service is stopped.
         , ServiceStarting   //!< Service is in starting process.
@@ -194,18 +194,20 @@ inline const char * NESystemService::getString( NESystemService::eServiceOption 
     {
     case NESystemService::eServiceOption::CMD_Undefined:
         return "NESystemService::CMD_Undefined";
-    case NESystemService::eServiceOption::CMD_Install:
-        return "NESystemService::CMD_Install";
-    case NESystemService::eServiceOption::CMD_Uninstall:
-        return "NESystemService::CMD_Uninstall";
-    case NESystemService::eServiceOption::CMD_Service:
-        return "NESystemService::CMD_Service";
     case NESystemService::eServiceOption::CMD_Console:
         return "NESystemService::CMD_Console";
-    case NESystemService::eServiceOption::CMD_Verbose:
-        return "NESystemService::CMD_Verbose";
     case NESystemService::eServiceOption::CMD_Help:
-        return "NESystemService::eServiceOption::CMD_Help";
+        return "NESystemService::CMD_Help";
+    case NESystemService::eServiceOption::CMD_Load:
+        return "NESystemService::CMD_Load";
+    case NESystemService::eServiceOption::CMD_Install:
+        return "NESystemService::CMD_Install";
+    case NESystemService::eServiceOption::CMD_Service:
+        return "NESystemService::CMD_Service";
+    case NESystemService::eServiceOption::CMD_Uninstall:
+        return "NESystemService::eServiceOption::CMD_Uninstall";
+    case NESystemService::eServiceOption::CMD_Verbose:
+        return "NESystemService::eServiceOption::CMD_Verbose";
     default:
         ASSERT( false );
         return "ERR: Unexpected NESystemService::eServiceOption value!";

--- a/framework/aregextend/service/NESystemService.hpp
+++ b/framework/aregextend/service/NESystemService.hpp
@@ -33,15 +33,18 @@ namespace NESystemService
      * \brief   NESystemService::eServiceOption
      *          Message routing service options.
      **/
-    enum class eServiceOption
+    enum class eServiceOption   : int32_t
     {
           CMD_Undefined     //!< Option is undefined.
-        , CMD_Install       //!< Option is to install (register) service in the system.
-        , CMD_Uninstall     //!< Option is to uninstall (unregister) service in the system.
-        , CMD_Service       //!< Option is to execute process as a system service (in background).
         , CMD_Console       //!< Option is to execute process as console application.
-        , CMD_Verbose       //!< Option is to display the data rate when execute process as console application.
         , CMD_Help          //!< Option is to display help on console.
+        , CMD_Load          //!< Option is to start the process and load configuration from specified file
+        , CMD_Install       //!< Option is to install (register) service in the system.
+        , CMD_Service       //!< Option is to execute process as a system service (in background).
+        , CMD_Uninstall     //!< Option is to uninstall (unregister) service in the system.
+        , CMD_Verbose       //!< Option is to display the data rate when execute process as console application.
+
+        , CMD_Custom        //!< No option, reserved for the custom options.
     };
 
     /**
@@ -54,20 +57,22 @@ namespace NESystemService
      **/
     const OptionParser::sOptionSetup ServiceOptionSetup[ ]
     {
-        //!< Default command.
-        { ""  , ""          , static_cast<int>(eServiceOption::CMD_Console)     , OptionParser::NO_DATA, {}, {}, {} }
-        //!< Command to install service. Valid for Windows OS, ignored in other cases.
-      , { "-i", "--install" , static_cast<int>(eServiceOption::CMD_Install)     , OptionParser::NO_DATA, {}, {}, {} }
-        //!< Command to uninstall service. Valid for Windows OS, ignored in other cases.
-      , { "-u", "--uninstall", static_cast<int>(eServiceOption::CMD_Uninstall)  , OptionParser::NO_DATA, {}, {}, {} }
-        //!< Command to run process as a system service process.
-      , { "-s", "--service" , static_cast<int>(eServiceOption::CMD_Service)     , OptionParser::NO_DATA, {}, {}, {} }
-        //!< Command to run process as a console application.
-      , { "-c", "--console" , static_cast<int>(eServiceOption::CMD_Console)     , OptionParser::NO_DATA, {}, {}, {} }
-        //!< Command to display data rate when run as console application.
-      , { "-v", "--verbose" , static_cast<int>(eServiceOption::CMD_Verbose)     , OptionParser::NO_DATA, {}, {}, {} }
-        //!< Command to display help on console.
-      , { "-h", "--help"    , static_cast<int>(eServiceOption::CMD_Help)        , OptionParser::NO_DATA, {}, {}, {} }
+          //!< Default command.
+          { ""  , ""            , static_cast<int>(eServiceOption::CMD_Console)     , OptionParser::NO_DATA         , {}, {}, {} }
+          //!< Command to run process as a console application.
+        , { "-c", "--console"   , static_cast<int>(eServiceOption::CMD_Console)     , OptionParser::NO_DATA         , {}, {}, {} }
+          //!< Command to display help on console.
+        , { "-h", "--help"      , static_cast<int>(eServiceOption::CMD_Help)        , OptionParser::NO_DATA         , {}, {}, {} }
+          //!< Command to display the error message.
+        , { "-l", "--load"      , static_cast<int>(eServiceOption::CMD_Load)        , OptionParser::STRING_NO_RANGE , {}, {}, {} }
+          //!< Command to install service. Valid for Windows OS, ignored in other cases.
+        , { "-i", "--install"   , static_cast<int>(eServiceOption::CMD_Install)     , OptionParser::NO_DATA         , {}, {}, {} }
+          //!< Command to run process as a system service process.
+        , { "-s", "--service"   , static_cast<int>(eServiceOption::CMD_Service)     , OptionParser::NO_DATA         , {}, {}, {} }
+          //!< Command to uninstall service. Valid for Windows OS, ignored in other cases.
+        , { "-u", "--uninstall" , static_cast<int>(eServiceOption::CMD_Uninstall)  , OptionParser::NO_DATA          , {}, {}, {} }
+          //!< Command to display data rate when run as console application.
+        , { "-v", "--verbose"   , static_cast<int>(eServiceOption::CMD_Verbose)     , OptionParser::NO_DATA         , {}, {}, {} }
     };
 
     /**

--- a/framework/aregextend/service/ServiceApplicationBase.hpp
+++ b/framework/aregextend/service/ServiceApplicationBase.hpp
@@ -261,7 +261,7 @@ protected:
 private:
 
     /**
-     * \brief   OS specific validity check of logger service.
+     * \brief   OS specific validity check of the service.
      **/
     bool _osIsValid( void ) const;
 
@@ -270,6 +270,9 @@ private:
      **/
     void _osFreeResources( void );
 
+    /**
+     * \brief   OS specific initialization of the service.
+     **/
     bool _osInitializeService( void );
 
     /**

--- a/framework/aregextend/service/SystemServiceBase.hpp
+++ b/framework/aregextend/service/SystemServiceBase.hpp
@@ -327,6 +327,10 @@ protected:
      * \brief   OS specific service manager handle.
      **/
     void *                                  mSeMHandle;
+    /**
+     * \brief   The relative or full path to the configuration file. By default, NEApplication::DEFAULT_CONFIG_FILE
+     **/
+    String                                  mFileConfig;
 
 //////////////////////////////////////////////////////////////////////////
 // Forbidden calls

--- a/framework/aregextend/service/private/ServiceApplicationBase.cpp
+++ b/framework/aregextend/service/private/ServiceApplicationBase.cpp
@@ -37,6 +37,7 @@ ServiceApplicationBase::ServiceApplicationBase(ServiceCommunicatonBase& commBase
 int ServiceApplicationBase::serviceMain(int argc, char** argv)
 {
     int result{ RESULT_SUCCEEDED };
+    Application::setWorkingDirectory(nullptr);
     if (parseOptions(argc, argv, NESystemService::ServiceOptionSetup, MACRO_ARRAYLEN(NESystemService::ServiceOptionSetup)) == false)
     {
         resetDefaultOptions();
@@ -56,6 +57,7 @@ int ServiceApplicationBase::serviceMain(int argc, char** argv)
         break;
 
     case NESystemService::eServiceOption::CMD_Service:  // fall through
+    case NESystemService::eServiceOption::CMD_Load:     // fall through
     case NESystemService::eServiceOption::CMD_Console:
         result = SystemServiceBase::serviceMain(static_cast<int>(argc), argv);
         mCommunication.waitToComplete();
@@ -82,7 +84,7 @@ bool ServiceApplicationBase::serviceInitialize(int /* argc */, char** /* argv */
                                 , false
                                 , true
                                 , false
-                                , NEApplication::DEFAULT_CONFIG_FILE.data()
+                                , mFileConfig.isEmpty() ? NEApplication::DEFAULT_CONFIG_FILE.data() : mFileConfig.getString()
                                 , static_cast<IEConfigurationListener*>(this));
     return _osInitializeService();
 }

--- a/framework/areglogger.vcxproj
+++ b/framework/areglogger.vcxproj
@@ -25,6 +25,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
+      <ModuleDefinitionFile>areglogger/resources/areglogger.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(ConfigShortName)'=='Release'">
@@ -51,10 +52,10 @@
     <Text Include="areglogger\client\private\CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="areglogger\resources\areglogger.def" />
+    <ResourceCompile Include="areglogger\resources\areglogger.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="areglogger\resources\areglogger.rc" />
+    <None Include="areglogger\resources\areglogger.def" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/framework/areglogger.vcxproj.filters
+++ b/framework/areglogger.vcxproj.filters
@@ -52,13 +52,13 @@
     <Text Include="areglogger\CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="areglogger\resources\areglogger.def">
-      <Filter>Source Files</Filter>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
     <ResourceCompile Include="areglogger\resources\areglogger.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="areglogger\resources\areglogger.def">
+      <Filter>Source Files</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/framework/areglogger/client/private/LogObserverApi.cpp
+++ b/framework/areglogger/client/private/LogObserverApi.cpp
@@ -24,13 +24,13 @@
 
 // Use these options if compile for Windows with MSVC
 #ifdef WINDOWS
-    #pragma comment(lib, "areg")
-    #pragma comment(lib, "aregextend")
+    #pragma comment(lib, "areg.lib")
+    #pragma comment(lib, "aregextend.lib")
 
 #if defined(USE_SQLITE_PACKAGE) && (USE_SQLITE_PACKAGE != 0)
     #pragma comment(lib, "sqlite3")
 #else   // defined(USE_SQLITE_PACKAGE) && (USE_SQLITE_PACKAGE != 0)
-    #pragma comment(lib, "aregsqlite3")
+    #pragma comment(lib, "aregsqlite3.lib")
 #endif  //defined(USE_SQLITE_PACKAGE) && (USE_SQLITE_PACKAGE != 0)
 #endif // WINDOWS
 

--- a/framework/logger/app/Logger.hpp
+++ b/framework/logger/app/Logger.hpp
@@ -50,24 +50,24 @@ private:
      **/
     enum class eLoggerOptions : int32_t
     {
-          CMD_LogUndefined      = NESystemService::eServiceOption::CMD_Undefined    //!< Undefined command.
-        , CMD_LogConsole        = NESystemService::eServiceOption::CMD_Console      //!< Run as console application. Valid only as a command line option.
-        , CMD_LogPrintHelp      = NESystemService::eServiceOption::CMD_Help         //!< Output help message.
-        , CMD_LogLoad           = NESystemService::eServiceOption::CMD_Load         //!< Start the service by loading initialization instructions from configuration file.
-        , CMD_LogInstall        = NESystemService::eServiceOption::CMD_Install      //!< Install as service. Valid only as a command line option in Windows OS.
-        , CMD_LogService        = NESystemService::eServiceOption::CMD_Service      //!< Start logger as a service. Valid only as a command line option in Windows OS.
-        , CMD_LogUninstall      = NESystemService::eServiceOption::CMD_Uninstall    //!< Uninstall as a service. Valid only as a command line option in Windows OS.
-        , CMD_LogVerbose        = NESystemService::eServiceOption::CMD_Verbose      //!< Display data rate information if possible. Functions only with extended features.
-        , CMD_LogPause          = NESystemService::eServiceOption::CMD_Custom       //!< Pause logger.
-        , CMD_LogRestart                                                            //!< Restart logger.
-        , CMD_LogInstances                                                          //!< Display the names of connected log provider and log observer instances.
-        , CMD_LogSilent                                                             //!< Silent mode, no data rate is displayed.
-        , CMD_LogQuit                                                               //!< Quit logger.
-        , CMD_LogQueryScopes                                                        //!< Query the list of scopes
-        , CMD_LogUpdateScope                                                        //!< Set the scope priorities.
-        , CMD_LogSaveLogs                                                           //!< Logger save logs in the file.
-        , CMD_LogSaveLogsStop                                                       //!< Stop saving logs in the file.
-        , CMD_LogSaveConfig                                                         //!< Save the log configuration in the config file.
+          CMD_LogUndefined      = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Undefined)  //!< Undefined command.
+        , CMD_LogConsole        = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Console)    //!< Run as console application. Valid only as a command line option.
+        , CMD_LogPrintHelp      = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Help)       //!< Output help message.
+        , CMD_LogLoad           = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Load)       //!< Start the service by loading initialization instructions from configuration file.
+        , CMD_LogInstall        = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Install)    //!< Install as service. Valid only as a command line option in Windows OS.
+        , CMD_LogService        = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Service)    //!< Start logger as a service. Valid only as a command line option in Windows OS.
+        , CMD_LogUninstall      = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Uninstall)  //!< Uninstall as a service. Valid only as a command line option in Windows OS.
+        , CMD_LogVerbose        = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Verbose)    //!< Display data rate information if possible. Functions only with extended features.
+        , CMD_LogPause          = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Custom)     //!< Pause logger.
+        , CMD_LogRestart                                                                                //!< Restart logger.
+        , CMD_LogInstances                                                                              //!< Display the names of connected log provider and log observer instances.
+        , CMD_LogSilent                                                                                 //!< Silent mode, no data rate is displayed.
+        , CMD_LogQuit                                                                                   //!< Quit logger.
+        , CMD_LogQueryScopes                                                                            //!< Query the list of scopes
+        , CMD_LogUpdateScope                                                                            //!< Set the scope priorities.
+        , CMD_LogSaveLogs                                                                               //!< Logger save logs in the file.
+        , CMD_LogSaveLogsStop                                                                           //!< Stop saving logs in the file.
+        , CMD_LogSaveConfig                                                                             //!< Save the log configuration in the config file.
     };
 
     /**

--- a/framework/logger/app/Logger.hpp
+++ b/framework/logger/app/Logger.hpp
@@ -50,23 +50,24 @@ private:
      **/
     enum class eLoggerOptions : int32_t
     {
-          CMD_LogUndefined      //!< Undefined command.
-        , CMD_LogPause          //!< Pause logger.
-        , CMD_LogRestart        //!< Restart logger.
-        , CMD_LogInstances      //!< Display the names of connected instances.
-        , CMD_LogVerbose        //!< Display data rate information if possible. Functions only with extended features.
-        , CMD_LogSilent         //!< Silent mode, no data rate is displayed.
-        , CMD_LogPrintHelp      //!< Output help message.
-        , CMD_LogQuit           //!< Quit logger.
-        , CMD_LogConsole        //!< Run as console application. Valid only as a command line option.
-        , CMD_LogInstall        //!< Install as service. Valid only as a command line option in Windows OS.
-        , CMD_LogUninstall      //!< Uninstall as a service. Valid only as a command line option in Windows OS.
-        , CMD_LogQueryScopes    //!< Query the list of scopes
-        , CMD_LogService        //!< Start logger as a service. Valid only as a command line option in Windows OS.
-        , CMD_LogUpdateScope    //!< Set the scope priorities.
-        , CMD_LogSaveLogs       //!< Logger save logs in the file.
-        , CMD_LogSaveLogsStop   //!< Cancel saving logs in the file.
-        , CMD_LogSaveConfig     //!< Save the log configuration in the config file.
+          CMD_LogUndefined      = NESystemService::eServiceOption::CMD_Undefined    //!< Undefined command.
+        , CMD_LogConsole        = NESystemService::eServiceOption::CMD_Console      //!< Run as console application. Valid only as a command line option.
+        , CMD_LogPrintHelp      = NESystemService::eServiceOption::CMD_Help         //!< Output help message.
+        , CMD_LogLoad           = NESystemService::eServiceOption::CMD_Load         //!< Start the service by loading initialization instructions from configuration file.
+        , CMD_LogInstall        = NESystemService::eServiceOption::CMD_Install      //!< Install as service. Valid only as a command line option in Windows OS.
+        , CMD_LogService        = NESystemService::eServiceOption::CMD_Service      //!< Start logger as a service. Valid only as a command line option in Windows OS.
+        , CMD_LogUninstall      = NESystemService::eServiceOption::CMD_Uninstall    //!< Uninstall as a service. Valid only as a command line option in Windows OS.
+        , CMD_LogVerbose        = NESystemService::eServiceOption::CMD_Verbose      //!< Display data rate information if possible. Functions only with extended features.
+        , CMD_LogPause          = NESystemService::eServiceOption::CMD_Custom       //!< Pause logger.
+        , CMD_LogRestart                                                            //!< Restart logger.
+        , CMD_LogInstances                                                          //!< Display the names of connected log provider and log observer instances.
+        , CMD_LogSilent                                                             //!< Silent mode, no data rate is displayed.
+        , CMD_LogQuit                                                               //!< Quit logger.
+        , CMD_LogQueryScopes                                                        //!< Query the list of scopes
+        , CMD_LogUpdateScope                                                        //!< Set the scope priorities.
+        , CMD_LogSaveLogs                                                           //!< Logger save logs in the file.
+        , CMD_LogSaveLogsStop                                                       //!< Stop saving logs in the file.
+        , CMD_LogSaveConfig                                                         //!< Save the log configuration in the config file.
     };
 
     /**

--- a/framework/logger/app/private/Logger.cpp
+++ b/framework/logger/app/private/Logger.cpp
@@ -60,18 +60,20 @@ namespace
           {"Usage of AREG Log collector (logger) :"}
         , NESystemService::MSG_SEPARATOR
         , {"-a, --save      : Command to save logs in the file. Used in console application. Usage: --save"}
+        , {"-b, --unsave    : Command to stop saving logs in the file. Used in console application. Usage: --unsave"}
         , {"-c, --console   : Command to run logger as a console application (default option). Usage: \'logger --console\'"}
         , {"-e, --query     : Command to query the list of logging scopes. Used in console application. Usage (\'*\' can be a cookie number): --query *"}
         , {"-f, --config    : Command to save current configuration, including log scopes in the config file. Used in console application. Usage: --config"}
         , {"-h, --help      : Command to display this message on console."}
         , {"-i, --install   : Command to install logger as a service. Valid only for Windows OS. Usage: \'logger --install\'"}
-        , {"-l, --silent    : Command option to stop displaying data rate. Used in console application. Usage: --silent"}
+        , {"-l, --load      : Command to initialize from specified file. Used to start application. Usage: \'logger --load=<path-to-init-file>\'"}
         , {"-n, --instances : Command option to display list of connected instances. Used in console application. Usage: --instances"}
         , {"-o, --scope     : Command to update log scope priority. Used in console application. Usage (\'*\' can be a cookie number): --scope *::areg_base_NESocket=NOTSET"}
         , {"-p, --pause     : Command option to pause connection. Used in console application. Usage: --pause"}
         , {"-q, --quit      : Command option to stop logger and quit application. Used in console application. Usage: --quit"}
         , {"-r, --restart   : Command option to restart connection. Used in console application. Usage: --restart"}
         , {"-s, --service   : Command to run logger as a system service. Usage: \'logger --service\'"}
+        , {"-t, --silent    : Command option to stop displaying data rate. Used in console application. Usage: --silent"}
         , {"-u, --uninstall : Command to uninstall logger as a service. Valid only for Windows OS. Usage: \'logger --uninstall\'"}
         , {"-v, --verbose   : Command option to display data rate. Used in console application. Usage: --verbose"}
         , NESystemService::MSG_SEPARATOR
@@ -104,13 +106,14 @@ const OptionParser::sOptionSetup Logger::ValidOptions[ ]
     , { "-f", "--config"    , static_cast<int>(eLoggerOptions::CMD_LogSaveConfig)   , OptionParser::STRING_NO_RANGE , {}, {}, {} }
     , { "-h", "--help"      , static_cast<int>(eLoggerOptions::CMD_LogPrintHelp)    , OptionParser::NO_DATA         , {}, {}, {} }
     , { "-i", "--install"   , static_cast<int>(eLoggerOptions::CMD_LogInstall)      , OptionParser::NO_DATA         , {}, {}, {} }
-    , { "-l", "--silent"    , static_cast<int>(eLoggerOptions::CMD_LogSilent)       , OptionParser::NO_DATA         , {}, {}, {} }
+    , { "-l", "--load"      , static_cast<int>(eLoggerOptions::CMD_LogLoad)         , OptionParser::STRING_NO_RANGE , {}, {}, {} }
     , { "-n", "--instances" , static_cast<int>(eLoggerOptions::CMD_LogInstances)    , OptionParser::NO_DATA         , {}, {}, {} }
     , { "-o", "--scope"     , static_cast<int>(eLoggerOptions::CMD_LogUpdateScope)  , OptionParser::STRING_NO_RANGE , {}, {}, {} }
     , { "-p", "--pause"     , static_cast<int>(eLoggerOptions::CMD_LogPause)        , OptionParser::NO_DATA         , {}, {}, {} }
     , { "-q", "--quit"      , static_cast<int>(eLoggerOptions::CMD_LogQuit)         , OptionParser::NO_DATA         , {}, {}, {} }
     , { "-r", "--restart"   , static_cast<int>(eLoggerOptions::CMD_LogRestart)      , OptionParser::NO_DATA         , {}, {}, {} }
     , { "-s", "--service"   , static_cast<int>(eLoggerOptions::CMD_LogService)      , OptionParser::NO_DATA         , {}, {}, {} }
+    , { "-t", "--silent"    , static_cast<int>(eLoggerOptions::CMD_LogSilent)       , OptionParser::NO_DATA         , {}, {}, {} }
     , { "-u", "--uninstall" , static_cast<int>(eLoggerOptions::CMD_LogUninstall)    , OptionParser::NO_DATA         , {}, {}, {} }
     , { "-v", "--verbose"   , static_cast<int>(eLoggerOptions::CMD_LogVerbose)      , OptionParser::NO_DATA         , {}, {}, {} }
 };
@@ -353,7 +356,8 @@ bool Logger::_checkCommand(const String& cmd)
             case eLoggerOptions::CMD_LogConsole:        // fall through
             case eLoggerOptions::CMD_LogInstall:        // fall through
             case eLoggerOptions::CMD_LogUninstall:      // fall through
-            case eLoggerOptions::CMD_LogService:
+            case eLoggerOptions::CMD_LogService:        // fall through
+            case eLoggerOptions::CMD_LogLoad:
                 Logger::_outputInfo("This command should be used in command line ...");
                 break;
 

--- a/framework/logobserver/app/LogObserver.hpp
+++ b/framework/logobserver/app/LogObserver.hpp
@@ -53,15 +53,16 @@ private:
      **/
     enum class eLoggerOptions : int32_t
     {
-          CMD_LogUndefined  = 0 //!< Undefined command.
-        , CMD_LogQueryScopes    //!< Query the list of scopes
-        , CMD_LogSaveConfig     //!< Save the configuration file.
+          CMD_LogUndefined   = 0//!< Undefined command.
         , CMD_LogPrintHelp      //!< Output help message.
-        , CMD_LogInformation    //!< Display the list of logging source instances.
+        , CMD_LogLoad           //!< Start the application by loading initialization instructions from configuration file.
+        , CMD_LogPause          //!< Pause log observer
+        , CMD_LogRestart        //!< Start / Restart log observer
+        , CMD_LogInstances      //!< Display the list of log providers
+        , CMD_LogQuit           //!< Quit logger.
+        , CMD_LogQueryScopes    //!< Query the list of scopes
         , CMD_LogUpdateScope    //!< Set and update the log scope priorities.
-        , CMD_LogPause          //!< Pause log observer.
-        , CMD_LogQuit           //!< Quit log observer.
-        , CMD_LogRestart        //!< Restart / continue log observer .
+        , CMD_LogSaveConfig     //!< Save the configuration file.
         , CMD_LogStop           //!< Stop log observer.
     };
 
@@ -85,24 +86,29 @@ private:
      **/
     static constexpr sObserverStatus    ObserverStatus[]
     {
+          // ----------------------------------------------------------------------------------------------------
+          // | Option                           |  status                                           |  error    |
+          // ----------------------------------------------------------------------------------------------------
           //!< No status, no error
-          { eLoggerOptions::CMD_LogUndefined    , "", "" }
-          //!< The status and error message when query scopes.
-        , { eLoggerOptions::CMD_LogQueryScopes  , "Log observer queries scopes."                    , "Log observer failed to query scopes." }
-          //!< The status and error message when request to save configuration
-        , { eLoggerOptions::CMD_LogSaveConfig   , "Log observer requested to save configuration."   , "Log observer failed to request save config." }
+          { eLoggerOptions::CMD_LogUndefined    , ""                                                , "" }
           //!< No status or error when output print help
-        , { eLoggerOptions::CMD_LogPrintHelp    , "", "" }
-          //!< The status or error message when request to output list of  connected instances.
-        , { eLoggerOptions::CMD_LogInformation  , "List of connected instances ..."                 , "" }
-          //!< The status or error message when request to update scopes.
-        , { eLoggerOptions::CMD_LogUpdateScope  , "Log observer requested to update scopes."        , "Log observer failed to request update scopes." }
+        , { eLoggerOptions::CMD_LogPrintHelp    , ""                                                , "" }
+          //!< No status or error when Start the application by loading initialization instructions from configuration file.
+        , { eLoggerOptions::CMD_LogLoad         , ""                                                , "The configuration file does not exist or wrong, make default initialization." }
           //!< The status or error message when request to pause logging.
         , { eLoggerOptions::CMD_LogPause        , "Log observer is paused, type \'-r\' to resume."  , "" }
-          //!< No status or error when request to quit log observer
-        , { eLoggerOptions::CMD_LogQuit         , "", "" }
           //!< The status or error  message when request to start or resume log observer.
         , { eLoggerOptions::CMD_LogRestart      , "Log observer triggered connection."              , "Log observer failed to trigger connection. Check initialization." }
+          //!< The status or error message when request to output list of  connected instances.
+        , { eLoggerOptions::CMD_LogInstances    , "List of connected instances ..."                 , "" }
+          //!< No status or error when request to quit log observer
+        , { eLoggerOptions::CMD_LogQuit         , "", "" }
+          //!< The status and error message when query scopes.
+        , { eLoggerOptions::CMD_LogQueryScopes  , "Log observer queries scopes."                    , "Log observer failed to query scopes." }
+          //!< The status or error message when request to update scopes.
+        , { eLoggerOptions::CMD_LogUpdateScope  , "Log observer requested to update scopes."        , "Log observer failed to request update scopes." }
+          //!< The status and error message when request to save configuration
+        , { eLoggerOptions::CMD_LogSaveConfig   , "Log observer requested to save configuration."   , "Log observer failed to request save config." }
           //!< The status or error message when request to stop logging.
         , { eLoggerOptions::CMD_LogStop         , "Log observer stops, type \'-r\' to resume."      , "Log observer failed to stop. Restart application." }
     };

--- a/framework/mcrouter/app/MulticastRouter.hpp
+++ b/framework/mcrouter/app/MulticastRouter.hpp
@@ -51,19 +51,19 @@ private:
      **/
     enum class eRouterOptions : int32_t
     {
-          CMD_RouterUndefined   = NESystemService::eServiceOption::CMD_Undefined    //!< Undefined command.
-        , CMD_RouterConsole     = NESystemService::eServiceOption::CMD_Console      //!< Run as console application. Valid only as a command line option
-        , CMD_RouterPrintHelp   = NESystemService::eServiceOption::CMD_Help         //!< Print help.
-        , CMD_RouterLoad        = NESystemService::eServiceOption::CMD_Load         //!< Start the service by loading initialization instructions from configuration file.
-        , CMD_RouterInstall     = NESystemService::eServiceOption::CMD_Install      //!< Install as service. Valid only as a command line option in Windows OS
-        , CMD_RouterService     = NESystemService::eServiceOption::CMD_Service      //!< Start router as a service. Valid only as a command line option in Windows OS
-        , CMD_RouterUninstall   = NESystemService::eServiceOption::CMD_Uninstall    //!< Uninstall as a service. Valid only as a command line option in Windows OS
-        , CMD_RouterVerbose     = NESystemService::eServiceOption::CMD_Verbose      //!< Display data rate information if possible. Functions only with extended features
-        , CMD_RouterPause       = NESystemService::eServiceOption::CMD_Custom       //!< Pause router.
-        , CMD_RouterRestart                                                         //!< Start / Restart router.
-        , CMD_RouterInstances                                                       //!< Display list of connected instances.
-        , CMD_RouterSilent                                                          //!< Silent mode, no data rate is displayed.
-        , CMD_RouterQuit                                                            //!< Quit router.
+          CMD_RouterUndefined   = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Undefined)  //!< Undefined command.
+        , CMD_RouterConsole     = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Console)    //!< Run as console application. Valid only as a command line option
+        , CMD_RouterPrintHelp   = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Help)       //!< Print help.
+        , CMD_RouterLoad        = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Load)       //!< Start the service by loading initialization instructions from configuration file.
+        , CMD_RouterInstall     = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Install)    //!< Install as service. Valid only as a command line option in Windows OS
+        , CMD_RouterService     = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Service)    //!< Start router as a service. Valid only as a command line option in Windows OS
+        , CMD_RouterUninstall   = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Uninstall)  //!< Uninstall as a service. Valid only as a command line option in Windows OS
+        , CMD_RouterVerbose     = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Verbose)    //!< Display data rate information if possible. Functions only with extended features
+        , CMD_RouterPause       = static_cast<int32_t>(NESystemService::eServiceOption::CMD_Custom)     //!< Pause router.
+        , CMD_RouterRestart                                                                             //!< Start / Restart router.
+        , CMD_RouterInstances                                                                           //!< Display list of connected instances.
+        , CMD_RouterSilent                                                                              //!< Silent mode, no data rate is displayed.
+        , CMD_RouterQuit                                                                                //!< Quit router.
     };
 
     /**

--- a/framework/mcrouter/app/MulticastRouter.hpp
+++ b/framework/mcrouter/app/MulticastRouter.hpp
@@ -22,9 +22,10 @@
 #include "aregextend/service/ServiceApplicationBase.hpp"
 
 #include "areg/base/SynchObjects.hpp"
+#include "aregextend/console/OptionParser.hpp"
+#include "aregextend/service/NESystemService.hpp"
 #include "mcrouter/app/NEMulticastRouterSettings.hpp"
 #include "mcrouter/service/RouterServerService.hpp"
-#include "aregextend/console/OptionParser.hpp"
 
 #include <utility>
 
@@ -50,18 +51,19 @@ private:
      **/
     enum class eRouterOptions : int32_t
     {
-          CMD_RouterUndefined   //!< Undefined command.
-        , CMD_RouterPause       //!< Pause router.
-        , CMD_RouterRestart     //!< Restart router.
-        , CMD_RouterInstances   //!< Display list of connected instances.
-        , CMD_RouterVerbose     //!< Display data rate information if possible. Functions only with extended features
-        , CMD_RouterSilent      //!< Silent mode, no data rate is displayed.
-        , CMD_RouterPrintHelp   //!< Print help.
-        , CMD_RouterQuit        //!< Quit router.
-        , CMD_RouterConsole     //!< Run as console application. Valid only as a command line option
-        , CMD_RouterInstall     //!< Install as service. Valid only as a command line option in Windows OS
-        , CMD_RouterUninstall   //!< Uninstall as a service. Valid only as a command line option in Windows OS
-        , CMD_RouterService     //!< Start router as a service. Valid only as a command line option in Windows OS
+          CMD_RouterUndefined   = NESystemService::eServiceOption::CMD_Undefined    //!< Undefined command.
+        , CMD_RouterConsole     = NESystemService::eServiceOption::CMD_Console      //!< Run as console application. Valid only as a command line option
+        , CMD_RouterPrintHelp   = NESystemService::eServiceOption::CMD_Help         //!< Print help.
+        , CMD_RouterLoad        = NESystemService::eServiceOption::CMD_Load         //!< Start the service by loading initialization instructions from configuration file.
+        , CMD_RouterInstall     = NESystemService::eServiceOption::CMD_Install      //!< Install as service. Valid only as a command line option in Windows OS
+        , CMD_RouterService     = NESystemService::eServiceOption::CMD_Service      //!< Start router as a service. Valid only as a command line option in Windows OS
+        , CMD_RouterUninstall   = NESystemService::eServiceOption::CMD_Uninstall    //!< Uninstall as a service. Valid only as a command line option in Windows OS
+        , CMD_RouterVerbose     = NESystemService::eServiceOption::CMD_Verbose      //!< Display data rate information if possible. Functions only with extended features
+        , CMD_RouterPause       = NESystemService::eServiceOption::CMD_Custom       //!< Pause router.
+        , CMD_RouterRestart                                                         //!< Start / Restart router.
+        , CMD_RouterInstances                                                       //!< Display list of connected instances.
+        , CMD_RouterSilent                                                          //!< Silent mode, no data rate is displayed.
+        , CMD_RouterQuit                                                            //!< Quit router.
     };
 
     /**

--- a/framework/mcrouter/app/private/MulticastRouter.cpp
+++ b/framework/mcrouter/app/private/MulticastRouter.cpp
@@ -62,12 +62,13 @@ namespace
         , {"-c, --console   : Command to run mcrouter as a console application (default option). Usage: \'mcrouter --console\'"}
         , {"-h, --help      : Command to display this message on console."}
         , {"-i, --install   : Command to install mcrouter as a service. Valid only for Windows OS. Usage: \'mcrouter --install\'"}
-        , {"-l, --silent    : Command option to stop displaying data rate. Used in console application. Usage: --silent"}
+        , {"-l, --load      : Command to initialize from specified file. Used to start application. Usage: \'mcrouter --load=<path-to-init-file>\'"}
         , {"-n, --instances : Command option to display list of connected instances. Used in console application. Usage: --instances"}
         , {"-p, --pause     : Command option to pause connection. Used in console application. Usage: --pause"}
         , {"-q, --quit      : Command option to stop router and quit application. Used in console application. Usage: --quit"}
         , {"-r, --restart   : Command option to restart connection. Used in console application. Usage: --restart"}
         , {"-s, --service   : Command to run mcrouter as a system service. Usage: \'mcrouter --service\'"}
+        , {"-t, --silent    : Command option to stop displaying data rate. Used in console application. Usage: --silent"}
         , {"-u, --uninstall : Command to uninstall mcrouter as a service. Valid only for Windows OS. Usage: \'mcrouter --uninstall\'"}
         , {"-v, --verbose   : Command option to display data rate. Used in console application. Usage: --verbose"}
         , NESystemService::MSG_SEPARATOR
@@ -96,12 +97,12 @@ const OptionParser::sOptionSetup MulticastRouter::ValidOptions[ ]
       { "-c", "--console"   , static_cast<int>(eRouterOptions::CMD_RouterConsole)   , OptionParser::NO_DATA , {}, {}, {} }
     , { "-h", "--help"      , static_cast<int>(eRouterOptions::CMD_RouterPrintHelp) , OptionParser::NO_DATA , {}, {}, {} }
     , { "-i", "--install"   , static_cast<int>(eRouterOptions::CMD_RouterInstall)   , OptionParser::NO_DATA , {}, {}, {} }
-    , { "-l", "--silent"    , static_cast<int>(eRouterOptions::CMD_RouterSilent)    , OptionParser::NO_DATA , {}, {}, {} }
     , { "-n", "--instances" , static_cast<int>(eRouterOptions::CMD_RouterInstances) , OptionParser::NO_DATA , {}, {}, {} }
     , { "-p", "--pause"     , static_cast<int>(eRouterOptions::CMD_RouterPause)     , OptionParser::NO_DATA , {}, {}, {} }
     , { "-q", "--quit"      , static_cast<int>(eRouterOptions::CMD_RouterQuit)      , OptionParser::NO_DATA , {}, {}, {} }
     , { "-r", "--restart"   , static_cast<int>(eRouterOptions::CMD_RouterRestart)   , OptionParser::NO_DATA , {}, {}, {} }
     , { "-s", "--service"   , static_cast<int>(eRouterOptions::CMD_RouterService)   , OptionParser::NO_DATA , {}, {}, {} }
+    , { "-t", "--silent"    , static_cast<int>(eRouterOptions::CMD_RouterSilent)    , OptionParser::NO_DATA , {}, {}, {} }
     , { "-u", "--uninstall" , static_cast<int>(eRouterOptions::CMD_RouterUninstall) , OptionParser::NO_DATA , {}, {}, {} }
     , { "-v", "--verbose"   , static_cast<int>(eRouterOptions::CMD_RouterVerbose)   , OptionParser::NO_DATA , {}, {}, {} }
 };
@@ -325,10 +326,11 @@ bool MulticastRouter::_checkCommand(const String& cmd)
                 quit = true;
                 break;
 
-            case MulticastRouter::eRouterOptions::CMD_RouterConsole:     // pass through
-            case MulticastRouter::eRouterOptions::CMD_RouterInstall:     // pass through
-            case MulticastRouter::eRouterOptions::CMD_RouterUninstall:   // pass through
-            case MulticastRouter::eRouterOptions::CMD_RouterService:
+            case MulticastRouter::eRouterOptions::CMD_RouterConsole:    // pass through
+            case MulticastRouter::eRouterOptions::CMD_RouterInstall:    // pass through
+            case MulticastRouter::eRouterOptions::CMD_RouterUninstall:  // pass through
+            case MulticastRouter::eRouterOptions::CMD_RouterService:    // pass through
+            case MulticastRouter::eRouterOptions::CMD_RouterLoad:
                 MulticastRouter::_outputInfo("This command should be used in command line ...");
                 break;
 


### PR DESCRIPTION
Added an option to load config file from command line. The path to the config file can be relative or full path.
This give flexibility to load config file in any location, not just the hardcoded file path. 
Also, fixed bug when parsing a command line.
Fixed bug when was created `areglogger` -- the `.def` file was not properly set in MS Visual Studio.