### PR TITLE
418 documentation to use areg sdk cmake functions and macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ endif()
 include("${AREG_CMAKE_CONFIG_DIR}/conf/cmake/areg.cmake")
 ```
 
-This either finds or fetches the AREG SDK components from `master` branch. See the **[CMake Integration Guide](./docs/wiki/CMAKE-INTEGRATE.md)** for more details.
+This either finds or fetches the AREG SDK components from `master` branch. See the **[CMake Integration Guide](./docs/wiki/cmake-integrate.md)** for more details.
 
 #### 2. Integrate as a project submodule
 

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -46,20 +46,20 @@ endmacro(macro_check_fix_areg_cxx_standard)
 # Description : Configures the compiler and linker options for executable applications.
 #               Automatically links the AREG library, along with any additional libraries specified.
 # Function ...: setAppOptions
-# Parameters .: ${item}         -- The name of the executable to apply options to.
+# Parameters .: ${target_name}  -- The name of the executable to apply options to.
 #               ${library_list} -- The list of additional libraries to link with the executable.
 # Usage ......: setAppOptions(<name of executable> <list of libraries>)
 # ---------------------------------------------------------------------------
-function(setAppOptions item library_list)
+function(setAppOptions target_name library_list)
 
     # Set common compile definitions for the executable
-    target_compile_definitions(${item} PRIVATE ${COMMON_COMPILE_DEF})
+    target_compile_definitions(${target_name} PRIVATE ${COMMON_COMPILE_DEF})
 
     # Apply common compiler options, such as disabling certain warnings
-    target_compile_options(${item} PRIVATE "${AREG_OPT_DISABLE_WARN_COMMON}")
+    target_compile_options(${target_name} PRIVATE "${AREG_OPT_DISABLE_WARN_COMMON}")
 
     # Link the AREG library, additional specified libraries, and any extended or extra libraries
-    target_link_libraries(${item} 
+    target_link_libraries(${target_name}
         ${AREG_PACKAGE_NAME}::aregextend   # AREG extended library
         ${library_list}                    # Custom libraries to link
         ${AREG_PACKAGE_NAME}::areg         # Core AREG library
@@ -126,25 +126,25 @@ endfunction(addExecutable)
 # Description : Configures the compiler and linker options for a static library.
 #               Automatically links the AREG library and any other specified libraries.
 # Function ...: setStaticLibOptions
-# Parameters .: ${item}         -- The name of the static library to apply options to.
+# Parameters .: ${target_name}  -- The name of the static library to apply options to.
 #               ${library_list} -- The list of libraries to link with the static library.
 # Usage ......: setStaticLibOptions(<name of static library> <list of libraries>) 
 # ---------------------------------------------------------------------------
-function(setStaticLibOptions item library_list)
+function(setStaticLibOptions target_name library_list)
 
     # Apply common compile definitions and options for static libraries
-    target_compile_definitions(${item} PRIVATE ${COMMON_COMPILE_DEF} _LIB)
-    target_compile_options(${item} PRIVATE ${AREG_COMPILER_VERSION})
-    target_compile_options(${item} PRIVATE "${AREG_OPT_DISABLE_WARN_COMMON}")
+    target_compile_definitions(${target_name} PRIVATE ${COMMON_COMPILE_DEF} _LIB)
+    target_compile_options(${target_name} PRIVATE ${AREG_COMPILER_VERSION})
+    target_compile_options(${target_name} PRIVATE "${AREG_OPT_DISABLE_WARN_COMMON}")
 
     # Additional compile options for non-Windows platforms
     if (NOT ${AREG_DEVELOP_ENV} MATCHES "Win32")
-        target_compile_options(${item} PRIVATE "-Bstatic")  # Ensure static linking
-        target_compile_options(${item} PRIVATE -fPIC)       # Position-independent code
+        target_compile_options(${target_name} PRIVATE "-Bstatic")  # Ensure static linking
+        target_compile_options(${target_name} PRIVATE -fPIC)       # Position-independent code
     endif()
 
     # Link the static library with the provided libraries and AREG framework
-    target_link_libraries(${item} ${library_list} ${AREG_PACKAGE_NAME}::areg ${AREG_LDFLAGS})
+    target_link_libraries(${target_name} ${library_list} ${AREG_PACKAGE_NAME}::areg ${AREG_LDFLAGS})
 
 endfunction(setStaticLibOptions)
 
@@ -231,14 +231,6 @@ function(addStaticLibEx_C target_name target_namespace source_list library_list)
 endfunction(addStaticLibEx_C)
 
 # ---------------------------------------------------------------------------
-# Description : Adds static library compiled with C-compiler, sets the sources and
-#               the options of library. The AREG library is automatically added.
-# Function ...: addStaticLib_C
-# Parameters .: ${target_name}  -- The name of the static library to build.
-#               ${source_list}  -- The list of the sources to build the static library.
-# usage ......: addStaticLib_C( <name of static library> <list of C-sources> ) 
-# ---------------------------------------------------------------------------
-# ---------------------------------------------------------------------------
 # Description : Creates a static library compiled with C-compiler,
 #               sets its source files, applies necessary options.
 #               The AREG library is automatically linked, so no need to specify it.
@@ -255,23 +247,23 @@ endfunction(addStaticLib_C)
 # Description : Configures the compiler and linker options for a shared library.
 #               Automatically links the AREG library and any other specified libraries.
 # Function ...: setSharedLibOptions
-# Parameters .: ${item}         -- The name of the shared library to apply options to.
+# Parameters .: ${target_name}  -- The name of the shared library to apply options to.
 #               ${library_list} -- The list of libraries to link with the shared library.
 # Usage ......: setSharedLibOptions(<name of shared library> <list of libraries>) 
 # ---------------------------------------------------------------------------
-function(setSharedLibOptions item library_list)
+function(setSharedLibOptions target_name library_list)
 
     # Apply common compile definitions for shared libraries
-    target_compile_definitions(${item} PRIVATE ${COMMON_COMPILE_DEF} _USRDLL)
-    target_compile_options(${item} PRIVATE "${AREG_OPT_DISABLE_WARN_COMMON}")
+    target_compile_definitions(${target_name} PRIVATE ${COMMON_COMPILE_DEF} _USRDLL)
+    target_compile_options(${target_name} PRIVATE "${AREG_OPT_DISABLE_WARN_COMMON}")
 
     # Link the shared library with provided libraries and AREG framework
-    target_link_libraries(${item} ${AREG_PACKAGE_NAME}::aregextend ${library_list} ${AREG_PACKAGE_NAME}::areg ${AREG_EXTENDED_LIBS} ${AREG_LDFLAGS})
+    target_link_libraries(${target_name} ${AREG_PACKAGE_NAME}::aregextend ${library_list} ${AREG_PACKAGE_NAME}::areg ${AREG_EXTENDED_LIBS} ${AREG_LDFLAGS})
 
     # Additional compile options for non-Windows platforms
     if (NOT ${AREG_DEVELOP_ENV} MATCHES "Win32")
-        target_compile_options(${item} PRIVATE -fPIC)       # Position-independent code for shared libraries
-        target_compile_options(${item} PRIVATE "-Bdynamic") # Ensure dynamic linking
+        target_compile_options(${target_name} PRIVATE -fPIC)       # Position-independent code for shared libraries
+        target_compile_options(${target_name} PRIVATE "-Bdynamic") # Ensure dynamic linking
     endif()
 
 endfunction(setSharedLibOptions)
@@ -666,8 +658,8 @@ endmacro(macro_declare_static_library)
 #               ${ARGN}      -- The list of source files, libraries, and resource files.
 #                               The files can be specified with full or relative paths.
 #
-# Usage ......: macro_declare_static_library(<lib_name> <list_of_sources_libraries_and_resources>)
-#               Example: macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
+# Usage ......: macro_declare_shared_library(<lib_name> <list_of_sources_libraries_and_resources>)
+#               Example: macro_declare_shared_library(mySharedLib src/main.cpp src/resource.rc libSomeDependency)
 # ---------------------------------------------------------------------------
 macro(macro_declare_shared_library lib_name)
 
@@ -711,12 +703,12 @@ endmacro(macro_declare_shared_library)
 #               - On Windows, resource files (*.rc) are set to use the RC language automatically.
 # 
 # Macro ......: macro_declare_executable
-# Parameters  : ${lib_name}  -- The name of the executable to be declared.
+# Parameters  : ${exe_name}  -- The name of the executable to be declared.
 #               ${ARGN}      -- The list of source files, libraries, and resource files.
 #                               The files can be specified with full or relative paths.
 #
-# Usage ......: macro_declare_static_library(<lib_name> <list_of_sources_libraries_and_resources>)
-#               Example: macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
+# Usage ......: macro_declare_executable(<lib_name> <list_of_sources_libraries_and_resources>)
+#               Example: macro_declare_executable(myApplication src/main.cpp src/resource.rc libSomeDependency)
 # ---------------------------------------------------------------------------
 macro(macro_declare_executable exe_name)
 
@@ -761,19 +753,19 @@ endmacro(macro_declare_executable)
 #               - ${compiler_short}  -- Output: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
 #               - ${compiler_cxx}    -- Output: Variable to hold the C++ compiler path (usually same as ${compiler_path}).
 #               - ${compiler_c}      -- Output: Variable to hold the corresponding C compiler name or path.
-#               - ${compiler_found}  -- Output: Boolean flag indicating if the compiler was successfully identified ("TRUE" or "FALSE").
+#               - ${compiler_supports}  -- Output: Boolean flag indicating if the compiler was successfully identified ("TRUE" or "FALSE").
 #
 # Usage ......: macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" 
 #                                           AREG_COMPILER_FAMILY 
 #                                           AREG_COMPILER_SHORT 
 #                                           AREG_CXX_COMPILER 
 #                                           AREG_C_COMPILER 
-#                                           _compiler_found
+#                                           _compiler_supports
 #                                         )
 # ---------------------------------------------------------------------------
-macro(macro_setup_compilers_data compiler_path compiler_family compiler_short compiler_cxx compiler_c compiler_found)
+macro(macro_setup_compilers_data compiler_path compiler_family compiler_short compiler_cxx compiler_c compiler_supports)
 
-    set(${compiler_found} FALSE)
+    set(${compiler_supports} FALSE)
     
     # Iterate over known compilers to identify the compiler type
     foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "c++;gnu;cc" "cc;gnu;cc" "cl;msvc;cl")
@@ -802,7 +794,7 @@ macro(macro_setup_compilers_data compiler_path compiler_family compiler_short co
             endif()
 
             # Mark compiler as found
-            set(${compiler_found} TRUE)
+            set(${compiler_supports} TRUE)
 
             # break the loop, we have found
             break()
@@ -827,18 +819,18 @@ endmacro(macro_setup_compilers_data)
 #               - ${compiler_short}  -- Output: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
 #               - ${compiler_cxx}    -- Output: Variable to hold the C++ compiler name.
 #               - ${compiler_c}      -- Output: Variable to hold the corresponding C compiler name.
-#               - ${compiler_found}  -- Output: Boolean flag indicating whether the compiler was successfully identified ("TRUE" or "FALSE").
+#               - ${compiler_supports}  -- Output: Boolean flag indicating whether the compiler was successfully identified ("TRUE" or "FALSE").
 #
 # Usage ......: macro_setup_compilers_data_by_family("gnu"
 #                                                    AREG_COMPILER_SHORT 
 #                                                    AREG_CXX_COMPILER 
 #                                                    AREG_C_COMPILER 
-#                                                    _compiler_found
+#                                                    _compiler_supports
 #                                                   )
 # ---------------------------------------------------------------------------
-macro(macro_setup_compilers_data_by_family compiler_family compiler_short compiler_cxx compiler_c compiler_found)
+macro(macro_setup_compilers_data_by_family compiler_family compiler_short compiler_cxx compiler_c compiler_supports)
 
-    set(${compiler_found} FALSE)
+    set(${compiler_supports} FALSE)
     
     # Iterate over known compilers and match the family
     foreach(_entry "clang++;llvm;clang" "g++;gnu;gcc" "cl;msvc;cl" "g++;cygwin;gcc")
@@ -859,7 +851,7 @@ macro(macro_setup_compilers_data_by_family compiler_family compiler_short compil
             endif()
 
             # Mark compiler as found
-            set(${compiler_found} TRUE)
+            set(${compiler_supports} TRUE)
 
             # break the loop, we have found
             break()

--- a/conf/cmake/functions.cmake
+++ b/conf/cmake/functions.cmake
@@ -4,11 +4,10 @@
 # ###########################################################################
 
 # ---------------------------------------------------------------------------
-# Description : Checks and sets the C++ standard for the project.
-#               The variable 'AREG_CXX_STANDARD' must be defined before calling this macro.
-#               If 'CMAKE_CXX_STANDARD' is not set, it will be assigned the value of 'AREG_CXX_STANDARD'.
-#               If 'CMAKE_CXX_STANDARD' is lower than 'AREG_CXX_STANDARD', a warning is displayed.
 # Macro    ...: macro_check_fix_areg_cxx_standard
+# Purpose ....: Validates and sets C++ standard compatibility.
+#               The variable 'AREG_CXX_STANDARD' must be defined before calling this macro.
+# Details ....: Ensures `CMAKE_CXX_STANDARD` matches `AREG_CXX_STANDARD`. If incompatible, outputs a warning.
 # Usage ......: macro_check_fix_areg_cxx_standard()
 # ---------------------------------------------------------------------------
 macro(macro_check_fix_areg_cxx_standard)
@@ -43,12 +42,245 @@ macro(macro_check_fix_areg_cxx_standard)
 endmacro(macro_check_fix_areg_cxx_standard)
 
 # ---------------------------------------------------------------------------
-# Description : Configures the compiler and linker options for executable applications.
-#               Automatically links the AREG library, along with any additional libraries specified.
+# Macro ......: macro_normalize_path
+# Purpose ....:  Normalizes Windows paths to Cygwin format if applicable.
+# Note .......: This macro does not address OS-specific path separator issues.
+# Parameters .: ${normal_path} [out] -- Name of variable to hold normalized path.
+#               ${os_path}     [in]  -- The Windows-specific path to normalize.
+# Usage ......: macro_normalize_path(<out-var> <windows-path>)
+# ---------------------------------------------------------------------------
+macro(macro_normalize_path normal_path os_path)
+    if (CYGWIN)
+        execute_process(COMMAND cygpath.exe -m "${os_path}" OUTPUT_VARIABLE _normalized_path OUTPUT_STRIP_TRAILING_WHITESPACE)
+        set(${normal_path} "${_normalized_path}")
+    else()
+        set(${normal_path} "${os_path}")
+    endif()
+endmacro(macro_normalize_path)
+
+# ---------------------------------------------------------------------------
+# Macro ......: macro_find_package
+# Purpose ....: Finds a package and returns paths to its includes and libraries if found.
+# Parameters .: ${package_name}      [in]   -- Name of the package to search for.
+#               ${package_found}     [out]  -- Name of variable indicating if the package was found.
+#               ${package_includes}  [out]  -- Variable holding the package's include directories.3
+#               ${package_libraries} [out]  -- Variable holding the package's libraries.
+# Usage ......: macro_find_package(<package-name> <found-flag-var> <includes-var> <libraries-var>)
+# Example ....: 
+#   set(SQLITE_FOUND FALSE)
+#   macro_find_package(SQLite3 SQLITE_FOUND SQLITE_INCLUDE SQLITE_LIB)
+# ---------------------------------------------------------------------------
+macro(macro_find_package package_name package_found package_includes package_libraries)
+    find_package(${package_name})
+    if (${package_name}_FOUND)
+        set(${package_found} TRUE)
+        set(${package_includes}  "${${package_name}_INCLUDE_DIRS}")
+        set(${package_libraries} "${${package_name}_LIBRARIES}")
+    else()
+        set(${package_found} FALSE)
+        set(${package_includes}  "")
+        set(${package_libraries} "")
+    endif()
+endmacro(macro_find_package)
+
+# ---------------------------------------------------------------------------
+# Macro ......: macro_create_option
+# Purpose ....: Creates a boolean cache variable with a default value.
+# Parameters .: ${var_name}     [out]   -- Name of the boolean variable.
+#               ${var_value}    [in]    -- Default value if the variable is not yet defined.
+#               ${var_describe} [in]    -- Description of the variable for the CMake cache.
+# Usage ......: macro_create_option(<name-var> <default-value> <describe>)
+# Example ....: macro_create_option(AREG_LOGS ON "Compile with logs")
+# ---------------------------------------------------------------------------
+macro(macro_create_option var_name var_value var_describe)
+    if (NOT DEFINED ${var_name})
+        set(${var_name} ${var_value} CACHE BOOL "${var_describe}" FORCE)
+    else()
+        set(${var_name} ${${var_name}} CACHE BOOL "${var_describe}" FORCE)
+    endif()
+endmacro(macro_create_option)
+
+# ---------------------------------------------------------------------------
+# Macro ......: macro_add_source
+# Purpose ....: Adds existing source files to a list based on a base directory. Checks file existence.
+# Parameters .: ${result_list}  -- Name of variable that on output will contain the list of source files.
+#               ${src_base_dir} -- Base directory of the source files.
+#               ${ARGN}         -- List of source files, relative to the base directory.
+# Usage ......: macro_add_source(<src-list-var> <base-dirpath> <files>)
+# Example ....: 
+#       set(aregextend_SRC)
+#       macro_add_source(aregextend_SRC "${AREG_FRAMEWORK}" aregextend/db/private/LogSqliteDatabase.cpp ...)
+# ---------------------------------------------------------------------------
+macro(macro_add_source result_list src_base_dir)
+    set(_list "${ARGN}")
+    foreach(_item IN LISTS _list)
+        set(_src "${src_base_dir}/${_item}")
+        if (EXISTS "${_src}")
+            list(APPEND ${result_list} "${_src}")
+        else()
+            message(FATAL_ERROR "AREG: >>> The item '${_item}' does not exist in '${src_base_dir}'")
+        endif()
+    endforeach()
+    unset(_list)
+endmacro(macro_add_source)
+
+# ---------------------------------------------------------------------------
+# Macro ......: macro_parse_arguments
+# Purpose ....: Parses files and libraries into separate lists for sources,
+#               libraries, and resources. Library names must match known targets.
+#               Resource files should have `.rc` extension (Windows-specific).
+#
+# Note .......: - Throws an error if file does not exist.
+#               - List of resource files is Windows specific, it contains files with extension .rc.
+#
+# Parameters .: ${res_sources}   [out]  -- Name of variable that on output will contain the list of source files.
+#               ${res_libs}      [out]  -- Name of variable that on output will contain the list of recognized CMake targets.
+#               ${res_resources} [out]  -- Name of variable that on output will contain the List of resource files ('*.rc')
+#               ${ARGN}          [in]   -- List of files, libraries, or resources to categorize.
+#
+# Usage ......: macro_parse_arguments(<sources-var> <libs-var> <resources-var> <sources-targets-resources>)
+# Example ....: macro_parse_arguments(src_files lib_targets res_files my_lib src/main.cpp src/object.cpp res/resource.rc)
+# ---------------------------------------------------------------------------
+macro(macro_parse_arguments res_sources res_libs res_resources)
+    set(_list "${ARGN}")
+    foreach(_item IN LISTS _list)
+        # Determine full path if file exists in the current directory
+        set(_full_path "${_item}")
+        if (NOT EXISTS "${_full_path}" AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/${_item}")
+            set(_full_path "${CMAKE_CURRENT_LIST_DIR}/${_item}")
+        endif()
+
+        # Add to appropriate lists
+        if (TARGET ${_item})
+            list(APPEND ${res_libs} ${_item})
+        elseif (EXISTS "${_full_path}")
+            list(APPEND ${res_sources} "${_full_path}")
+            # Check for resource file extension
+            cmake_path(GET _full_path EXTENSION _ext)
+            if (_ext STREQUAL "rc")
+                list(APPEND ${res_resources} "${_full_path}")
+            endif()
+        else()
+            message(FATAL_ERROR "AREG: >>> File \'${_item}\' does not exist, stopping.")
+        endif()
+    endforeach()
+endmacro(macro_parse_arguments)
+
+# ---------------------------------------------------------------------------
+# Macro ......: macro_setup_compilers_data
+# Purpose ....: Identifies and configures compiler family, short names, and paths.
+# Note .......: Beside "gnu", "llvm", "msvc", the GNU compilers for CYGWIN are included as a "cygwin" family.
+# Parameters .: - ${compiler_path}   -- Input:  Path to the C++ compiler.
+#               - ${compiler_family} -- Output: Name of variable to hold compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
+#               - ${compiler_short}  -- Output: Name of variable to hold short name of the compiler (e.g., "gcc", "clang", "cl").
+#               - ${compiler_cxx}    -- Output: Name of variable to hold the C++ compiler path (usually same as ${compiler_path}).
+#               - ${compiler_c}      -- Output: Name of variable to hold the corresponding C compiler name or path.
+#               - ${is_identified}   -- Output: Name of variable to hold Boolean indicating successful identification.
+# Usage ......: macro_setup_compilers_data(<compiler> <family-var> <short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)
+# Example ....: macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" 
+#                                           AREG_COMPILER_FAMILY 
+#                                           AREG_COMPILER_SHORT 
+#                                           AREG_CXX_COMPILER 
+#                                           AREG_C_COMPILER 
+#                                           _compiler_supports
+#                                         )
+# ---------------------------------------------------------------------------
+macro(macro_setup_compilers_data compiler_path compiler_family compiler_short compiler_cxx compiler_c is_identified)
+
+    set(${is_identified} FALSE)
+    
+    # Iterate over known compilers to identify the compiler type
+    foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "c++;gnu;cc" "cc;gnu;cc" "cl;msvc;cl")
+        list(GET _entry 0 _cxx_compiler)
+        list(GET _entry 1 _family)
+        list(GET _entry 2 _c_compiler)
+
+        # Check if the provided compiler matches the known C++ compiler
+        string(FIND "${compiler_path}" "${_cxx_compiler}" _found_pos REVERSE)
+        if (_found_pos GREATER -1)
+            # Handle special case for CYGWIN and GNU family compilers
+            if (CYGWIN AND ("${_family}" STREQUAL "gnu"))
+                set(${compiler_family} "cygwin")
+            else()
+                set(${compiler_family} "${_family}")
+            endif()
+
+            set(${compiler_short} "${_cxx_compiler}")
+            set(${compiler_cxx}   "${compiler_path}")
+
+            # Determine the corresponding C compiler path or name
+            if ("${_cxx_compiler}" STREQUAL "${_c_compiler}")
+                set(${compiler_c} "${compiler_path}")
+            else()
+                string(REPLACE "${_cxx_compiler}" "${_c_compiler}" ${compiler_c} "${compiler_path}")
+            endif()
+
+            # Mark compiler as found
+            set(${is_identified} TRUE)
+
+            # break the loop, we have found
+            break()
+        endif()
+    endforeach()
+
+endmacro(macro_setup_compilers_data)
+
+# ---------------------------------------------------------------------------
+# Macro ......: macro_setup_compilers_data_by_family
+# Purpose ....: Configures compiler names based on family (e.g., gnu, msvc, llvm, cygwin).
+# Note .......: The "cygwin" family is supported for GNU compilers on the CYGWIN platform in Windows.
+# Parameters .: - ${compiler_family} -- Input: Compiler family  name (e.g., "gnu", "msvc").
+#               - ${compiler_short}  -- Output: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
+#               - ${compiler_cxx}    -- Output: Variable to hold the C++ compiler name.
+#               - ${compiler_c}      -- Output: Variable to hold the corresponding C compiler name.
+#               - ${is_identified}   -- Output: Name of variable to hold Boolean indicating successful identification..
+# Usage ......: macro_setup_compilers_data(<compiler> <family-var> <short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)
+# Example ....: macro_setup_compilers_data_by_family("gnu"
+#                                                    AREG_COMPILER_SHORT 
+#                                                    AREG_CXX_COMPILER 
+#                                                    AREG_C_COMPILER 
+#                                                    _compiler_supports
+#                                                   )
+# ---------------------------------------------------------------------------
+macro(macro_setup_compilers_data_by_family compiler_family compiler_short compiler_cxx compiler_c is_identified)
+
+    set(${is_identified} FALSE)
+    
+    # Iterate over known compilers and match the family
+    foreach(_entry "clang++;llvm;clang" "g++;gnu;gcc" "cl;msvc;cl" "g++;cygwin;gcc")
+        list(GET _entry 0 _compiler)
+        list(GET _entry 1 _family)
+        list(GET _entry 2 _c_compiler)
+
+        if ("${_family}" STREQUAL "${compiler_family}")
+            # Special case for Windows
+            if (WIN32 AND "${_family}" STREQUAL "llvm")
+                set(${compiler_short} "clang-cl")
+                set(${compiler_cxx}   "clang-cl")
+                set(${compiler_c}     "clang-cl")
+            else()
+                set(${compiler_short} "${_compiler}")
+                set(${compiler_cxx}   "${_compiler}")
+                set(${compiler_c}     "${_c_compiler}")
+            endif()
+
+            # Mark compiler as found
+            set(${is_identified} TRUE)
+
+            # break the loop, we have found
+            break()
+        endif()
+    endforeach()
+
+endmacro(macro_setup_compilers_data_by_family)
+
+# ---------------------------------------------------------------------------
 # Function ...: setAppOptions
-# Parameters .: ${target_name}  -- The name of the executable to apply options to.
-#               ${library_list} -- The list of additional libraries to link with the executable.
-# Usage ......: setAppOptions(<name of executable> <list of libraries>)
+# Purpose ....: Configures the compiler and linker options for executable applications.
+#               Automatically links the AREG library, along with any additional libraries specified.
+# Parameters .: ${target_name}  -- Name of the executable to apply options to.
+#               ${library_list} -- List of additional libraries to link.
+# Usage ......: setAppOptions(<target-name> <library-list>)
 # ---------------------------------------------------------------------------
 function(setAppOptions target_name library_list)
 
@@ -70,15 +302,15 @@ function(setAppOptions target_name library_list)
 endfunction(setAppOptions)
 
 # ---------------------------------------------------------------------------
-# Description : Creates an executable, sets its source files, applies necessary options, 
+# Purpose ....: Creates an executable, sets its source files, applies necessary options, 
 #               and links it with the provided list of libraries. 
-#               The AREG library is automatically linked, so no need to specify it.
+#               The AREG library is automatically linked, no need to specify it.
 # Function ...: addExecutableEx
-# Parameters .: ${target_name}      -- The name of the executable to build.
-#               ${target_namespace} -- The namespace of the executable, used for aliasing (optional).
-#               ${source_list}      -- The list of source files used to build the executable.
-#               ${library_list}     -- The list of libraries to link with the executable.
-# Usage ......: addExecutableEx(<name of executable> <namespace (optional)> <list of sources> <list of libraries>)
+# Parameters .: ${target_name}      -- The name of the executable target.
+#               ${target_namespace} -- Namespace for aliasing. Can be empty.
+#               ${source_list}      -- List of source files used to build the target executable.
+#               ${library_list}     -- Libraries to link with the executable.
+# Usage ......: addExecutableEx(<target-name> <namespace-opt> <source-list> <library-list>)
 # ---------------------------------------------------------------------------
 function(addExecutableEx target_name target_namespace source_list library_list)
 
@@ -110,12 +342,12 @@ function(addExecutableEx target_name target_namespace source_list library_list)
 endfunction(addExecutableEx)
 
 # ---------------------------------------------------------------------------
-# Description : Creates an executable, sets its source files, applies necessary options. 
-#               The AREG library is automatically linked, so no need to specify it.
 # Function ...: addExecutable
-# Parameters .: ${target_name}      -- The name of the executable to build.
-#               ${source_list}      -- The list of source files used to build the executable.
-# Usage ......: addExecutable(<name of executable> <list of sources>)
+# Purpose ....: Wrapper for addExecutableEx, assuming there is not list of libraries to link with.
+#               The AREG library is automatically linked, no need to specify it.
+# Parameters .: ${target_name}      -- Name of the executable to build.
+#               ${source_list}      -- List of source files used to build the executable.
+# Usage ......: addExecutable(<target-name> <source-list>)
 # ---------------------------------------------------------------------------
 function(addExecutable target_name source_list)
     addExecutableEx(${target_name} "" "${source_list}" "")
@@ -123,12 +355,13 @@ endfunction(addExecutable)
 
 
 # ---------------------------------------------------------------------------
-# Description : Configures the compiler and linker options for a static library.
-#               Automatically links the AREG library and any other specified libraries.
 # Function ...: setStaticLibOptions
-# Parameters .: ${target_name}  -- The name of the static library to apply options to.
-#               ${library_list} -- The list of libraries to link with the static library.
-# Usage ......: setStaticLibOptions(<name of static library> <list of libraries>) 
+# Purpose ....: Configures compiler and linker settings for a static library,
+#               automatically linking the AREG Framework library along with any 
+#               additional specified libraries
+# Parameters .: ${target_name}  -- Name of the static library to apply options to.
+#               ${library_list} -- List of libraries to link with the static library.
+# Usage ......: setStaticLibOptions(<target-name> <library-list>)
 # ---------------------------------------------------------------------------
 function(setStaticLibOptions target_name library_list)
 
@@ -149,15 +382,15 @@ function(setStaticLibOptions target_name library_list)
 endfunction(setStaticLibOptions)
 
 # ---------------------------------------------------------------------------
-# Description : Creates a static library, sets its source files, applies necessary options, 
-#               and links it with the provided list of libraries.
-#               The AREG library is automatically linked, so no need to specify it.
 # Function ...: addStaticLibEx
-# Parameters .: ${target_name}      -- The name of the static library to build.
-#               ${target_namespace} -- The namespace of the static library (optional for aliasing).
-#               ${source_list}      -- The list of source files used to build the static library.
-#               ${library_list}     -- The list of libraries to link with the static library.
-# Usage ......: addStaticLibEx(<name of static library> <namespace (optional)> <list of sources> <list of libraries>)
+# Purpose ....: Creates a static library with specified source files and options,
+#               importing and auto-linking the AREG Framework library along with
+#               any additional libraries.
+# Parameters .: ${target_name}      -- Name of the static library to build.
+#               ${target_namespace} -- Namespace for aliasing. Can be empty string if no aliasing.
+#               ${source_list}      -- List of source files to build the static library.
+#               ${library_list}     -- List of libraries to link.
+# Usage ......: addStaticLibEx(<target-name> <namespace-opt> <source-list> <library-list>)
 # ---------------------------------------------------------------------------
 function(addStaticLibEx target_name target_namespace source_list library_list)
 
@@ -184,28 +417,28 @@ function(addStaticLibEx target_name target_namespace source_list library_list)
 endfunction(addStaticLibEx)
 
 # ---------------------------------------------------------------------------
-# Description : Creates a static library, sets its source files, applies necessary options.
-#               The AREG library is automatically linked, so no need to specify it.
 # Function ...: addStaticLib
-# Parameters .: ${target_name}      -- The name of the static library to build.
-#               ${source_list}      -- The list of source files used to build the static library.
-# Usage ......: addStaticLib(<name of static library> <list of sources>)
+# Purpose ....: Wrapper of addStaticLibEx, assuming there is no list of libraries to link.
+#               Creates a static library, setting sources and options, importing, 
+#               and auto-linking the AREG Framework library.
+# Parameters .: ${target_name}      -- Name of the static library to build.
+#               ${source_list}      -- List of source files to build the static library.
+# Usage ......: addStaticLib(<target-name> <source-list>)
 # ---------------------------------------------------------------------------
 function(addStaticLib target_name source_list)
     addStaticLibEx(${target_name} "" "${source_list}" "")
 endfunction(addStaticLib)
 
 # ---------------------------------------------------------------------------
-# Description : Creates a static library compiled with C-compiler,
-#               sets its source files, applies necessary options, and links it
-#               with the provided list of libraries.
-#               The AREG library is automatically linked, so no need to specify it.
 # Function ...: addStaticLibEx_C
-# Parameters .: ${target_name}      -- The name of the static library to build.
-#               ${target_namespace} -- The namespace of the static library (optional for aliasing).
-#               ${source_list}      -- The list of C-code source files used to build the static library.
-#               ${library_list}     -- The list of libraries to link with the static library.
-# Usage ......: addStaticLibEx_C(<name of static library> <namespace (optional)> <list of C-code sources> <list of libraries>)
+# Purpose ....: Creates a static library compiled with C, setting sources, 
+#               importing, and auto-linking the AREG Framework library along 
+#               with any additional libraries.
+# Parameters .: ${target_name}      -- Name of the static library to build.
+#               ${target_namespace} -- Namespace for aliasing. Pass empty string if no aliasing.
+#               ${source_list}      -- List of C-source files to build the static library.
+#               ${library_list}     -- Libraries to link with the static library.
+# Usage ......: addStaticLibEx_C(<target-name> <namespace-opt> <C-source-list> <library-list>)
 # ---------------------------------------------------------------------------
 function(addStaticLibEx_C target_name target_namespace source_list library_list)
     set(exList "${ARGN}")
@@ -231,25 +464,25 @@ function(addStaticLibEx_C target_name target_namespace source_list library_list)
 endfunction(addStaticLibEx_C)
 
 # ---------------------------------------------------------------------------
-# Description : Creates a static library compiled with C-compiler,
-#               sets its source files, applies necessary options.
-#               The AREG library is automatically linked, so no need to specify it.
 # Function ...: addStaticLib_C
-# Parameters .: ${target_name}      -- The name of the static library to build.
-#               ${source_list}      -- The list of C-code source files used to build the static library.
-# Usage ......: addStaticLib_C(<name of static library> <list of C-code sources>)
+# Purpose ....: Wrapper for addStaticLibEx_C, assuming there is no aliasing and 
+#               list of libraries for linking. Creates a static library compiled with C,
+#               setting sources, importing, and auto-linking the AREG Framework library.
+# Parameters .: ${target_name}      -- Name of the static library to build.
+#               ${source_list}      -- List of C-source files to build the static library.
+# Usage ......: addStaticLib_C(<target-name> <C-source-list>)
 # ---------------------------------------------------------------------------
 function(addStaticLib_C target_name source_list)
     addStaticLibEx_C(${target_name} "" "${source_list}" "")
 endfunction(addStaticLib_C)
 
 # ---------------------------------------------------------------------------
-# Description : Configures the compiler and linker options for a shared library.
-#               Automatically links the AREG library and any other specified libraries.
 # Function ...: setSharedLibOptions
-# Parameters .: ${target_name}  -- The name of the shared library to apply options to.
-#               ${library_list} -- The list of libraries to link with the shared library.
-# Usage ......: setSharedLibOptions(<name of shared library> <list of libraries>) 
+# Purpose ....: Configures settings for a shared library, automatically linking
+#               the AREG Framework library and any additional specified libraries.
+# Parameters .: ${target_name}  -- Name of the shared library to apply options to.
+#               ${library_list} -- List of libraries for linking.
+# Usage ......: setSharedLibOptions(<target-name> <library-list>)
 # ---------------------------------------------------------------------------
 function(setSharedLibOptions target_name library_list)
 
@@ -269,15 +502,15 @@ function(setSharedLibOptions target_name library_list)
 endfunction(setSharedLibOptions)
 
 # ---------------------------------------------------------------------------
-# Description : Creates a shared library, sets its source files, applies necessary options, 
-#               and links it with the provided list of libraries.
-#               The AREG library is automatically linked, so no need to specify it.
 # Function ...: addSharedLibEx
-# Parameters .: ${target_name}      -- The name of the shared library to build.
-#               ${target_namespace} -- The namespace of the shared library (optional for aliasing).
-#               ${source_list}      -- The list of source files used to build the shared library.
-#               ${library_list}     -- The list of libraries to link with the shared library.
-# Usage ......: addSharedLibEx(<name of shared library> <namespace (optional)> <list of sources> <list of libraries>)
+# Purpose ....: Creates a shared library with specified source files and options,
+#               importing and auto-linking the AREG Framework library along with
+#               any additional libraries.
+# Parameters .: ${target_name}      -- Name of the shared library to build.
+#               ${target_namespace} -- Namespace for aliasing. Can be empty string if no aliasing.
+#               ${source_list}      -- List of source files to build the shared library.
+#               ${library_list}     -- Libraries for linking.
+# Usage ......: addSharedLibEx(<target-name> <namespace-opt> <source-list> <library-list>)
 # ---------------------------------------------------------------------------
 function(addSharedLibEx target_name target_namespace source_list library_list)
 
@@ -304,61 +537,34 @@ function(addSharedLibEx target_name target_namespace source_list library_list)
 endfunction(addSharedLibEx)
 
 # ---------------------------------------------------------------------------
-# Description : Creates a shared library, sets its source files, applies necessary options.
-#               The AREG library is automatically linked, so no need to specify it.
 # Function ...: addSharedLib
-# Parameters .: ${target_name}      -- The name of the shared library to build.
-#               ${source_list}      -- The list of source files used to build the shared library.
-# Usage ......: addSharedLib(<name of shared library> <list of sources>)
+# Purpose ....: Wrapper for addSharedLibEx, assuming there is no aliasing and no list for linking.
+#               Creates a shared library with specified sources, options, imports,
+#               and auto-linking the AREG Framework library.
+# Parameters .: ${target_name}      -- Name of the shared library to build.
+#               ${source_list}      -- List of source files to build the shared library.
+# Usage ......: addSharedLib(<target-name> <source-list>)
 # ---------------------------------------------------------------------------
 function(addSharedLib target_name target_source_list)
     addSharedLibEx(${target_name} "" "${target_source_list}" "")
 endfunction(addSharedLib)
 
 # ---------------------------------------------------------------------------
-# Description : Converts Windows-specific paths to Cygwin format if running under Cygwin.
-#               Otherwise, the path remains unchanged.
-# Note .......: This macro does not address OS-specific path separator issues.
-# Parameters .: ${normal_path} -- The normalized path (output).
-#               ${os_path}     -- The OS-specific path to normalize.
-# Macro ......: macro_normalize_path
-# Usage ......: macro_normalize_path(<result_variable> <OS specific path>)
-# ---------------------------------------------------------------------------
-macro(macro_normalize_path normal_path os_path)
-    if (CYGWIN)
-        execute_process(COMMAND cygpath.exe -m "${os_path}" OUTPUT_VARIABLE _normalized_path OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(${normal_path} "${_normalized_path}")
-    else()
-        set(${normal_path} "${os_path}")
-    endif()
-endmacro(macro_normalize_path)
-
-# ---------------------------------------------------------------------------
-# Description : This function invokes the service interface code generator 
-#               to produce source files and either adds them to a new static 
-#               library (if it doesn't exist) or includes them in an existing 
-#               one. It accepts the static library name, full paths to 
-#               Service Interface file, Service Interface name and paths for generated files.
-#               The service interface name must match the file name (without the .siml extension).
-#               
-#               Example: 
-#               For a project 'fun_library' with 'HelloWorld.siml' and 'WeHaveFun.siml' interfaces, 
-#               calling macro_add_service_interface("fun_library" ... HelloWorld ...) generates 
-#               source files for HelloWorld and includes them in the static library. 
-#               A subsequent call for WeHaveFun adds it to the same library.
-# 
 # Macro ......: macro_add_service_interface
+# Purpose ....: Generates and adds service-specific files to a static library
+#               based on a given Service Interface document ('*.siml').
 # Parameters .: ${lib_name}         -- Name of the static library.
-#               ${interface_doc}    -- Full path to the Service Interface document file. 
-#               ${interface_name}   -- Name of the Service Interface (without '.siml').
-#               ${codegen_root}     -- Root directory for generating files.
+#               ${interface_doc}    -- Full path to the Service Interface document file ('.siml').
+#               ${codegen_root}     -- Root directory for file generation.
 #               ${output_path}      -- Relative path for generated files.
 #               ${codegen_tool}     -- Full path to the code generator tool.
 # 
-# Usage ......: macro_add_service_interface(<library name> <documend dir><interface name>.siml <interface name> <codegen root> <sub-path> <codegen tool>)
-# Example ....: macro_add_service_interface("fun_library" "~/project/my-fun/sources/service/interfaces/FunInterface.siml" FunInterface "~/project/my-fun/" "generate/service/interfaces" /tools/areg/codegen.jar)
+# Usage ......: macro_add_service_interface(<name-lib> <full-path-siml> <root-gen> <relative-path> <codegen-tool>)
+# Example ....: 
+#   macro_add_service_interface(funlib "/home/dev/fun/src/service/HelloWorld.siml" "/home/dev/fun/product" "generate/service" /tools/areg/codegen.jar)
+#   macro_add_service_interface(funlib "/home/dev/fun/src/service/WeHaveFun.siml"  "/home/dev/fun/product" "generate/service" /tools/areg/codegen.jar)
 # ---------------------------------------------------------------------------
-macro(macro_add_service_interface lib_name interface_doc interface_name codegen_root output_path codegen_tool)
+macro(macro_add_service_interface lib_name interface_doc codegen_root output_path codegen_tool)
 
     if (NOT ${Java_FOUND})
         message(FATAL_ERROR "AREG Setup: Java not found! Install Java 17 or higher to run the code generator.")
@@ -370,19 +576,25 @@ macro(macro_add_service_interface lib_name interface_doc interface_name codegen_
 
     # Set path for generated files
     set(_generate "${codegen_root}/${output_path}")
+    set(_interface_name "")
+    cmake_path(GET interface_doc STEM _interface_name)
+    if ("${_interface_name}" STREQUAL "")
+        message(FATAL_ERROR "AREG Setup: The path \'${interface_doc}\' has no file name. Cannot generate Service Interface files.")
+        return()
+    endif()
     
     # List of generated source and header files
     list(APPEND _sources
-        ${_generate}/private/${interface_name}ClientBase.cpp
-        ${_generate}/private/${interface_name}Events.cpp
-        ${_generate}/private/${interface_name}Proxy.cpp
-        ${_generate}/private/${interface_name}Stub.cpp
-        ${_generate}/private/NE${interface_name}.cpp
-        ${_generate}/private/${interface_name}Events.hpp
-        ${_generate}/private/${interface_name}Proxy.hpp
-        ${_generate}/${interface_name}ClientBase.hpp
-        ${_generate}/${interface_name}Stub.hpp
-        ${_generate}/NE${interface_name}.hpp
+        ${_generate}/private/${_interface_name}ClientBase.cpp
+        ${_generate}/private/${_interface_name}Events.cpp
+        ${_generate}/private/${_interface_name}Proxy.cpp
+        ${_generate}/private/${_interface_name}Stub.cpp
+        ${_generate}/private/NE${_interface_name}.cpp
+        ${_generate}/private/${_interface_name}Events.hpp
+        ${_generate}/private/${_interface_name}Proxy.hpp
+        ${_generate}/${_interface_name}ClientBase.hpp
+        ${_generate}/${_interface_name}Stub.hpp
+        ${_generate}/NE${_interface_name}.hpp
     )
 
     # Add generated files to an existing or new static library
@@ -400,16 +612,18 @@ macro(macro_add_service_interface lib_name interface_doc interface_name codegen_
 endmacro(macro_add_service_interface)
 
 # ---------------------------------------------------------------------------
-# Description : Generates code for a service interface using a code generator and includes
-#               the generated files in a static library.
 # Function ...: addServiceInterfaceEx
-# Parameters .: ${lib_name}       -- The static library name.
-#               ${source_root}    -- The root directory of the source files.
-#               ${relative_path}  -- The relative path to the Service Interface files.
-#               ${sub_dir}        -- Optional sub-directory within relative_path (can be empty).
-#               ${interface_name} -- The name of the Service Interface (without the '.siml' extension).
-# Usage ......: addServiceInterfaceEx(<static library> <source root> <relative path> <sub-directory> <interface name>)
-# Example ....: addServiceInterfaceEx("fun_library" "/home/develop/project/my-fun/sources" "my/service/interfaces" "" FunInterface)
+# Purpose ....: Wrapper for macro_add_service_interface, assuming that the code generator
+#               tool is in the 'tools/codegen.jar', the root directory for file generation
+#               is ${AREG_BUILD_ROOT} and the code is generated in the "${AREG_GENERATE}/${relative_path}". 
+#               Generates code and includes files for a Service Interface document (.siml) in a static library.
+# Parameters .: ${lib_name}       -- Static library name.
+#               ${source_root}    -- Source root directory.
+#               ${relative_path}  -- Relative path to the Service Interface file.
+#               ${sub_dir}        -- Optional sub-directory within 'relative_path'. Can be empty string.
+#               ${interface_name} -- Service Interface name (excluding `.siml` extension).
+# Usage ......: addServiceInterfaceEx(<library-name> <source-root> <relative-path> <sub-dir-opt> <service-interface-name>)
+# Example ....: addServiceInterfaceEx("fun_library" "/home/dev/project/fun/src" "my/service/interfaces" "" FunInterface)
 # ---------------------------------------------------------------------------
 function(addServiceInterfaceEx lib_name source_root relative_path sub_dir interface_name)
 
@@ -424,21 +638,21 @@ function(addServiceInterfaceEx lib_name source_root relative_path sub_dir interf
     endif()
 
     macro_add_service_interface(${lib_name}
-                                ${interface_doc}
-                                ${interface_name}
+                                "${interface_doc}"
                                 "${codegen_root}"
                                 "${output_path}"
                                 "${codegen_tool}")
 endfunction(addServiceInterfaceEx)
 
 # ---------------------------------------------------------------------------
-# Description : Wrapper for addServiceInterfaceEx, with the source root assumed
-#               to be ${CMAKE_SOURCE_DIR} and the relative path ${CMAKE_CURRENT_LIST_DIR}.
 # Function ...: addServiceInterface
-# Parameters .: ${lib_name}       -- The name of the static library.
-#               ${sub_dir}        -- The sub-directory of the service interface files.
-#               ${interface_name} -- The name of the Service Interface (without the '.siml' extension).
-# Usage ......: addServiceInterface(<static library> <sub-directory> <Service Interface name>)
+# Purpose ....: Wrapper for addServiceInterfaceEx, with the source root assumed
+#               to be ${CMAKE_SOURCE_DIR} and the Service Interface document is located
+#               relative to ${CMAKE_CURRENT_LIST_DIR}.
+# Parameters .: ${lib_name}       -- Name of the static library.
+#               ${sub_dir}        -- Optional sub-directory, where the Service Interface document is located. Can be empty.
+#               ${interface_name} -- Service Interface name (excluding '.siml' extension).
+# Usage ......: addServiceInterface(<library-name> <sub-dir-opt> <service-interface-name>)
 # ---------------------------------------------------------------------------
 function(addServiceInterface lib_name sub_dir interface_name)
     file(RELATIVE_PATH relative_path ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_LIST_DIR})
@@ -446,51 +660,10 @@ function(addServiceInterface lib_name sub_dir interface_name)
 endfunction(addServiceInterface)
 
 # ---------------------------------------------------------------------------
-# Description : Searches for a package and sets output variables to indicate the package's
-#               include directories and libraries if found.
-# Macro ......: macro_find_package
-# Parameters .: ${package_name}      -- The package name to search.
-#               ${package_found}     -- Output variable, set to TRUE if the package is found.
-#               ${package_includes}  -- Output variable, set to the package's include directories (if any).
-#               ${package_libraries} -- Output variable, set to the package's libraries (if any).
-# Usage ......: macro_find_package(<package> <found flag> <includes> <libraries>)
-# Example ....: macro_find_package(SQLite3 SQLITE_FOUND SQLITE_INCLUDE SQLITE_LIB)
-# ---------------------------------------------------------------------------
-macro(macro_find_package package_name package_found package_includes package_libraries)
-    find_package(${package_name})
-    if (${package_name}_FOUND)
-        set(${package_found} TRUE)
-        set(${package_includes}  "${${package_name}_INCLUDE_DIRS}")
-        set(${package_libraries} "${${package_name}_LIBRARIES}")
-    else()
-        set(${package_found} FALSE)
-        set(${package_includes}  "")
-        set(${package_libraries} "")
-    endif()
-endmacro(macro_find_package)
-
-# ---------------------------------------------------------------------------
-# Description : Creates or updates a boolean cache variable in CMake, ensuring it is defined and set correctly.
-# Macro ......: macro_create_option
-# Parameters .: ${var_name}     -- The name of the boolean variable.
-#               ${var_value}    -- The default value if the variable is not yet defined.
-#               ${var_describe} -- A brief description of the variable for CMake cache.
-# Usage ......: macro_create_option(<var_name> <default_value> <description>)
-# Example ....: macro_create_option(AREG_LOGS ON "Compile with logs")
-# ---------------------------------------------------------------------------
-macro(macro_create_option var_name var_value var_describe)
-    if (NOT DEFINED ${var_name})
-        set(${var_name} ${var_value} CACHE BOOL "${var_describe}" FORCE)
-    else()
-        set(${var_name} ${${var_name}} CACHE BOOL "${var_describe}" FORCE)
-    endif()
-endmacro(macro_create_option)
-
-# ---------------------------------------------------------------------------
-# Description : Recursively removes empty directories.
 # Function ...: removeEmptyDirs
-# Parameters .: ${dir_name} -- The directory path to check and potentially remove.
-# Usage ......: removeEmptyDirs(<directory path>)
+# Purpose ....: Recursively removes empty directories within the specified directory path.
+# Parameters .: ${dir_name} -- Directory path to check and potentially remove.
+# Usage ......: removeEmptyDirs(<dir-path>)
 # ---------------------------------------------------------------------------
 function(removeEmptyDirs dir_name)
     if (EXISTS "${dir_name}" AND IS_DIRECTORY "${dir_name}")
@@ -512,105 +685,12 @@ function(removeEmptyDirs dir_name)
 endfunction(removeEmptyDirs)
 
 # ---------------------------------------------------------------------------
-# Description : Adds source files to a list, checking if the files exist relative to the base directory.
-# Macro ......: macro_add_source
-# Parameters .: ${result_list}  -- The output list of source files.
-#               ${src_base_dir} -- The base directory for the source files.
-#               ${ARGN}         -- The list of source files (relative to the base directory).
-# Usage ......: set(aregextend_SRC)
-#               macro_add_source(aregextend_SRC "${AREG_FRAMEWORK}" aregextend/db/private/LogSqliteDatabase.cpp ...)
-# ---------------------------------------------------------------------------
-macro(macro_add_source result_list src_base_dir)
-    set(_list "${ARGN}")
-    foreach(_item IN LISTS _list)
-        set(_src "${src_base_dir}/${_item}")
-        if (EXISTS "${_src}")
-            list(APPEND ${result_list} "${_src}")
-        else()
-            message(FATAL_ERROR "AREG: >>> The item '${_item}' does not exist in '${src_base_dir}'")
-        endif()
-    endforeach()
-    unset(_list)
-endmacro(macro_add_source)
-
-
-# ---------------------------------------------------------------------------
-# Description : This macro processes a list of input arguments that can include:
-#                   1. **CMake targets** (predefined libraries or targets).
-#                   2. **Source files**: Files provided with either absolute paths or 
-#                      paths relative to the current directory.
-#                   3. **Resource files** (*.rc): Windows-specific resource files.
-#               The macro categorizes the input arguments into three separate lists:
-#                   1. **Libraries list**: Contains any known CMake targets.
-#                   2. **Source files list**: Includes valid source files (.cpp, .c) 
-#                      from either the provided absolute paths or relative paths.
-#                   3. **Resource files list**: Filters out .rc files, specifically for Windows,
-#                      and stores them in a separate list.
-#
-# Behavior ...: 
-#               - If a file does not exist, either as a full path or relative to the current directory, 
-#                 the macro throws a fatal error.
-#               - On Windows, it specifically identifies and appends resource files (*.rc) to the 
-#                 resources list.
-#
-# Macro ......: macro_parse_arguments
-# Parameters .: ${res_sources}   -- Output: A list containing the parsed source files.
-#               ${res_libs}      -- Output: A list containing the recognized CMake targets (libraries).
-#               ${res_resources} -- Output: A list containing the identified resource files (*.rc).
-#               ${ARGN}          -- Input: A list of files, libraries, or resources to be categorized.
-#
-# Usage ......: macro_parse_arguments(<var sources> <var libs> <var resources> my_target my/app/main.cpp my/lib/object.cpp my/resource/resource.rc)
-#               Example: macro_parse_arguments(src_files lib_targets res_files my_lib src/main.cpp src/object.cpp res/resource.rc)
-# ---------------------------------------------------------------------------
-macro(macro_parse_arguments res_sources res_libs res_resources)
-    set(_list "${ARGN}")
-    foreach(_item IN LISTS _list)
-        # Check if the _item is a known CMake target
-        if (TARGET ${_item})
-            list(APPEND ${res_libs} ${_item})
-        # Check if the _item is an existing file, relative or full path
-        elseif (EXISTS "${_item}")
-            list(APPEND ${res_sources} "${_item}")
-        elseif (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${_item}")
-            list(APPEND ${res_sources} "${CMAKE_CURRENT_LIST_DIR}/${_item}")
-        else()
-            message(FATAL_ERROR "AREG: >>> File \'${_item}\' does not exist, ignoring")
-        endif()
-    endforeach()
-
-    # Separate out resource files (*.rc) for setting their properties on Windows
-    foreach(_file IN LISTS ${res_sources})
-        cmake_path(GET _file EXTENSION _ext)
-        if (_ext STREQUAL "rc")
-            list(APPEND ${res_resources} "${_file}")
-        endif()
-    endforeach()
-
-endmacro(macro_parse_arguments)
-
-# ---------------------------------------------------------------------------
-# Description : This macro declares a static library by processing the provided list of
-#               arguments and categorizing them into three main groups:
-#                   1. **Source Files**: These are the .cpp or .c files used to build the library.
-#                      The macro supports both absolute paths and paths relative to the current directory.
-#                   2. **Libraries**: These are existing CMake targets (predefined libraries) 
-#                      that the static library depends on.
-#                   3. **Resource Files**: These are .rc files (Windows resource files). 
-#                      On Windows systems, the macro ensures they are processed using the appropriate RC language settings.
-#               The macro declares a static library target using the collected source files and linked libraries.
-#               It also handles resource file configuration on Windows platforms.
-#
-# Notes ......: 
-#               - Throws a fatal error if no source files are provided.
-#               - On Windows, resource files (*.rc) are set to use the RC language automatically.
-# 
 # Macro ......: macro_declare_static_library
-# Parameters .: ${lib_name}  -- The name of the static library to be declared.
-#               ${ARGN}      -- The list of source files, libraries, and resource files.
-#                               The files can be specified with full or relative paths.
-#
-# Usage ......: macro_declare_static_library(<lib_name> <list_of_sources_libraries_and_resources>)
-#               Example: macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
+# Purpose ....: Declares a static library with categorized sources, libraries, and resources using 'macro_parse_arguments'.
+# Parameters .: ${lib_name}  -- Name of the static library.
+#               ${ARGN}      -- List of source files, libraries, and resources.
+# Usage ......: macro_declare_static_library(<lib-name> <sources-targets-resources>)
+# Example ....: macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
 # ---------------------------------------------------------------------------
 macro(macro_declare_static_library lib_name)
 
@@ -638,28 +718,12 @@ macro(macro_declare_static_library lib_name)
 endmacro(macro_declare_static_library)
 
 # ---------------------------------------------------------------------------
-# Description : This macro declares a shared library by processing the provided list of
-#               arguments and categorizing them into three main groups:
-#                   1. **Source Files**: These are the .cpp or .c files used to build the library.
-#                      The macro supports both absolute paths and paths relative to the current directory.
-#                   2. **Libraries**: These are existing CMake targets (predefined libraries) 
-#                      that the shared library depends on.
-#                   3. **Resource Files**: These are .rc files (Windows resource files). 
-#                      On Windows systems, the macro ensures they are processed using the appropriate RC language settings.
-#               The macro declares a shared library target using the collected source files and linked libraries.
-#               It also handles resource file configuration on Windows platforms.
-#
-# Notes ......: 
-#               - Throws a fatal error if no source files are provided.
-#               - On Windows, resource files (*.rc) are set to use the RC language automatically.
-# 
 # Macro ......: macro_declare_shared_library
-# Parameters .: ${lib_name}  -- The name of the shared library to be declared.
-#               ${ARGN}      -- The list of source files, libraries, and resource files.
-#                               The files can be specified with full or relative paths.
-#
-# Usage ......: macro_declare_shared_library(<lib_name> <list_of_sources_libraries_and_resources>)
-#               Example: macro_declare_shared_library(mySharedLib src/main.cpp src/resource.rc libSomeDependency)
+# Purpose ....: Declares a shared library with categorized sources, libraries, and resources using macro_parse_arguments.
+# Parameters .: ${lib_name}  -- Name of the shared library.
+#               ${ARGN}      -- List of source files, libraries, and resources.
+# Usage ......: macro_declare_shared_library(<lib-name> <sources-targets-resources>)
+# Example ....: macro_declare_shared_library(mySharedLib src/main.cpp src/resource.rc libSomeDependency)
 # ---------------------------------------------------------------------------
 macro(macro_declare_shared_library lib_name)
 
@@ -687,28 +751,13 @@ macro(macro_declare_shared_library lib_name)
 endmacro(macro_declare_shared_library)
 
 # ---------------------------------------------------------------------------
-# Description : This macro declares an executable by processing the provided list of
-#               arguments and categorizing them into three main groups:
-#                   1. **Source Files**: These are the .cpp or .c files used to build the library.
-#                      The macro supports both absolute paths and paths relative to the current directory.
-#                   2. **Libraries**: These are existing CMake targets (predefined libraries) 
-#                      that the executable depends on.
-#                   3. **Resource Files**: These are .rc files (Windows resource files). 
-#                      On Windows systems, the macro ensures they are processed using the appropriate RC language settings.
-#               The macro declares a executable target using the collected source files and linked libraries.
-#               It also handles resource file configuration on Windows platforms.
-#
-# Notes ......: 
-#               - Throws a fatal error if no source files are provided.
-#               - On Windows, resource files (*.rc) are set to use the RC language automatically.
-# 
 # Macro ......: macro_declare_executable
-# Parameters  : ${exe_name}  -- The name of the executable to be declared.
-#               ${ARGN}      -- The list of source files, libraries, and resource files.
-#                               The files can be specified with full or relative paths.
-#
-# Usage ......: macro_declare_executable(<lib_name> <list_of_sources_libraries_and_resources>)
-#               Example: macro_declare_executable(myApplication src/main.cpp src/resource.rc libSomeDependency)
+# Purpose ....: Declares an executable target with categorized sources, 
+#               libraries, and resources using macro_parse_arguments.
+# Parameters  : ${exe_name}  -- Name of the target executable.
+#               ${ARGN}      -- List of source files, libraries, and resources.
+# Usage ......: macro_declare_executable(<executable-name> <sources-targets-resources>)
+# Example ....: macro_declare_executable(myApplication src/main.cpp src/resource.rc libSomeDependency)
 # ---------------------------------------------------------------------------
 macro(macro_declare_executable exe_name)
 
@@ -736,144 +785,14 @@ macro(macro_declare_executable exe_name)
 endmacro(macro_declare_executable)
 
 # ---------------------------------------------------------------------------
-# Description : This macro identifies the compiler family (e.g., GNU, Clang, MSVC),
-#               extracts a short name for the compiler, and attempts to guess the corresponding
-#               C compiler based on the provided C++ compiler path or name. It handles cases
-#               where only the compiler name is provided (assuming it is available in the system's PATH).
-#               If a match is found, it sets the output variables for the compiler family, short name,
-#               C++ compiler path, and C compiler path, and marks the process as successful.
-#               Otherwise, the output flag indicates failure.
-#
-# Note .......: Beside "gnu", "llvm", "msvc", the compilers for CYGWIN are included in the family "cygwin"
-#               to identify that the application is compiled in Windows under CYGWIN platform with GNU compilers.
-# Macro ......: macro_declare_executable
-# Parameters .: 
-#               - ${compiler_path}   -- Input: The name or full path of the C++ compiler executable.
-#               - ${compiler_family} -- Output: Variable to hold the identified compiler family (e.g., "gnu", "msvc").
-#               - ${compiler_short}  -- Output: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
-#               - ${compiler_cxx}    -- Output: Variable to hold the C++ compiler path (usually same as ${compiler_path}).
-#               - ${compiler_c}      -- Output: Variable to hold the corresponding C compiler name or path.
-#               - ${compiler_supports}  -- Output: Boolean flag indicating if the compiler was successfully identified ("TRUE" or "FALSE").
-#
-# Usage ......: macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" 
-#                                           AREG_COMPILER_FAMILY 
-#                                           AREG_COMPILER_SHORT 
-#                                           AREG_CXX_COMPILER 
-#                                           AREG_C_COMPILER 
-#                                           _compiler_supports
-#                                         )
-# ---------------------------------------------------------------------------
-macro(macro_setup_compilers_data compiler_path compiler_family compiler_short compiler_cxx compiler_c compiler_supports)
-
-    set(${compiler_supports} FALSE)
-    
-    # Iterate over known compilers to identify the compiler type
-    foreach(_entry "clang-cl;llvm;clang-cl" "clang++;llvm;clang" "clang;llvm;clang" "g++;gnu;gcc" "gcc;gnu;gcc" "c++;gnu;cc" "cc;gnu;cc" "cl;msvc;cl")
-        list(GET _entry 0 _cxx_compiler)
-        list(GET _entry 1 _family)
-        list(GET _entry 2 _c_compiler)
-
-        # Check if the provided compiler matches the known C++ compiler
-        string(FIND "${compiler_path}" "${_cxx_compiler}" _found_pos REVERSE)
-        if (_found_pos GREATER -1)
-            # Handle special case for CYGWIN and GNU family compilers
-            if (CYGWIN AND ("${_family}" STREQUAL "gnu"))
-                set(${compiler_family} "cygwin")
-            else()
-                set(${compiler_family} "${_family}")
-            endif()
-
-            set(${compiler_short} "${_cxx_compiler}")
-            set(${compiler_cxx}   "${compiler_path}")
-
-            # Determine the corresponding C compiler path or name
-            if ("${_cxx_compiler}" STREQUAL "${_c_compiler}")
-                set(${compiler_c} "${compiler_path}")
-            else()
-                string(REPLACE "${_cxx_compiler}" "${_c_compiler}" ${compiler_c} "${compiler_path}")
-            endif()
-
-            # Mark compiler as found
-            set(${compiler_supports} TRUE)
-
-            # break the loop, we have found
-            break()
-        endif()
-    endforeach()
-
-endmacro(macro_setup_compilers_data)
-
-# ---------------------------------------------------------------------------
-# Description : This macro identifies the short name of the C++ and C compilers
-#               based on the provided compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
-#               It assumes that the compiler executables are available in the system's PATH.
-#               Once a match is found for the compiler family, it sets the output variables 
-#               for the short name, C++ compiler name, and C compiler name, and marks the process as successful.
-#               If no match is found, it sets the output flag to "FALSE".
-#
-# Note .......: The "cygwin" family is supported for GNU compilers on the CYGWIN platform in Windows.
-#
-# Macro ......: macro_setup_compilers_data_by_family
-# Parameters .: 
-#               - ${compiler_family} -- Input: The name of the compiler family (e.g., "gnu", "msvc").
-#               - ${compiler_short}  -- Output: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
-#               - ${compiler_cxx}    -- Output: Variable to hold the C++ compiler name.
-#               - ${compiler_c}      -- Output: Variable to hold the corresponding C compiler name.
-#               - ${compiler_supports}  -- Output: Boolean flag indicating whether the compiler was successfully identified ("TRUE" or "FALSE").
-#
-# Usage ......: macro_setup_compilers_data_by_family("gnu"
-#                                                    AREG_COMPILER_SHORT 
-#                                                    AREG_CXX_COMPILER 
-#                                                    AREG_C_COMPILER 
-#                                                    _compiler_supports
-#                                                   )
-# ---------------------------------------------------------------------------
-macro(macro_setup_compilers_data_by_family compiler_family compiler_short compiler_cxx compiler_c compiler_supports)
-
-    set(${compiler_supports} FALSE)
-    
-    # Iterate over known compilers and match the family
-    foreach(_entry "clang++;llvm;clang" "g++;gnu;gcc" "cl;msvc;cl" "g++;cygwin;gcc")
-        list(GET _entry 0 _compiler)
-        list(GET _entry 1 _family)
-        list(GET _entry 2 _c_compiler)
-
-        if ("${_family}" STREQUAL "${compiler_family}")
-            # Special case for Windows
-            if (WIN32 AND "${_family}" STREQUAL "llvm")
-                set(${compiler_short} "clang-cl")
-                set(${compiler_cxx}   "clang-cl")
-                set(${compiler_c}     "clang-cl")
-            else()
-                set(${compiler_short} "${_compiler}")
-                set(${compiler_cxx}   "${_compiler}")
-                set(${compiler_c}     "${_c_compiler}")
-            endif()
-
-            # Mark compiler as found
-            set(${compiler_supports} TRUE)
-
-            # break the loop, we have found
-            break()
-        endif()
-    endforeach()
-
-endmacro(macro_setup_compilers_data_by_family)
-
-# ---------------------------------------------------------------------------
-# Description : This function prints a detailed status report for the AREG project's CMake configuration.
-#               It provides an overview of the build environment, compiler, output directories, 
-#               and relevant configuration options such as installed packages and libraries.
-#
 # Function ...: printAregConfigStatus
-# Parameters .: 
-#               - ${var_make_print} -- Boolean flag indicating whether to print the status message. 
-#                                      If FALSE, the function exits without printing.
+# Purpose ....: Prints a detailed status of AREG's CMake configuration, including details of the build environment.
+# Parameters .: - ${var_make_print} -- Boolean flag indicating whether to print the status message (if FALSE, the function exits without printing).
 #               - ${var_prefix}     -- A prefix added to each line of the status message (e.g., project name or custom label).
 #               - ${var_header}     -- A custom header message displayed at the beginning of the status report.
 #               - ${var_footer}     -- A custom footer message displayed at the end of the status report.
-#
-# Usage ......: printAregConfigStatus(
+# Usage ......: printAregConfigStatus(<flag-to-print> <prefix> <header-output> <footer-output>)
+# Example ....: printAregConfigStatus(
 #                                   TRUE
 #                                   "AREG"
 #                                   "----------------------> AREG project CMake Status Report Begin <-----------------------"

--- a/conf/cmake/setup.cmake
+++ b/conf/cmake/setup.cmake
@@ -17,12 +17,22 @@ endif()
 
 # The location of cmake configuration files.
 if (NOT DEFINED AREG_CMAKE_CONFIG_DIR OR "${AREG_CMAKE_CONFIG_DIR}" STREQUAL "")
-    set(AREG_CMAKE_CONFIG_DIR   "${AREG_SDK_ROOT}/conf/cmake")
+    if (EXISTS "${AREG_SDK_ROOT}/conf/cmake/")
+        set(AREG_CMAKE_CONFIG_DIR   "${AREG_SDK_ROOT}/conf/cmake")
+    else()
+        message(FATAL_ERROR "AREG: >>> Cannot find \'conf\cmake\' sub-directory in the AREG SDK Root \'${AREG_SDK_ROOT}\'. Set \'AREG_CMAKE_CONFIG_DIR\' manually.")
+    endif()
 endif()
 
-# The location of AREG Framework source codes.
+# The location of AREG Framework header files.
 if (NOT DEFINED AREG_FRAMEWORK OR "${AREG_FRAMEWORK}" STREQUAL "")
-    set(AREG_FRAMEWORK               "${AREG_SDK_ROOT}/framework")
+    if (EXISTS "${AREG_SDK_ROOT}/framework/areg/")
+        set(AREG_FRAMEWORK               "${AREG_SDK_ROOT}/framework")
+    elseif (EXISTS "${AREG_SDK_ROOT}/include/areg/")
+        set(AREG_FRAMEWORK               "${AREG_SDK_ROOT}/include")
+    else()
+        message(FATAL_ERROR "AREG: >>> Cannot find AREG Framework headers in the AREG SDK Root \'${AREG_SDK_ROOT}\'. Set \'AREG_FRAMEWORK\' manually.")
+    endif()
 endif()
 
 # The location of AREG Framework examples

--- a/docs/wiki/cmake-functions.md
+++ b/docs/wiki/cmake-functions.md
@@ -1,0 +1,381 @@
+# AREG SDK CMake Functions and Macro
+
+The [functions.cmake](./../../conf/cmake/functions.cmake) file in the AREG SDK repository contains a set of custom CMake functions and macros that streamline project configuration tasks for building projects based on AREG Framework. Below is a detailed breakdown of each function and macro, including their purposes and usage.
+
+---
+
+## Introduction
+
+This file offers reusable CMake functions and macros, designed to simplify repetitive tasks in CMake configuration. By including this file, developers can leverage pre-built utilities for complex configuration, ensuring a cleaner and more maintainable CMake setup.
+
+
+The [functions.cmake](./../../conf/cmake/functions.cmake) file provides reusable CMake utilities to simplify and improve the configuration of projects, which use AREG Framework. The developers can use functions and macro declared in `functions.cmake` by including [setup.cmake](./../../conf/cmake/setup.cmake) file in their project in their project to ensure consistent and efficient project setup.
+
+> [!IMPORTANT]
+> It is recommended to include the file `setup.cmake` in the `CMakeLists.txt` files instead of including `functions.cmake` to reuse functions and marco, and integrate AREG Framework properly. Before including the file, set the `AREG_SDK_ROOT` CMake variable indicating the location of `<areg-sdk>` installation directory. More details about integration are described in the [AREG Framework Integration](./cmake-integrate.md) document of AREG SDK Wiki.
+
+---
+
+## AREG Framework CMake Macro
+
+Following are the CMake macro with description that can be used by developers:
+
+### macro_check_fix_areg_cxx_standard
+
+- **Macro**: macro_check_fix_areg_cxx_standard
+- **Description**: Checks and sets the C++ standard for the project. The variable 'AREG_CXX_STANDARD' must be defined before calling this macro. If 'CMAKE_CXX_STANDARD' is not set, it will be assigned the value of 'AREG_CXX_STANDARD'. If 'CMAKE_CXX_STANDARD' is lower than 'AREG_CXX_STANDARD', a warning is displayed.
+- **Macro Usage**: macro_check_fix_areg_cxx_standard()
+
+### macro_normalize_path
+- **Macro**: macro_normalize_path(normal_path os_path)
+- **Description**: Converts Windows-specific paths to Cygwin format if running under Cygwin. Otherwise, the path remains unchanged.
+- **Note**: This macro does not address OS-specific path separator issues.
+- **Parameters**:
+  - *normal_path* [out]: The normalized path.
+  - *os_path* [in]: The OS-specific path to normalize.
+- **Macro Usage**: *macro_normalize_path(<result_variable> <OS specific path>)*
+
+### macro_add_service_interface
+
+- **Macro**: macro_add_service_interface(lib_name interface_doc interface_name codegen_root output_path codegen_tool)
+- **Description**: This function invokes the service interface code generator to produce source files and either adds them to a new static library (if it doesn't exist) or includes them in an existing one. It accepts the static library name, full paths to Service Interface file, Service Interface name and paths for generated files. The service interface name must match the file name (without the .siml extension).
+- **Parameters**:
+  - *lib_name* [in]: Name of the static library.
+  - *interface_doc* [in]:Full path to the Service Interface document file. 
+  - *interface_name* [in]: Name of the Service Interface (without '.siml').
+  - *codegen_root* [in]: Root directory for generating files.
+  - *output_path* [in]: Relative path for generated files.
+  - *codegen_tool* [in]: Full path to the code generator tool.
+- **Macro Usage**: *macro_add_service_interface(<library name> <documend dir><interface name>.siml <interface name> <codegen root> <sub-path> <codegen tool>)*
+- **Example: For a project 'fun_library' with 'HelloWorld.siml' and 'WeHaveFun.siml' interfaces calling macro_add_service_interface("fun_library" ... HelloWorld ...) generates source files for HelloWorld and includes them in the static library. A subsequent call for WeHaveFun adds it to the same library.
+   ```cmkae
+   macro_add_service_interface("fun_library" "~/project/my-fun/sources/service/interfaces/FunInterface.siml" FunInterface "~/project/my-fun/" "generate/service/interfaces" /tools/areg/codegen.jar)
+   ```
+
+### macro_find_package
+
+- **Macro**: macro_find_package(package_name package_found package_includes package_libraries)
+- **Description**: Searches for a package and sets output variables to indicate the package's include directories and libraries if found.
+- **Parameters**:
+  - *package_name* [in]: The package name to search.
+  - *package_found* [out]: Pass the name of variable. On output the variable is TRUE if the package is found.
+  - *package_includes* [out]: Pass the name of variable. On output the variable indicates the package's include directories (if any).
+  - *package_libraries* [out]: Pass the name of variable. On output the variable indicates the package's libraries (if any).
+- **Macro Usage**: *macro_find_package(<package> <found flag> <includes> <libraries>)*
+- **Example**:
+   ```cmake
+   macro_find_package(SQLite3 SQLITE_FOUND SQLITE_INCLUDE SQLITE_LIB)
+   ```
+
+### macro_create_option
+
+- **Macro**: macro_create_option(var_name var_value var_description)
+- **Description**: Creates or updates a boolean cache variable in CMake, ensuring it is defined and set correctly.
+- **Parameters**: 
+  - *var_name* [in, out]: The name of the boolean variable.
+  - *var_value* [in]: The default value if the variable is not yet defined.
+  - *var_describe* [in]: A brief description of the variable for CMake cache.
+- **Macro Usage**: *macro_create_option(<var_name> <default_value> <description>)*
+- **Example**:
+   ```cmake
+   macro_create_option(AREG_LOGS ON "Compile with logs")
+   ```
+
+### macro_add_source
+
+- **Macro**: macro_add_source(result_list src_base_dir ...)
+- **Description**: Adds source files to a list, checking if the files exist relative to the base directory.
+- **Parameters**:
+  - *result_list* [in, out]: The output list of source files.
+  - *src_base_dir* [in]: The base directory for the source files.
+  - *ARGN* [in]: The list of source files (relative to the base directory).
+- **Macro Usage**: macro_add_source(<src list variable> <base directory path> <list of source files with relative path>)
+- **Example**:
+   ```cmake
+   set(aregextend_SRC)
+   macro_add_source(aregextend_SRC "${AREG_FRAMEWORK}" aregextend/db/private/LogSqliteDatabase.cpp ...)
+   ```
+
+### macro_parse_arguments
+
+- **Macro**: macro_parse_arguments(res_sources res_libs res_resources ...)
+- **Description**: This macro processes a list of input arguments that can include:
+          1. **CMake targets** (predefined libraries or targets).
+          2. **Source files**: Files provided with either absolute paths or paths relative to the current directory.
+          3. **Resource files** (*.rc): Windows-specific resource files.    
+       The macro categorizes the input arguments into three separate lists:
+          1. **Libraries list**: Contains any known CMake targets.
+          2. **Source files list**: Includes valid source files (.cpp, .c) from either the provided absolute paths or relative paths.
+          3. **Resource files list**: Filters out .rc files, specifically for Windows, and stores them in a separate list.
+       **Behavior**: 
+          - If a file does not exist, either as a full path or relative to the current directory, the macro throws a fatal error.
+          - On Windows, it specifically identifies and appends resource files (*.rc) to the resources list.
+- **Parameters**:
+  - *res_sources* [out]: A list containing the parsed source files.
+  - *res_libs* [out]: Output: A list containing the recognized CMake targets (libraries).
+  - *res_resources* [out]: A list containing the identified resource files (*.rc).
+  - *${ARGN}* [in]: A list of files, libraries, or resources to be categorized.
+- **Macro Usage**: *macro_parse_arguments(<var sources> <var libs> <var resources> my_target my/app/main.cpp my/lib/object.cpp my/resource/resource.rc)*
+- **Example**:    
+   ```cmake
+   macro_parse_arguments(src_files lib_targets res_files my_lib src/main.cpp src/object.cpp res/resource.rc)
+   ```
+
+### macro_declare_static_library
+
+- **Macro**: macro_declare_static_library(lib_name ...)
+- **Description**: This macro declares a static library by processing the provided list of arguments and categorizing them into three main groups:
+            1. **Source Files**: These are the .cpp or .c files used to build the library. The macro supports both absolute paths and paths relative to the current directory.
+            2. **Libraries**: These are existing CMake targets (predefined libraries) that the static library depends on.
+            3. **Resource Files**: These are .rc files (Windows resource files). On Windows systems, the macro ensures they are processed using the appropriate RC language settings.
+       The macro declares a static library target using the collected source files and linked libraries. It also handles resource file configuration on Windows platforms.
+- **Notes**: 
+   - Throws a fatal error if no source files are provided.
+   - On Windows, resource files (*.rc) are set to use the RC language automatically.
+- **Parameters**:
+  - **lib_name** [in]: The name of the static library to be declared.
+  - **${ARGN}** [in]: The list of source files, libraries, and resource files. The files can be specified with full or relative paths.
+- **Macro Usage**: *macro_declare_static_library(<lib_name> <list_of_sources_libraries_and_resources>)*
+- **Example**:
+   ```cmake
+   macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
+   ```
+
+### macro_declare_shared_library
+
+- **Macro**: macro_declare_shared_library(lib_name ...)
+- **Description**: This macro declares a shared library by processing the provided list of arguments and categorizing them into three main groups:
+            1. **Source Files**: These are the .cpp or .c files used to build the library. The macro supports both absolute paths and paths relative to the current directory.
+            2. **Libraries**: These are existing CMake targets (predefined libraries) that the shared library depends on.
+            3. **Resource Files**: These are .rc files (Windows resource files). On Windows systems, the macro ensures they are processed using the appropriate RC language settings.
+       The macro declares a shared library target using the collected source files and linked libraries. It also handles resource file configuration on Windows platforms.
+- **Notes**: 
+   - Throws a fatal error if no source files are provided.
+   - On Windows, resource files (*.rc) are set to use the RC language automatically.
+- **Parameters**:
+  - *lib_name* [in]: The name of the shared library to be declared.
+  - *${ARGN}* [in]: The list of source files, libraries, and resource files. The files can be specified with full or relative paths.
+- **Macro Usage**: *macro_declare_shared_library(<lib_name> <list_of_sources_libraries_and_resources>)*
+- **Example**:
+   ```cmake
+   macro_declare_shared_library(mySharedLib src/main.cpp src/resource.rc libSomeDependency)
+   ```
+
+### macro_declare_executable
+
+- **Macro**: macro_declare_executable(exe_name ...)
+- **Description**: This macro declares an executable by processing the provided list of arguments and categorizing them into three main groups:
+            1. **Source Files**: These are the .cpp or .c files used to build the library. The macro supports both absolute paths and paths relative to the current directory.
+            2. **Libraries**: These are existing CMake targets (predefined libraries) that the executable depends on.
+            3. **Resource Files**: These are .rc files (Windows resource files). On Windows systems, the macro ensures they are processed using the appropriate RC language settings.
+       The macro declares a executable target using the collected source files and linked libraries. It also handles resource file configuration on Windows platforms.
+- **Notes**: 
+   - Throws a fatal error if no source files are provided.
+   - On Windows, resource files (*.rc) are set to use the RC language automatically.
+- **Parameters**:
+  - *exe_name* [in]: The name of the executable to be declared.
+  - *${ARGN}* [in]: The list of source files, libraries, and resource files. The files can be specified with full or relative paths.
+- **Macro Usage**: *macro_declare_executable(<lib_name> <list_of_sources_libraries_and_resources>)*
+- **Example**:
+   ```cmake
+   macro_declare_executable(myApplication src/main.cpp src/resource.rc libSomeDependency)
+   ```
+
+### macro_setup_compilers_data
+
+- **Macro**: macro_setup_compilers_data(compiler_path compiler_family compiler_short compiler_cxx compiler_c compiler_found)
+- **Description**: This macro identifies the compiler family (e.g., GNU, Clang, MSVC), extracts a short name for the compiler, and attempts to guess the corresponding C compiler based on the provided C++ compiler path or name. It handles cases where only the compiler name is provided (assuming it is available in the system's PATH). If a match is found, it sets the output variables for the compiler family, short name, C++ compiler path, and C compiler path, and marks the process as successful. Otherwise, the output flag indicates failure.
+- **Note**: Beside "gnu", "llvm", "msvc", the compilers for CYGWIN are included in the family "cygwin" to identify that the application is compiled in Windows under CYGWIN platform with GNU compilers.
+- **Parameters**: 
+  - *compiler_path* [in]: The name or full path of the C++ compiler executable.
+  - *compiler_family* [out]: Variable to hold the identified compiler family (e.g., "gnu", "msvc").
+  - *compiler_short* [out]: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
+  - *compiler_cxx* [out]: Variable to hold the C++ compiler path (usually same as ${compiler_path}).
+  - *compiler_c* [out]: Variable to hold the corresponding C compiler name or path.
+  - *compiler_supports* [out]: Boolean flag indicating if the compiler was successfully identified ("TRUE" or "FALSE").
+- **Macro Usage**: macro_setup_compilers_data(<compiler with path> <var compiler family> <var compiler short> <var CXX compiler> <var C compiler> <flag compiler supports>)
+- **Example**:
+   ```cmake
+   macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" AREG_COMPILER_FAMILY AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _compiler_found)
+   ```
+
+### macro_setup_compilers_data_by_family
+
+- **Macro**: macro_setup_compilers_data_by_family(compiler_family compiler_short compiler_cxx compiler_c compiler_supports)
+- **Description**: This macro identifies the short name of the C++ and C compilers based on the provided compiler family (e.g., "gnu", "msvc", "llvm", "cygwin"). It assumes that the compiler executables are available in the system's PATH. Once a match is found for the compiler family, it sets the output variables for the short name, C++ compiler name, and C compiler name, and marks the process as successful. If no match is found, it sets the output flag to "FALSE".
+- **Note**: The "cygwin" family is supported for GNU compilers on the CYGWIN platform in Windows.
+- **Parameters**: 
+  - *compiler_family* [in]: The name of the compiler family (e.g., "gnu", "msvc").
+  - *compiler_short* [out]: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
+  - *compiler_cxx* [out]: Variable to hold the C++ compiler name.
+  - *compiler_c* [out]: Variable to hold the corresponding C compiler name.
+  - *compiler_supports* [out]: Boolean flag indicating whether the compiler was successfully identified ("TRUE" or "FALSE").
+- **Macro Usage**: macro_setup_compilers_data_by_family(<compiler family name> <var compiler short> <var CXX compiler> <var C compiler> <flag compiler supports>)
+- **Example**:
+   ```cmake
+   macro_setup_compilers_data_by_family("gnu" AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _compiler_supports)
+   ```
+
+---
+
+## AREG Framework CMake Functions
+
+Following are the CMake functions with description that can be used by developers:
+
+### setAppOptions
+
+- **Function**: *setAppOptions(target_name, library_list)*
+- **Description**: Configures the compiler and linker options for target applications. Automatically links the AREG library, along with any additional libraries specified.
+- **Parameters**:
+  - *target_name* [in]: The name of the target application to apply options to.
+  - *library_list* [in]: The list of additional libraries to link with the target application.
+- **Function Usage**: *setAppOptions(<name of target> <list of libraries>)*
+
+### addExecutableEx
+
+- **Function**: *addExecutableEx(target_name target_namespace source_list library_list)*
+- **Description**: Creates an target executable, sets its source files, applies necessary options, and links it with the provided list of libraries. The AREG library is automatically linked, so no need to specify it.
+- **Parameters**:
+  - *target_name* [in]: The name of the target executable to build.
+  - *target_namespace* [in]: The namespace of the target, used for aliasing. Pass empty string if has no namespace.
+  - *source_list* [in]: The list of source files used to build the target executable.
+  - *library_list* [in]: The list of libraries to link with the executable.
+- **Function Usage**: *addExecutableEx(<name of target executable> <namespace (optional)> <list of sources> <list of libraries>)*
+
+### addExecutable
+
+- **Function**: *addExecutable(target_name source_list)*
+- **Description**: Creates an executable, sets its source files, applies necessary options. The AREG library is automatically linked, so no need to specify it.
+- **Parameters**:
+  - *target_name* [in]: The name of the executable to build.
+  - *source_list* [in]: The list of source files used to build the executable.
+- **Function Usage**: *addExecutable(<name of executable> <list of sources>)*
+
+### setStaticLibOptions
+
+- **Function**: setStaticLibOptions(target_name library_list)
+- **Description**: Configures the compiler and linker options for a static library. Automatically links the AREG library and any other specified libraries.
+- **Parameters**:
+  - *target_name* [in]: The name of the static library to apply options to.
+  - *library_list* [in]: The list of libraries to link with the static library.
+- **Function Usage **: *setStaticLibOptions(<name of static library> <list of libraries>)* 
+
+### addStaticLibEx
+
+- **Function**: addStaticLibEx(target_name target_namespace source_list library_list)
+- **Description**: Creates a static library, sets its source files, applies necessary options, and links it with the provided list of libraries. The AREG library is automatically linked, so no need to specify it.
+- **Parameters**
+  - *target_name* [in]: The name of the static library to build.
+  - *target_namespace* [in]: (**optional**) The namespace of the static library. Pass empty string if has no namespace.
+  - *source_list* [in]: The list of source files used to build the static library.
+  - *library_list* [in]: The list of libraries to link with the static library.
+- **Function Usage**: *addStaticLibEx(<name of static library> <namespace (optional)> <list of sources> <list of libraries>)*
+
+### addStaticLib
+
+- **Function**: addStaticLib(target_name source_list)
+- **Description**: Creates a static library, sets its source files, applies necessary options. The AREG library is automatically linked, so no need to specify it.
+- **Parameters**
+  - *target_name* [in]: The name of the static library to build.
+  - *source_list* [in]: The list of source files used to build the static library.
+- **Function Usage**: *addStaticLib(<name of static library> <list of sources>)*
+
+### addStaticLibEx_C
+
+- **Function**: addStaticLibEx_C(target_name target_namespace source_list library_list)
+- **Description**: Creates a static library compiled with C-compiler, sets its source files, applies necessary options, and links it with the provided list of libraries. The AREG library is automatically linked, so no need to specify it.
+- **Parameters**:
+  - *target_name* [in]: The name of the static library to build.
+  - *target_namespace* [in]: (**optional**) The namespace of the static library. Pass empty string if has no namespace.
+  - *source_list* [in]: The list of C-code source files used to build the static library.
+  - *library_list* [in]: The list of libraries to link with the static library.
+- **Function Usage**: *addStaticLibEx_C(<name of static library> <namespace (optional)> <list of C-code sources> <list of libraries>)*
+
+### addStaticLib_C
+
+- **Function**: addStaticLib_C(target_name source_list)
+- **Description**: Creates a static library compiled with C-compiler, sets its source files, applies necessary options. The AREG library is automatically linked, so no need to specify it.
+- **Parameters**:
+  - *target_name* [in]: The name of the static library to build.
+  - *source_list* [in]: The list of C-code source files used to build the static library.
+- **Function Usage**: *addStaticLib_C(<name of static library> <list of C-code sources>)*
+
+### setSharedLibOptions
+
+- **Function**: setSharedLibOptions(item_name library_list)
+- **Description**: Configures the compiler and linker options for a shared library. Automatically links the AREG library and any other specified libraries.
+- **Parameters**:
+  - target_name [in]: The name of the shared library to apply options to.
+  - *library_list* [in]: The list of libraries to link with the shared library.
+- **Function Usage**: *setSharedLibOptions(<name of shared library> <list of libraries>)* 
+
+### addSharedLibEx
+
+- **Function**: addSharedLibEx(target_name target_namespace source_list library_list)
+- **Description**: Creates a shared library, sets its source files, applies necessary options, and links it with the provided list of libraries. The AREG library is automatically linked, so no need to specify it.
+- **Parameters**:
+  - *target_name* [in]: The name of the shared library to build.
+  - *target_namespace* [in]: The namespace of the shared library (optional for aliasing).
+  - *source_list* [in]: The list of source files used to build the shared library.
+  - *library_list* [in]: The list of libraries to link with the shared library.
+- **Function Usage**: *addSharedLibEx(<name of shared library> <namespace (optional)> <list of sources> <list of libraries>)*
+
+### addSharedLib
+- **Function**: addSharedLib(target_name source_list)
+- **Description**: Creates a shared library, sets its source files, applies necessary options. The AREG library is automatically linked, so no need to specify it.
+- **Parameters**:
+  - *target_name* [in]: The name of the shared library to build.
+  - *source_list* [in]: The list of source files used to build the shared library.
+- **Function Usage**: *addSharedLib(<name of shared library> <list of sources>)*
+
+### addServiceInterfaceEx
+
+- **Function**: addServiceInterfaceEx(lib_name source_root relative_path sub_dir interface_name)
+- **Description**: Generates code for a service interface using a code generator and includes the generated files in a static library.
+- **Parameters**
+  - *lib_name* [in]: The static library name.
+  - *source_root* [in]: The root directory of the source files.
+  - *relative_path* [in]: The relative path to the Service Interface files.
+  - *sub_dir* [in]: Optional sub-directory within relative_path (can be empty).
+  - *interface_name* [in]: The name of the Service Interface (without the '.siml' extension).
+- **Function Usage**: *addServiceInterfaceEx(<static library> <source root> <relative path> <sub-directory> <interface name>)*
+- **Example**:
+   ```cmake
+   addServiceInterfaceEx("fun_library" "/home/develop/project/my-fun/sources" "my/service/interfaces" "" FunInterface)
+   ```
+
+### addServiceInterface
+
+- **Function**: addServiceInterface(lib_name sub_dir interface_name)
+- **Description**: Wrapper for addServiceInterfaceEx, with the source root assumed to be `CMAKE_SOURCE_DIR` and the relative path `CMAKE_CURRENT_LIST_DIR`.
+- **Parameters**:
+  - *lib_name* [in]: The name of the static library.
+  - *sub_dir* [in]: The sub-directory of the service interface files.
+  - *interface_name* [in]: The name of the Service Interface (without the '.siml' extension).
+- **Function Usage**: *addServiceInterface(<static library> <sub-directory> <Service Interface name>)*
+
+### removeEmptyDirs
+
+- **Function**: removeEmptyDirs(dir_name)
+- **Description**: Recursively removes empty directories.
+- **Parameters**:
+  - dir_name [in]: The directory path to check and potentially remove.
+- **Function Usage**: *removeEmptyDirs(<directory path>)*
+
+### printAregConfigStatus
+
+- **Function**: printAregConfigStatus(var_make_print var_prefix var_header var_footer)
+- **Description**: This function prints a detailed status report for the AREG project's CMake configuration. It provides an overview of the build environment, compiler, output directories, and relevant configuration options such as installed packages and libraries.
+- **Parameters**: 
+  - *var_make_print* [in]: Boolean flag indicating whether to print the status message. If FALSE, the function exits without printing.
+  - *var_prefix* [in]: A prefix added to each line of the status message (e.g., project name or custom label).
+  - *var_header* [in]: A custom header message displayed at the beginning of the status report.
+  - *var_footer* [in]: A custom footer message displayed at the end of the status report.
+- **Function Usage**: printAregConfigStatus(<flag to print> <prefix name> <header to output> <footer to output>)
+- **Example**: 
+   ```cmake
+   printAregConfigStatus(TRUE "AREG"
+                        "----------------------> AREG project CMake Status Report Begin <-----------------------"
+                        "-----------------------> AREG project CMake Status Report End <------------------------"
+                        )
+   ```

--- a/docs/wiki/cmake-functions.md
+++ b/docs/wiki/cmake-functions.md
@@ -59,7 +59,7 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Purpose**: Normalizes Windows paths to Cygwin format, if applicable.
 - **Note**: This macro does not address OS-specific path separator issues.
 - **Parameters**:
-  - `normal_path` [out]: The normalized path.
+  - `normal_path` [out]: Name of variable to hold normalized path.
   - `os_path` [in]: The Windows-specific path to normalize.
 - **Usage**: `macro_normalize_path(<out-var> <windows-path>)`
 
@@ -75,8 +75,8 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Usage**: `macro_add_service_interface(<name-lib> <full-path-siml> <root-gen> <relative-path> <codegen-tool>)`
 - **Example**:
    ```cmkae
-   macro_add_service_interface(funlib "/home/dev/project/fun/src/service/HelloWorld.siml" "/home/dev/project/fun/product" "generate/service" /tools/areg/codegen.jar)
-   macro_add_service_interface(funlib "/home/dev/project/fun/src/service/WeHaveFun.siml"  "/home/dev/project/fun/product" "generate/service" /tools/areg/codegen.jar)
+   macro_add_service_interface(funlib "/home/dev/fun/src/service/HelloWorld.siml" "/home/dev/fun/product" "generate/service" /tools/areg/codegen.jar)
+   macro_add_service_interface(funlib "/home/dev/fun/src/service/WeHaveFun.siml"  "/home/dev/fun/product" "generate/service" /tools/areg/codegen.jar)
    ```
 
 ### `macro_find_package`
@@ -111,7 +111,7 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Syntax**: `macro_add_source(result_list src_base_dir ...)`
 - **Purpose**: Adds existing source files to a list based on a base directory. Checks file existence.
 - **Parameters**:
-  - `result_list` [in, out]: List of source files.
+  - `result_list` [in, out]: Name of variable that on output will contain the list of source files.
   - `src_base_dir` [in]: Base directory of the source files.
   - `${ARGN}` [in]: List of source files, relative to the base directory.
 - **Usage**: `macro_add_source(<src-list-var> <base-dirpath> <files>)`
@@ -128,9 +128,9 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
   - Throws an error if file does not exist.
   - List of resource files is Windows specific, it contains files with extension `.rc`.
 - **Parameters**:
-  - `res_sources` [out]: List of source files.
-  - `res_libs` [out]: List of recognized CMake targets.
-  - `res_resources` [out]: List of resource files (`*.rc`).
+  - `res_sources` [out]: Name of variable that on output will contain the list of source files.
+  - `res_libs` [out]: Name of variable that on output will contain the list of recognized CMake targets.
+  - `res_resources` [out]: Name of variable that on output will contain the List of resource files (`*.rc`).
   - `${ARGN}` [in]: List of files, libraries, or resources to categorize.
 - **Usage**: `macro_parse_arguments(<sources-var> <libs-var> <resources-var> <sources-targets-resources>)`
 - **Example**:    
@@ -166,7 +166,7 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Syntax**: `macro_declare_executable(exe_name ...)`
 - **Purpose**: Declares an executable target with categorized sources, libraries, and resources using **[macro_parse_arguments](#macro_parse_arguments)**.
 - **Parameters**:
-  - `exe_name` [in]: Name of the executable.
+  - `exe_name` [in]: Name of the target executable.
   - `${ARGN}` [in]: List of source files, libraries, and resources.
 - **Usage**: `macro_declare_executable(<executable-name> <sources-targets-resources>)`
 - **Example**:
@@ -180,11 +180,11 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Note**: Beside "gnu", "llvm", "msvc", the GNU compilers for CYGWIN are included as a "cygwin" family.
 - **Parameters**:
   - `compiler_path` [in]: Path to the C++ compiler.
-  - `compiler_family` [out]: Compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
-  - `compiler_short` [out]: Short name of the compiler (e.g., "gcc", "clang", "cl").
-  - `compiler_cxx` [out]: C++ compiler path.
-  - `compiler_c` [out]: C compiler path.
-  - `is_identified` [out]: Boolean indicating successful identification.
+  - `compiler_family` [out]: Name of variable to hold compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
+  - `compiler_short` [out]: Name of variable to hold short name of the compiler (e.g., "gcc", "clang", "cl").
+  - `compiler_cxx` [out]: Name of variable to hold C++ compiler name, usually same as `compiler_path`.
+  - `compiler_c` [out]: Name of variable to hold C compiler path.
+  - `is_identified` [out]: Name of variable to hold Boolean indicating successful identification.
 - **Usage**: `macro_setup_compilers_data(<compiler> <family-var> <short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)`
 - **Example**:
    ```cmakr
@@ -197,10 +197,10 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Note**: The "cygwin" family is supported for GNU compilers on the CYGWIN platform in Windows.
 - **Parameters**:
   - `compiler_family` [in]: Compiler family name (e.g., "gnu", "msvc").
-  - `compiler_short` [out]: Short name of the compiler (e.g., "gcc", "clang", "cl").
-  - `compiler_cxx` [out]: C++ compiler path.
-  - `compiler_c` [out]: C compiler path.
-  - `is_identified` [out]: Boolean indicating successful identification.
+  - `compiler_short` [out]: Name of variable to hold short name of the compiler (e.g., "gcc", "clang", "cl").
+  - `compiler_cxx` [out]: Name of variable to hold C++ compiler path.
+  - `compiler_c` [out]: Name of variable to hold C compiler path.
+  - `is_identified` [out]: Name of variable to hold Boolean indicating successful identification.
 - **Usage**: `macro_setup_compilers_data_by_family(<compiler-family> <short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)`
 - **Example**:
    ```cmake
@@ -224,14 +224,14 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Purpose**: Creates an executable target with specified source files and libraries.
 - **Parameters**:
   - `target_name` [in]: The name of the executable target.
-  - `target_namespace` [in]: Namespace for aliasing.
+  - `target_namespace` [in]: Namespace for aliasing. Can be empty.
   - `source_list` [in]: List of source files used to build the target executable.
   - `library_list` [in]: Libraries to link with the executable.
 - **Usage**: `addExecutableEx(<target-name> <namespace-opt> <source-list> <library-list>)`
 
 ### `addExecutable`
 - **Syntax**: `addExecutable(target_name source_list)`
-- **Purpose**: Creates an executable target, setting up sources, options, and imports, and auto-linking the AREG Framework library.
+- **Purpose**: Wrapper for [`addExecutableEx`](#addexecutableex), assuming there is no aliasing and list of libraries to link. Creates an executable target, setting up sources, options, and imports, and auto-linking the AREG Framework library.
 - **Parameters**:
   - `target_name` [in]: Name of the executable to build.
   - `source_list` [in]: List of source files used to build the executable.
@@ -250,14 +250,14 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Purpose**: Creates a static library with specified source files and options, importing and auto-linking the AREG Framework library along with any additional libraries.
 - **Parameters**:
   - `target_name` [in]: Name of the static library to build.
-  - `target_namespace` [in]: Namespace of the target, used for aliasing (pass an empty string if no aliasing is needed).
+  - `target_namespace` [in]: Namespace for aliasing. Can be empty string if no aliasing.
   - `source_list` [in]: List of source files to build the static library.
   - `library_list` [in]: List of libraries to link.
 - **Usage**: `addStaticLibEx(<target-name> <namespace-opt> <source-list> <library-list>)`
 
 ### `addStaticLib`
 - **Syntax**: `addStaticLib(target_name source_list)`
-- **Purpose**: Creates a static library, setting sources and options, importing, and auto-linking the AREG Framework library.
+- **Purpose**: Wrapper for [`addStaticLibEx`](#addstaticlibex), assuming there is no aliasing and no list of libraries to link. Creates a static library, setting sources and options, importing, and auto-linking the AREG Framework library.
 - **Parameters**:
   - `target_name` [in]: Name of the static library to build.
   - `source_list` [in]: List of source files to build the static library.
@@ -268,14 +268,14 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Purpose**: Creates a static library compiled with C, setting sources, importing, and auto-linking the AREG Framework library along with any additional libraries.
 - **Parameters**:
   - `target_name` [in]: Name of the static library to build.
-  - `target_namespace` [in]: Namespace of the target, used for aliasing (pass an empty string if no aliasing is needed).
+  - `target_namespace` [in]: Namespace for aliasing. Pass empty string if no aliasing.
   - `source_list` [in]: List of C-source files to build the static library.
   - `library_list` [in]: Libraries to link with the static library.
 - **Usage**: `addStaticLibEx_C(<target-name> <namespace-opt> <C-source-list> <library-list>)`
 
 ### `addStaticLib_C`
 - **Syntax**: `addStaticLib_C(target_name source_list)`
-- **Purpose**: Creates a static library compiled with C, setting sources, importing, and auto-linking the AREG Framework library.
+- **Purpose**: Wrapper for [`addStaticLibEx_C`](#addstaticlibex_c), assuming there is no aliasing and list of libraries for linking. Creates a static library compiled with C, setting sources, importing, and auto-linking the AREG Framework library.
 - **Parameters**:
   - `target_name` [in]: Name of the static library to build.
   - `source_list` [in]: List of C-source files to build the static library.
@@ -292,16 +292,16 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 ### `addSharedLibEx`
 - **Syntax**: `addSharedLibEx(target_name target_namespace source_list library_list)`
 - **Purpose**: Creates a shared library with specified source files and options, importing and auto-linking the AREG Framework library along with any additional libraries.
-- **Parameters**:
+- **Parameters**: 
   - `target_name` [in]: Name of the shared library to build.
-  - `target_namespace` [in]: Namespace of the target, used for aliasing (pass an empty string if no aliasing is needed).
+  - `target_namespace` [in]: Namespace for aliasing. Can be empty string if no aliasing.
   - `source_list` [in]: List of source files to build the shared library.
   - `library_list` [in]: Libraries for linking.
 - **Usage**: `addSharedLibEx(<target-name> <namespace-opt> <source-list> <library-list>)`
 
 ### `addSharedLib`
 - **Syntax**: `addSharedLib(target_name source_list)`
-- **Purpose**: Creates a shared library with specified sources, options, imports, and auto-linking the AREG Framework library.
+- **Purpose**: Wrapper for [`addSharedLibEx`](#addsharedlibex), assuming there is no aliasing and no list for linking. Creates a shared library with specified sources, options, imports, and auto-linking the AREG Framework library.
 - **Parameters**:
   - `target_name` [in]: Name of the shared library to build.
   - `source_list` [in]: List of source files to build the shared library.
@@ -309,7 +309,7 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 
 ### `addServiceInterfaceEx`
 - **Syntax**: `addServiceInterfaceEx(lib_name source_root relative_path sub_dir interface_name)`
-- **Purpose**: Generates code and includes files for a Service Interface document (`.siml`) in a static library.
+- **Purpose**: Wrapper for [`macro_add_service_interface`](#macro_add_service_interface), assuming that the root directory for code generation is `AREG_BUILD_ROOT` and generated files are located in the `${AREG_GENERATE}/${relative_path}`. Generates code and includes files for a Service Interface document (`.siml`) in a static library.
 - **Parameters**:
   - `lib_name` [in]: Static library name.
   - `source_root` [in]: Source root directory.
@@ -324,10 +324,10 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 
 ### `addServiceInterface`
 - **Syntax**: `addServiceInterface(lib_name sub_dir interface_name)`
-- **Purpose**: A wrapper for `addServiceInterfaceEx`, assuming the source root as `CMAKE_SOURCE_DIR` and the relative path as `CMAKE_CURRENT_LIST_DIR`.
+- **Purpose**: A wrapper for [`addServiceInterfaceEx`](#addserviceinterfaceex), assuming the source root as `CMAKE_SOURCE_DIR` and the Service Interface document is located relative to+ `CMAKE_CURRENT_LIST_DIR`.
 - **Parameters**:
   - `lib_name` [in]: Static library name.
-  - `sub_dir` [in]: Optional sub-directory (can be empty).
+  - `sub_dir` [in]: Optional sub-directory, where the Service Interface document is located. Can be empty.
   - `interface_name` [in]: Service Interface name (excluding `.siml` extension).
 - **Usage**: `addServiceInterface(<library-name> <sub-dir-opt> <service-interface-name>)`
 

--- a/docs/wiki/cmake-functions.md
+++ b/docs/wiki/cmake-functions.md
@@ -1,59 +1,92 @@
-# AREG SDK CMake Functions and Macro
+# AREG SDK CMake Functions and Macros
 
-The [functions.cmake](./../../conf/cmake/functions.cmake) ile in AREG SDK includes custom CMake functions and macros that streamline configuration for projects built on the AREG Framework. Below is a breakdown of each function, highlighting its purpose, usage, and parameters.
+The [functions.cmake](./../../conf/cmake/functions.cmake) file in AREG SDK contains custom CMake functions and macros to streamline project configuration for those built on the AREG Framework. This document provides a detailed overview of each function, its purpose, syntax, parameters, and usage examples.
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [CMake Macro Overview](#cmake-macro-overview)
+  - [`macro_check_fix_areg_cxx_standard`](#macro_check_fix_areg_cxx_standard)
+  - [`macro_normalize_path`](#macro_normalize_path)
+  - [`macro_add_service_interface`](#macro_add_service_interface)
+  - [`macro_find_package`](#macro_find_package)
+  - [`macro_create_option`](#macro_create_option)
+  - [`macro_add_source`](#macro_add_source)
+  - [`macro_parse_arguments`](#macro_parse_arguments)
+  - [`macro_declare_static_library`](#macro_declare_static_library)
+  - [`macro_declare_shared_library`](#macro_declare_shared_library)
+  - [`macro_declare_executable`](#macro_declare_executable)
+  - [`macro_setup_compilers_data`](#macro_setup_compilers_data)
+  - [`macro_setup_compilers_data_by_family`](#macro_setup_compilers_data_by_family)
+- [CMake Functions Overview](#cmake-functions-overview)
+  - [`setAppOptions`](#setappoptions)
+  - [`addExecutableEx`](#addexecutableex)
+  - [`addExecutable`](#addexecutable)
+  - [`setStaticLibOptions`](#setstaticliboptions)
+  - [`addStaticLibEx`](#addstaticlibex)
+  - [`addStaticLib`](#addstaticlib)
+  - [`addStaticLibEx_C`](#addstaticlibex_c)
+  - [`addStaticLib_C`](#addstaticlib_c)
+  - [`setSharedLibOptions`](#setsharedliboptions)
+  - [`addSharedLibEx`](#addsharedlibex)
+  - [`addSharedLib`](#addsharedlib)
+  - [`addServiceInterfaceEx`](#addserviceinterfaceex)
+  - [`addServiceInterface`](#addserviceinterface)
+  - [`removeEmptyDirs`](#removeemptydirs)
+  - [`printAregConfigStatus`](#printaregconfigstatus)
 
 ---
 
 ## Introduction
 
-The [functions.cmake](./../../conf/cmake/functions.cmake)  contains reusable CMake utilities designed to simplify repetitive tasks, supporting a cleaner, more maintainable project setup.
+The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable CMake utilities that simplify repetitive tasks, making project setup cleaner and more maintainable.
 
-> [!IMPORTANT]
-> Include [setup.cmake](./../../conf/cmake/setup.cmake) (not functions.cmake) in `CMakeLists.txt` files to ensure proper AREG Framework integration, after setting `AREG_SDK_ROOT` to the `<areg-sdk>` installation directory. More details about integration are described in the [AREG Framework Integration](./cmake-integrate.md) document of AREG SDK Wiki.
+> [!NOTE]
+> Include [areg.cmake](./../../conf/cmake/areg.cmake) (not functions.cmake) in `CMakeLists.txt` files to ensure proper AREG Framework integration after setting `AREG_SDK_ROOT` to the `<areg-sdk>` installation directory. More details can be found in the [AREG Framework Integration](./cmake-integrate.md) document in the AREG SDK Wiki.
 
 ---
 
 ## CMake Macro Overview
 
-### macro_check_fix_areg_cxx_standard
+### `macro_check_fix_areg_cxx_standard`
 - **Syntax**: `macro_check_fix_areg_cxx_standard()`
-- **Purpose**: Validates and sets C++ standard compatibility. The variable 'AREG_CXX_STANDARD' must be defined before calling this macro.
-- **Details**: Ensures `CMAKE_CXX_STANDARD` matches `AREG_CXX_STANDARD`. If incompatible, outputs a warning.
+- **Purpose**: Validates and sets the C++ standard compatibility. The variable `AREG_CXX_STANDARD` must be defined before calling this macro.
+- **Details**: Ensures `CMAKE_CXX_STANDARD` matches `AREG_CXX_STANDARD`. Outputs a warning if incompatible.
 - **Usage**: `macro_check_fix_areg_cxx_standard()`
 
-### macro_normalize_path
+### `macro_normalize_path`
 - **Syntax**: `macro_normalize_path(normal_path os_path)`
-- **Purpose**: Normalizes Windows paths to Cygwin format if applicable.
+- **Purpose**: Normalizes Windows paths to Cygwin format, if applicable.
 - **Note**: This macro does not address OS-specific path separator issues.
 - **Parameters**:
-  - `normal_path` [out]: Path normalized.
-  - `os_path` [in]: Windows specific path to normalize.
+  - `normal_path` [out]: The normalized path.
+  - `os_path` [in]: The Windows-specific path to normalize.
 - **Usage**: `macro_normalize_path(<out-var> <windows-path>)`
 
-### macro_add_service_interface
+### `macro_add_service_interface`
 - **Syntax**: `macro_add_service_interface(interface_doc codegen_root output_path codegen_tool)`
-- **Purpose**: From the given Service Interface document file (`*.siml`), generates and adds service specific files to a static library..
+- **Purpose**: Generates and adds service-specific files to a static library based on a given Service Interface document (`*.siml`).
 - **Parameters**:
   - `lib_name` [in]: Name of the static library.
-  - `interface_doc` [in]:Full path to the Service Interface document file (`.siml`). 
-  - `codegen_root` [in]: Root directory to generate files.
-  - `output_path` [in]: Relative path to generate files.
+  - `interface_doc` [in]: Full path to the Service Interface document file (`.siml`).
+  - `codegen_root` [in]: Root directory for file generation.
+  - `output_path` [in]: Relative path for generated files.
   - `codegen_tool` [in]: Full path to the code generator tool.
 - **Usage**: `macro_add_service_interface(<name-lib> <full-path-siml> <root-gen> <relative-path> <codegen-tool>)`
-- **Example:
+- **Example**:
    ```cmkae
    macro_add_service_interface(funlib "~/project/fun/src/service/HelloWorld.siml" "~/project/fun/product" "generate/service" /tools/areg/codegen.jar)
    macro_add_service_interface(funlib "~/project/fun/src/service/WeHaveFun.siml"  "~/project/fun/product" "generate/service" /tools/areg/codegen.jar)
    ```
 
-### macro_find_package
+### `macro_find_package`
 - **Syntax**: `macro_find_package(package_name package_found package_includes package_libraries)`
-- **Purpose**: Finds a package, returning paths to includes and libraries if found.
+- **Purpose**: Finds a package and returns paths to its includes and libraries if found.
 - **Parameters**:
-  - `package_name` [in]: package name to search.
-  - `package_found` [out]: Variable to hold package found flag.
-  - `package_includes` [out]: Variable to hold package's include directories.
-  - `package_libraries` [out]: Variable to hold package's libraries.
+  - `package_name` [in]: Name of the package to search for.
+  - `package_found` [out]: Variable indicating if the package was found.
+  - `package_includes` [out]: Variable holding the package's include directories.
+  - `package_libraries` [out]: Variable holding the package's libraries.
 - **Usage**: `macro_find_package(<package-name> <found-flag-var> <includes-var> <libraries-var>)`
 - **Example**:
    ```cmake
@@ -61,26 +94,26 @@ The [functions.cmake](./../../conf/cmake/functions.cmake)  contains reusable CMa
    macro_find_package(SQLite3 SQLITE_FOUND SQLITE_INCLUDE SQLITE_LIB)
    ```
 
-### macro_create_option
+### `macro_create_option`
 - **Syntax**: `macro_create_option(var_name var_value var_describe)`
 - **Purpose**: Creates a boolean cache variable with a default value.
-- **Parameters**: 
+- **Parameters**:
   - `var_name` [out]: Name of the boolean variable.
   - `var_value` [in]: Default value if the variable is not yet defined.
-  - `var_describe` [in]: A brief Purpose of the variable for CMake cache.
+  - `var_describe` [in]: Description of the variable for the CMake cache.
 - **Usage**: `macro_create_option(<name-var> <default-value> <describe>)`
 - **Example**:
    ```cmake
    macro_create_option(AREG_LOGS ON "Compile with logs")
    ```
 
-### macro_add_source
+### `macro_add_source`
 - **Syntax**: `macro_add_source(result_list src_base_dir ...)`
-- **Purpose**: Adds existing source files to a list based on a base directory. Checks the file existence.
+- **Purpose**: Adds existing source files to a list based on a base directory. Checks file existence.
 - **Parameters**:
   - `result_list` [in, out]: List of source files.
   - `src_base_dir` [in]: Base directory of the source files.
-  - `${ARGN}` [in]: List of source files (should be relative to the base directory).
+  - `${ARGN}` [in]: List of source files, relative to the base directory.
 - **Usage**: `macro_add_source(<src-list-var> <base-dirpath> <files>)`
 - **Example**:
    ```cmake
@@ -88,87 +121,87 @@ The [functions.cmake](./../../conf/cmake/functions.cmake)  contains reusable CMa
    macro_add_source(aregextend_SRC "${AREG_FRAMEWORK}" aregextend/db/private/LogSqliteDatabase.cpp ...)
    ```
 
-### macro_parse_arguments
+### `macro_parse_arguments`
 - **Syntax**: `macro_parse_arguments(res_sources res_libs res_resources)`
-- **Purpose**: Parses files and libraries into separate lists for sources, libraries, and resources. The library names should match the name of any known targets. The resource files should have `.rc` extension (Windows specific), source files should have `.cpp`, `.cxx` or `.c` file extension, and should exist on file system.
+- **Purpose**: Parses files and libraries into separate lists for sources, libraries, and resources. Library names must match known targets. Resource files should have `.rc` extension (Windows-specific).
 - **Note**:
-  - Throws an error if file with relative or path does not exist.
-  - The resource file with extension `.rc` is relevant only to the Windows system. On other systems it will be considered as a source file.
+  - Throws an error if file does not exist.
+  - List of resource files is Windows specific, it contains files with extension `.rc`.
 - **Parameters**:
   - `res_sources` [out]: List of source files.
-  - `res_libs` [out]: List containing the recognized CMake targets.
-  - `res_resources` [out]: List of identified resource files (*.rc).
-  - `${ARGN}` [in]: List of files with relative or full path, libraries, or resources to categorize.
+  - `res_libs` [out]: List of recognized CMake targets.
+  - `res_resources` [out]: List of resource files (`*.rc`).
+  - `${ARGN}` [in]: List of files, libraries, or resources to categorize.
 - **Usage**: `macro_parse_arguments(<sources-var> <libs-var> <resources-var> <sources-targets-resources>)`
 - **Example**:    
    ```cmake
    macro_parse_arguments(src_files lib_targets res_files my_lib src/main.cpp src/object.cpp res/resource.rc)
    ```
 
-### macro_declare_static_library
+### `macro_declare_static_library`
 - **Syntax**: `macro_declare_static_library(lib_name ...)`
-- **Purpose**: Declares a static library with categorized sources, libraries, and resources. It splits the list of files using **[macro_parse_arguments](#macro_parse_arguments)** macro and declares new static library target. The detected targets are used to link the libraries.
+- **Purpose**: Declares a static library with categorized sources, libraries, and resources using **[macro_parse_arguments](#macro_parse_arguments)**.
 - **Parameters**:
-  - `lib_name` [in]: Name of the static library to declare.
-  - `${ARGN}` [in]: List of source files, libraries, and resource files.
+  - `lib_name` [in]: Name of the static library.
+  - `${ARGN}` [in]: List of source files, libraries, and resources.
 - **Usage**: `macro_declare_static_library(<lib-name> <sources-targets-resources>)`
 - **Example**:
    ```cmake
    macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
    ```
 
-### macro_declare_shared_library
+### `macro_declare_shared_library`
 - **Syntax**: `macro_declare_shared_library(lib_name ...)`
-- **Purpose**: Similar to **[macro_declare_static_library](#macro_declare_static_library)**, for shared libraries. The detected targets are used to link the libraries.
+- **Purpose**: Declares a shared library with categorized sources, libraries, and resources using **[macro_parse_arguments](#macro_parse_arguments)**.
 - **Parameters**:
-  - `lib_name` [in]: Name of the shared library to be declared.
-  - `${ARGN}` [in]: List of source files, libraries, and resource files. Files can be specified with full or relative paths.
+  - `lib_name` [in]: Name of the shared library.
+  - `${ARGN}` [in]: List of source files, libraries, and resources.
 - **Usage**: `macro_declare_shared_library(<lib-name> <sources-targets-resources>)`
 - **Example**:
    ```cmake
    macro_declare_shared_library(mySharedLib src/main.cpp src/resource.rc libSomeDependency)
    ```
 
-### macro_declare_executable
+### `macro_declare_executable`
 - **Syntax**: `macro_declare_executable(exe_name ...)`
-- **Purpose**: Declares an executable with categorized sources, libraries, and resources. It splits the list of files using **[macro_parse_arguments](#macro_parse_arguments)** macro and declares new executable target. The list of detected targets is used to link the libraries.
+- **Purpose**: Declares an executable target with categorized sources, libraries, and resources using **[macro_parse_arguments](#macro_parse_arguments)**.
 - **Parameters**:
-  - `exe_name` [in]: Name of the executable to be declared.
-  - `${ARGN}` [in]: List of source files, libraries, and resource files. Files can be specified with full or relative paths.
+  - `exe_name` [in]: Name of the executable.
+  - `${ARGN}` [in]: List of source files, libraries, and resources.
 - **Usage**: `macro_declare_executable(<executable-name> <sources-targets-resources>)`
 - **Example**:
    ```cmake
    macro_declare_executable(myApplication src/main.cpp src/resource.rc libSomeDependency)
    ```
 
-### macro_setup_compilers_data
+### `macro_setup_compilers_data`
 - **Syntax**: `macro_setup_compilers_data(compiler_path compiler_family compiler_short compiler_cxx compiler_c is_identified)`
-- **Purpose**: Identifies and sets up compiler family, short names and paths, `compiler_supports` variable stores the flag if compiler is supported by AREG SDK.
+- **Purpose**: Identifies and configures compiler family, short names, and paths.
 - **Note**: Beside "gnu", "llvm", "msvc", the GNU compilers for CYGWIN are included as a "cygwin" family.
-- **Parameters**: 
-  - `compiler_path` [in]: Name or full path of the C++ compiler.
-  - `compiler_family` [out]: Variable to hold identified compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
-  - `compiler_short` [out]: Variable to hold short name of the compiler (e.g., "gcc", "clang").
-  - `compiler_cxx` [out]: Variable to hold C++ compiler name or path (usually same as ${compiler_path}).
-  - `compiler_c` [out]: Variable to hold corresponding C compiler name or path.
-  - `is_identified` [out]: Variable to hold Boolean flag indicating if the compiler was successfully identified ("TRUE" or "FALSE").
+- **Parameters**:
+  - `compiler_path` [in]: Path to the C++ compiler.
+  - `compiler_family` [out]: Compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
+  - `compiler_short` [out]: Short name of the compiler (e.g., "gcc", "clang", "cl").
+  - `compiler_cxx` [out]: C++ compiler path.
+  - `compiler_c` [out]: C compiler path.
+  - `is_identified` [out]: Boolean indicating successful identification.
 - **Usage**: `macro_setup_compilers_data(<compiler> <compiler-family-var> <compiler-short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)`
 - **Example**:
    ```cmakr
    macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" AREG_COMPILER_FAMILY AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _is_identified)
    ```
 
-### macro_setup_compilers_data_by_family
+### `macro_setup_compilers_data_by_family`
 - **Syntax**: `macro_setup_compilers_data_by_family(compiler_family compiler_short compiler_cxx compiler_c is_identified)`
-- **Purpose**: Configures compiler names based on family (e.g., gnu, msvc, llvm, cygwin). Make sure that the compiler path is included in PATH environment variable.
+- **Purpose**: Configures compiler names based on family (e.g., gnu, msvc, llvm, cygwin).
 - **Note**: The "cygwin" family is supported for GNU compilers on the CYGWIN platform in Windows.
-- **Parameters**: 
-  - `compiler_family` [in]: Name of the compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
-  - `compiler_short` [out]: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
-  - `compiler_cxx` [out]: Variable to hold the C++ compiler name or path.
-  - `compiler_c` [out]: Variable to hold the corresponding C compiler name.
-  - `is_identified` [out]: Variable to hold Boolean flag indicating whether the compiler was successfully identified ("TRUE" or "FALSE").
-- **Usage**: `macro_setup_compilers_data_by_family(<compiler-family> <compiler-short-var> <CXX-compiler-vat> <C-compiler-vat> <identified-var>)`
+- **Parameters**:
+  - `compiler_family` [in]: Compiler family name (e.g., "gnu", "msvc").
+  - `compiler_short` [out]: Short name of the compiler (e.g., "gcc", "clang", "cl").
+  - `compiler_cxx` [out]: C++ compiler path.
+  - `compiler_c` [out]: C compiler path.
+  - `is_identified` [out]: Boolean indicating successful identification.
+- **Usage**: `macro_setup_compilers_data_by_family(<compiler-family> <compiler-short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)`
 - **Example**:
    ```cmake
    macro_setup_compilers_data_by_family("gnu" AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _is_identified)
@@ -178,145 +211,145 @@ The [functions.cmake](./../../conf/cmake/functions.cmake)  contains reusable CMa
 
 ## CMake Functions Overview
 
-### setAppOptions
+### `setAppOptions`
 - **Syntax**: `setAppOptions(target_name library_list)`
-- **Purpose**: Configures compiler and linker settings for an application target, imports and auto-linking the AREG Framework library and any additional libraries.
+- **Purpose**: Configures compiler and linker settings for an application target, automatically linking the AREG Framework library along with additional specified libraries.
 - **Parameters**:
-  - `target_name` [in]: Name of the target application to apply options to.
-  - `library_list` [in]: List of additional libraries to link with the target application.
+  - `target_name` [in]: The target application.
+  - `library_list` [in]: Additional libraries to link.
 - **Usage**: `setAppOptions(<target-name> <library-list>)`
 
-### addExecutableEx
+### `addExecutableEx`
 - **Syntax**: `addExecutableEx(target_name target_namespace source_list library_list)`
-- **Purpose**: Creates an executable target, setting sources, options, imports and auto-linking the AREG Framework library and any additional libraries.
+- **Purpose**: Creates an executable target with specified source files and libraries.
 - **Parameters**:
-  - `target_name` [in]: Name of the target executable to build.
-  - `target_namespace` [in]: Namespace of the target, used for aliasing. Pass empty string if has no aliasing.
+  - `target_name` [in]: The name of the executable target.
+  - `target_namespace` [in]: Namespace for aliasing.
   - `source_list` [in]: List of source files used to build the target executable.
-  - `library_list` [in]: List of libraries to link with the executable.
-- **Usage**: `addExecutableEx(<target-name> <namespace-opt> <sources-list> <libraries-list>)`
+  - `library_list` [in]: Libraries to link with the executable.
+- **Usage**: `addExecutableEx(<target-name> <namespace-opt> <source-list> <library-list>)`
 
-### addExecutable
+### `addExecutable`
 - **Syntax**: `addExecutable(target_name source_list)`
-- **Purpose**: Creates an executable target, setting sources, options, imports and auto-linking the AREG library.
+- **Purpose**: Creates an executable target, setting up sources, options, and imports, and auto-linking the AREG Framework library.
 - **Parameters**:
   - `target_name` [in]: Name of the executable to build.
   - `source_list` [in]: List of source files used to build the executable.
-- **Usage**: `addExecutable(<target-name> <sources-list>)`
+- **Usage**: `addExecutable(<target-name> <source-list>)`
 
-### setStaticLibOptions
+### `setStaticLibOptions`
 - **Syntax**: `setStaticLibOptions(target_name library_list)`
-- **Purpose**: Configures compiler and linker settings for a static library, imports and auto-linking the AREG Framework library and any additional libraries.
+- **Purpose**: Configures compiler and linker settings for a static library, automatically linking the AREG Framework library along with any additional specified libraries.
 - **Parameters**:
   - `target_name` [in]: Name of the static library to apply options to.
   - `library_list` [in]: List of libraries to link with the static library.
-- **Usage **: `setStaticLibOptions(<target-name> <libraries-list>)` 
+- **Usage**: `setStaticLibOptions(<target-name> <library-list>)`
 
-### addStaticLibEx
+### `addStaticLibEx`
 - **Syntax**: `addStaticLibEx(target_name target_namespace source_list library_list)`
-- **Purpose**: Creates a static library, applying specified sources and options, imports and auto-linking the AREG Framework library and any additional libraries.
-- **Parameters**
+- **Purpose**: Creates a static library with specified source files and options, importing and auto-linking the AREG Framework library along with any additional libraries.
+- **Parameters**:
   - `target_name` [in]: Name of the static library to build.
-  - `target_namespace` [in]: Namespace of the target, used for aliasing. Pass empty string if has no aliasing.
+  - `target_namespace` [in]: Namespace of the target, used for aliasing (pass an empty string if no aliasing is needed).
   - `source_list` [in]: List of source files to build the static library.
-  - `library_list` [in]: List of libraries for linking.
-- **Usage**: `addStaticLibEx(<target-name> <namespace-opt> <sources-list> <libraries-list>)`
+  - `library_list` [in]: List of libraries to link.
+- **Usage**: `addStaticLibEx(<target-name> <namespace-opt> <source-list> <library-list>)`
 
-### addStaticLib
+### `addStaticLib`
 - **Syntax**: `addStaticLib(target_name source_list)`
-- **Purpose**: Creates a static library, applying specified sources and options, imports and auto-linking the AREG Framework library.
-- **Parameters**
+- **Purpose**: Creates a static library, setting sources and options, importing, and auto-linking the AREG Framework library.
+- **Parameters**:
   - `target_name` [in]: Name of the static library to build.
   - `source_list` [in]: List of source files to build the static library.
-- **Usage**: `addStaticLib(<target-name> <sources-list>)`
+- **Usage**: `addStaticLib(<target-name> <source-list>)`
 
-### addStaticLibEx_C
+### `addStaticLibEx_C`
 - **Syntax**: `addStaticLibEx_C(target_name target_namespace source_list library_list)`
-- **Purpose**: Creates a static library compiled with C, setting sources, imports and auto-linking the AREG Framework library and any additional libraries.
+- **Purpose**: Creates a static library compiled with C, setting sources, importing, and auto-linking the AREG Framework library along with any additional libraries.
 - **Parameters**:
   - `target_name` [in]: Name of the static library to build.
-  - `target_namespace` [in]: Namespace of the target, used for aliasing. Pass empty string if has no aliasing.
-  - `source_list` [in]: List of C-code source files to build the static library.
-  - `library_list` [in]: List of libraries to link with the static library.
-- **Usage**: `addStaticLibEx_C(<target-name> <namespace-opt> <C-sources-list> <libraries-list>)`
+  - `target_namespace` [in]: Namespace of the target, used for aliasing (pass an empty string if no aliasing is needed).
+  - `source_list` [in]: List of C-source files to build the static library.
+  - `library_list` [in]: Libraries to link with the static library.
+- **Usage**: `addStaticLibEx_C(<target-name> <namespace-opt> <C-source-list> <library-list>)`
 
-### addStaticLib_C
+### `addStaticLib_C`
 - **Syntax**: `addStaticLib_C(target_name source_list)`
-- **Purpose**: Creates a static library compiled with C, setting sources, imports and auto-linking the AREG Framework library.
+- **Purpose**: Creates a static library compiled with C, setting sources, importing, and auto-linking the AREG Framework library.
 - **Parameters**:
   - `target_name` [in]: Name of the static library to build.
-  - `source_list` [in]: List of C-code source files to build the static library.
-- **Usage**: `addStaticLib_C(<target-name> <C-sources-list>)`
+  - `source_list` [in]: List of C-source files to build the static library.
+- **Usage**: `addStaticLib_C(<target-name> <C-source-list>)`
 
-### setSharedLibOptions
-- **Syntax**: `setSharedLibOptions(item_name library_list)`
-- **Purpose**: Configures settings for a shared library, imports and auto-linking the AREG Framework library and any additional libraries.
+### `setSharedLibOptions`
+- **Syntax**: `setSharedLibOptions(target_name library_list)`
+- **Purpose**: Configures settings for a shared library, automatically linking the AREG Framework library and any additional specified libraries.
 - **Parameters**:
   - `target_name` [in]: Name of the shared library to apply options to.
   - `library_list` [in]: List of libraries for linking.
-- **Usage**: `setSharedLibOptions(<target-name> <libraries-list>)`
+- **Usage**: `setSharedLibOptions(<target-name> <library-list>)`
 
-### addSharedLibEx
+### `addSharedLibEx`
 - **Syntax**: `addSharedLibEx(target_name target_namespace source_list library_list)`
-- **Purpose**: Creates a shared library, setting sources, options, imports and auto-linking the AREG Framework library and any additional libraries.
+- **Purpose**: Creates a shared library with specified source files and options, importing and auto-linking the AREG Framework library along with any additional libraries.
 - **Parameters**:
   - `target_name` [in]: Name of the shared library to build.
-  - `target_namespace` [in]: Namespace of the target, used for aliasing. Pass empty string if has no aliasing.
+  - `target_namespace` [in]: Namespace of the target, used for aliasing (pass an empty string if no aliasing is needed).
   - `source_list` [in]: List of source files to build the shared library.
-  - `library_list` [in]: List of libraries for linking.
-- **Usage**: `addSharedLibEx(<target-name> <namespace-opt> <sources-list> <libraries-list>)`
+  - `library_list` [in]: Libraries for linking.
+- **Usage**: `addSharedLibEx(<target-name> <namespace-opt> <source-list> <library-list>)`
 
-### addSharedLib
+### `addSharedLib`
 - **Syntax**: `addSharedLib(target_name source_list)`
-- **Purpose**: Creates a shared library, setting sources, options, imports and auto-linking the AREG Framework library.
+- **Purpose**: Creates a shared library with specified sources, options, imports, and auto-linking the AREG Framework library.
 - **Parameters**:
   - `target_name` [in]: Name of the shared library to build.
-  - `source_list` [in]: List of source files to build shared library.
-- **Usage**: `addSharedLib(<target-name> <sources-list>)`
+  - `source_list` [in]: List of source files to build the shared library.
+- **Usage**: `addSharedLib(<target-name> <source-list>)`
 
-### addServiceInterfaceEx
+### `addServiceInterfaceEx`
 - **Syntax**: `addServiceInterfaceEx(lib_name source_root relative_path sub_dir interface_name)`
-- **Purpose**: From given Service Interface document file (`.siml`), generates codes and includes files in a static library.
-- **Parameters**
+- **Purpose**: Generates code and includes files for a Service Interface document (`.siml`) in a static library.
+- **Parameters**:
   - `lib_name` [in]: Static library name.
   - `source_root` [in]: Source root directory.
-  - `relative_path` [in]: Service Interface relative file path.
-  - `sub_dir` [in]: Optional sub-directory within the `relative_path`.
-  - `interface_name` [in]: Service Interface name (without `.siml` extension).
+  - `relative_path` [in]: Relative path to the Service Interface file.
+  - `sub_dir` [in]: Optional sub-directory within `relative_path`.
+  - `interface_name` [in]: Service Interface name (excluding `.siml` extension).
 - **Usage**: `addServiceInterfaceEx(<library-name> <source-root> <relative-path> <sub-dir-opt> <service-interface-name>)`
 - **Example**:
    ```cmake
-   addServiceInterfaceEx("fun_library" "/home/develop/project/my-fun/sources" "my/service/interfaces" "" FunInterface)
+   addServiceInterfaceEx("fun_library" "/home/develop/project/fun/src" "my/service/interfaces" "" FunInterface)
    ```
 
-### addServiceInterface
+### `addServiceInterface`
 - **Syntax**: `addServiceInterface(lib_name sub_dir interface_name)`
-- **Purpose**: A wrapper for addServiceInterfaceEx, assuming the source root as `CMAKE_SOURCE_DIR` and relative path as `CMAKE_CURRENT_LIST_DIR`.
+- **Purpose**: A wrapper for `addServiceInterfaceEx`, assuming the source root as `CMAKE_SOURCE_DIR` and the relative path as `CMAKE_CURRENT_LIST_DIR`.
 - **Parameters**:
   - `lib_name` [in]: Static library name.
-  - `sub_dir` [in]: Optional sub-directory. Can by empty.
-  - `interface_name` [in]: Service Interface name (without `.siml` extension).
+  - `sub_dir` [in]: Optional sub-directory (can be empty).
+  - `interface_name` [in]: Service Interface name (excluding `.siml` extension).
 - **Usage**: `addServiceInterface(<library-name> <sub-dir-opt> <service-interface-name>)`
 
-### removeEmptyDirs
+### `removeEmptyDirs`
 - **Syntax**: `removeEmptyDirs(dir_name)`
-- **Purpose**: Recursively removes empty directories.
+- **Purpose**: Recursively removes empty directories within the specified directory path.
 - **Parameters**:
   - `dir_name` [in]: Directory path to check and potentially remove.
 - **Usage**: `removeEmptyDirs(<dir-path>)`
 
-### printAregConfigStatus
+### `printAregConfigStatus`
 - **Syntax**: `printAregConfigStatus(var_make_print var_prefix var_header var_footer)`
-- **Purpose**: Prints a detailed status of AREG's CMake configuration, including build environment details.
+- **Purpose**: Prints a detailed status of AREG's CMake configuration, including details of the build environment.
 - **Parameters**: 
-  - `var_make_print` [in]: Boolean flag indicating whether to print the status message. If FALSE, the function exits without printing.
+  - `var_make_print` [in]: Boolean flag indicating whether to print the status message (if FALSE, the function exits without printing).
   - `var_prefix` [in]: A prefix added to each line of the status message (e.g., project name or custom label).
   - `var_header` [in]: A custom header message displayed at the beginning of the status report.
   - `var_footer` [in]: A custom footer message displayed at the end of the status report.
 - **Usage**: `printAregConfigStatus(<flag-to-print> <prefix> <header-output> <footer-output>)`
 - **Example**: 
    ```cmake
-   printAregConfigStatus(TRUE "AREG"
+    printAregConfigStatus(TRUE "AREG"
                         "----------------------> AREG project CMake Status Report Begin <-----------------------"
                         "-----------------------> AREG project CMake Status Report End <------------------------"
                         )

--- a/docs/wiki/cmake-functions.md
+++ b/docs/wiki/cmake-functions.md
@@ -1,95 +1,87 @@
 # AREG SDK CMake Functions and Macro
 
-The [functions.cmake](./../../conf/cmake/functions.cmake) file in the AREG SDK repository contains a set of custom CMake functions and macros that streamline project configuration tasks for building projects based on AREG Framework. Below is a detailed breakdown of each function and macro, including their purposes and usage.
+The [functions.cmake](./../../conf/cmake/functions.cmake) ile in AREG SDK includes custom CMake functions and macros that streamline configuration for projects built on the AREG Framework. Below is a breakdown of each function, highlighting its purpose, usage, and parameters.
 
 ---
 
 ## Introduction
 
-This file offers reusable CMake functions and macros, designed to simplify repetitive tasks in CMake configuration. By including this file, developers can leverage pre-built utilities for complex configuration, ensuring a cleaner and more maintainable CMake setup.
-
-
-The [functions.cmake](./../../conf/cmake/functions.cmake) file provides reusable CMake utilities to simplify and improve the configuration of projects, which use AREG Framework. The developers can use functions and macro declared in `functions.cmake` by including [setup.cmake](./../../conf/cmake/setup.cmake) file in their project in their project to ensure consistent and efficient project setup.
+The [functions.cmake](./../../conf/cmake/functions.cmake)  contains reusable CMake utilities designed to simplify repetitive tasks, supporting a cleaner, more maintainable project setup.
 
 > [!IMPORTANT]
-> It is recommended to include the file `setup.cmake` in the `CMakeLists.txt` files instead of including `functions.cmake` to reuse functions and marco, and integrate AREG Framework properly. Before including the file, set the `AREG_SDK_ROOT` CMake variable indicating the location of `<areg-sdk>` installation directory. More details about integration are described in the [AREG Framework Integration](./cmake-integrate.md) document of AREG SDK Wiki.
+> Include [setup.cmake](./../../conf/cmake/setup.cmake) (not functions.cmake) in `CMakeLists.txt` files to ensure proper AREG Framework integration, after setting `AREG_SDK_ROOT` to the `<areg-sdk>` installation directory. More details about integration are described in the [AREG Framework Integration](./cmake-integrate.md) document of AREG SDK Wiki.
 
 ---
 
-## AREG Framework CMake Macro
-
-Following are the CMake macro with description that can be used by developers:
+## CMake Macro Overview
 
 ### macro_check_fix_areg_cxx_standard
-
-- **Macro**: macro_check_fix_areg_cxx_standard
-- **Description**: Checks and sets the C++ standard for the project. The variable 'AREG_CXX_STANDARD' must be defined before calling this macro. If 'CMAKE_CXX_STANDARD' is not set, it will be assigned the value of 'AREG_CXX_STANDARD'. If 'CMAKE_CXX_STANDARD' is lower than 'AREG_CXX_STANDARD', a warning is displayed.
-- **Macro Usage**: macro_check_fix_areg_cxx_standard()
+- **Syntax**: `macro_check_fix_areg_cxx_standard()`
+- **Purpose**: Validates and sets C++ standard compatibility. The variable 'AREG_CXX_STANDARD' must be defined before calling this macro.
+- **Details**: Ensures `CMAKE_CXX_STANDARD` matches `AREG_CXX_STANDARD`. If incompatible, outputs a warning.
+- **Usage**: `macro_check_fix_areg_cxx_standard()`
 
 ### macro_normalize_path
-- **Macro**: macro_normalize_path(normal_path os_path)
-- **Description**: Converts Windows-specific paths to Cygwin format if running under Cygwin. Otherwise, the path remains unchanged.
+- **Syntax**: `macro_normalize_path(normal_path os_path)`
+- **Purpose**: Normalizes Windows paths to Cygwin format if applicable.
 - **Note**: This macro does not address OS-specific path separator issues.
 - **Parameters**:
-  - *normal_path* [out]: The normalized path.
-  - *os_path* [in]: The OS-specific path to normalize.
-- **Macro Usage**: *macro_normalize_path(<result_variable> <OS specific path>)*
+  - `normal_path` [out]: Path normalized.
+  - `os_path` [in]: Windows specific path to normalize.
+- **Usage**: `macro_normalize_path(<out-var> <windows-path>)`
 
 ### macro_add_service_interface
-
-- **Macro**: macro_add_service_interface(lib_name interface_doc interface_name codegen_root output_path codegen_tool)
-- **Description**: This function invokes the service interface code generator to produce source files and either adds them to a new static library (if it doesn't exist) or includes them in an existing one. It accepts the static library name, full paths to Service Interface file, Service Interface name and paths for generated files. The service interface name must match the file name (without the .siml extension).
+- **Syntax**: `macro_add_service_interface(interface_doc codegen_root output_path codegen_tool)`
+- **Purpose**: From the given Service Interface document file (`*.siml`), generates and adds service specific files to a static library..
 - **Parameters**:
-  - *lib_name* [in]: Name of the static library.
-  - *interface_doc* [in]:Full path to the Service Interface document file. 
-  - *interface_name* [in]: Name of the Service Interface (without '.siml').
-  - *codegen_root* [in]: Root directory for generating files.
-  - *output_path* [in]: Relative path for generated files.
-  - *codegen_tool* [in]: Full path to the code generator tool.
-- **Macro Usage**: *macro_add_service_interface(<library name> <documend dir><interface name>.siml <interface name> <codegen root> <sub-path> <codegen tool>)*
-- **Example: For a project 'fun_library' with 'HelloWorld.siml' and 'WeHaveFun.siml' interfaces calling macro_add_service_interface("fun_library" ... HelloWorld ...) generates source files for HelloWorld and includes them in the static library. A subsequent call for WeHaveFun adds it to the same library.
+  - `lib_name` [in]: Name of the static library.
+  - `interface_doc` [in]:Full path to the Service Interface document file (`.siml`). 
+  - `codegen_root` [in]: Root directory to generate files.
+  - `output_path` [in]: Relative path to generate files.
+  - `codegen_tool` [in]: Full path to the code generator tool.
+- **Usage**: `macro_add_service_interface(<name-lib> <full-path-siml> <root-gen> <relative-path> <codegen-tool>)`
+- **Example:
    ```cmkae
-   macro_add_service_interface("fun_library" "~/project/my-fun/sources/service/interfaces/FunInterface.siml" FunInterface "~/project/my-fun/" "generate/service/interfaces" /tools/areg/codegen.jar)
+   macro_add_service_interface(funlib "~/project/fun/src/service/HelloWorld.siml" "~/project/fun/product" "generate/service" /tools/areg/codegen.jar)
+   macro_add_service_interface(funlib "~/project/fun/src/service/WeHaveFun.siml"  "~/project/fun/product" "generate/service" /tools/areg/codegen.jar)
    ```
 
 ### macro_find_package
-
-- **Macro**: macro_find_package(package_name package_found package_includes package_libraries)
-- **Description**: Searches for a package and sets output variables to indicate the package's include directories and libraries if found.
+- **Syntax**: `macro_find_package(package_name package_found package_includes package_libraries)`
+- **Purpose**: Finds a package, returning paths to includes and libraries if found.
 - **Parameters**:
-  - *package_name* [in]: The package name to search.
-  - *package_found* [out]: Pass the name of variable. On output the variable is TRUE if the package is found.
-  - *package_includes* [out]: Pass the name of variable. On output the variable indicates the package's include directories (if any).
-  - *package_libraries* [out]: Pass the name of variable. On output the variable indicates the package's libraries (if any).
-- **Macro Usage**: *macro_find_package(<package> <found flag> <includes> <libraries>)*
+  - `package_name` [in]: package name to search.
+  - `package_found` [out]: Variable to hold package found flag.
+  - `package_includes` [out]: Variable to hold package's include directories.
+  - `package_libraries` [out]: Variable to hold package's libraries.
+- **Usage**: `macro_find_package(<package-name> <found-flag-var> <includes-var> <libraries-var>)`
 - **Example**:
    ```cmake
+   set(SQLITE_FOUND FALSE)
    macro_find_package(SQLite3 SQLITE_FOUND SQLITE_INCLUDE SQLITE_LIB)
    ```
 
 ### macro_create_option
-
-- **Macro**: macro_create_option(var_name var_value var_description)
-- **Description**: Creates or updates a boolean cache variable in CMake, ensuring it is defined and set correctly.
+- **Syntax**: `macro_create_option(var_name var_value var_describe)`
+- **Purpose**: Creates a boolean cache variable with a default value.
 - **Parameters**: 
-  - *var_name* [in, out]: The name of the boolean variable.
-  - *var_value* [in]: The default value if the variable is not yet defined.
-  - *var_describe* [in]: A brief description of the variable for CMake cache.
-- **Macro Usage**: *macro_create_option(<var_name> <default_value> <description>)*
+  - `var_name` [out]: Name of the boolean variable.
+  - `var_value` [in]: Default value if the variable is not yet defined.
+  - `var_describe` [in]: A brief Purpose of the variable for CMake cache.
+- **Usage**: `macro_create_option(<name-var> <default-value> <describe>)`
 - **Example**:
    ```cmake
    macro_create_option(AREG_LOGS ON "Compile with logs")
    ```
 
 ### macro_add_source
-
-- **Macro**: macro_add_source(result_list src_base_dir ...)
-- **Description**: Adds source files to a list, checking if the files exist relative to the base directory.
+- **Syntax**: `macro_add_source(result_list src_base_dir ...)`
+- **Purpose**: Adds existing source files to a list based on a base directory. Checks the file existence.
 - **Parameters**:
-  - *result_list* [in, out]: The output list of source files.
-  - *src_base_dir* [in]: The base directory for the source files.
-  - *ARGN* [in]: The list of source files (relative to the base directory).
-- **Macro Usage**: macro_add_source(<src list variable> <base directory path> <list of source files with relative path>)
+  - `result_list` [in, out]: List of source files.
+  - `src_base_dir` [in]: Base directory of the source files.
+  - `${ARGN}` [in]: List of source files (should be relative to the base directory).
+- **Usage**: `macro_add_source(<src-list-var> <base-dirpath> <files>)`
 - **Example**:
    ```cmake
    set(aregextend_SRC)
@@ -97,281 +89,231 @@ Following are the CMake macro with description that can be used by developers:
    ```
 
 ### macro_parse_arguments
-
-- **Macro**: macro_parse_arguments(res_sources res_libs res_resources ...)
-- **Description**: This macro processes a list of input arguments that can include:
-          1. **CMake targets** (predefined libraries or targets).
-          2. **Source files**: Files provided with either absolute paths or paths relative to the current directory.
-          3. **Resource files** (*.rc): Windows-specific resource files.    
-       The macro categorizes the input arguments into three separate lists:
-          1. **Libraries list**: Contains any known CMake targets.
-          2. **Source files list**: Includes valid source files (.cpp, .c) from either the provided absolute paths or relative paths.
-          3. **Resource files list**: Filters out .rc files, specifically for Windows, and stores them in a separate list.
-       **Behavior**: 
-          - If a file does not exist, either as a full path or relative to the current directory, the macro throws a fatal error.
-          - On Windows, it specifically identifies and appends resource files (*.rc) to the resources list.
+- **Syntax**: `macro_parse_arguments(res_sources res_libs res_resources)`
+- **Purpose**: Parses files and libraries into separate lists for sources, libraries, and resources. The library names should match the name of any known targets. The resource files should have `.rc` extension (Windows specific), source files should have `.cpp`, `.cxx` or `.c` file extension, and should exist on file system.
+- **Note**:
+  - Throws an error if file with relative or path does not exist.
+  - The resource file with extension `.rc` is relevant only to the Windows system. On other systems it will be considered as a source file.
 - **Parameters**:
-  - *res_sources* [out]: A list containing the parsed source files.
-  - *res_libs* [out]: Output: A list containing the recognized CMake targets (libraries).
-  - *res_resources* [out]: A list containing the identified resource files (*.rc).
-  - *${ARGN}* [in]: A list of files, libraries, or resources to be categorized.
-- **Macro Usage**: *macro_parse_arguments(<var sources> <var libs> <var resources> my_target my/app/main.cpp my/lib/object.cpp my/resource/resource.rc)*
+  - `res_sources` [out]: List of source files.
+  - `res_libs` [out]: List containing the recognized CMake targets.
+  - `res_resources` [out]: List of identified resource files (*.rc).
+  - `${ARGN}` [in]: List of files with relative or full path, libraries, or resources to categorize.
+- **Usage**: `macro_parse_arguments(<sources-var> <libs-var> <resources-var> <sources-targets-resources>)`
 - **Example**:    
    ```cmake
    macro_parse_arguments(src_files lib_targets res_files my_lib src/main.cpp src/object.cpp res/resource.rc)
    ```
 
 ### macro_declare_static_library
-
-- **Macro**: macro_declare_static_library(lib_name ...)
-- **Description**: This macro declares a static library by processing the provided list of arguments and categorizing them into three main groups:
-            1. **Source Files**: These are the .cpp or .c files used to build the library. The macro supports both absolute paths and paths relative to the current directory.
-            2. **Libraries**: These are existing CMake targets (predefined libraries) that the static library depends on.
-            3. **Resource Files**: These are .rc files (Windows resource files). On Windows systems, the macro ensures they are processed using the appropriate RC language settings.
-       The macro declares a static library target using the collected source files and linked libraries. It also handles resource file configuration on Windows platforms.
-- **Notes**: 
-   - Throws a fatal error if no source files are provided.
-   - On Windows, resource files (*.rc) are set to use the RC language automatically.
+- **Syntax**: `macro_declare_static_library(lib_name ...)`
+- **Purpose**: Declares a static library with categorized sources, libraries, and resources. It splits the list of files using **[macro_parse_arguments](#macro_parse_arguments)** macro and declares new static library target. The detected targets are used to link the libraries.
 - **Parameters**:
-  - **lib_name** [in]: The name of the static library to be declared.
-  - **${ARGN}** [in]: The list of source files, libraries, and resource files. The files can be specified with full or relative paths.
-- **Macro Usage**: *macro_declare_static_library(<lib_name> <list_of_sources_libraries_and_resources>)*
+  - `lib_name` [in]: Name of the static library to declare.
+  - `${ARGN}` [in]: List of source files, libraries, and resource files.
+- **Usage**: `macro_declare_static_library(<lib-name> <sources-targets-resources>)`
 - **Example**:
    ```cmake
    macro_declare_static_library(myStaticLib src/main.cpp src/resource.rc libSomeDependency)
    ```
 
 ### macro_declare_shared_library
-
-- **Macro**: macro_declare_shared_library(lib_name ...)
-- **Description**: This macro declares a shared library by processing the provided list of arguments and categorizing them into three main groups:
-            1. **Source Files**: These are the .cpp or .c files used to build the library. The macro supports both absolute paths and paths relative to the current directory.
-            2. **Libraries**: These are existing CMake targets (predefined libraries) that the shared library depends on.
-            3. **Resource Files**: These are .rc files (Windows resource files). On Windows systems, the macro ensures they are processed using the appropriate RC language settings.
-       The macro declares a shared library target using the collected source files and linked libraries. It also handles resource file configuration on Windows platforms.
-- **Notes**: 
-   - Throws a fatal error if no source files are provided.
-   - On Windows, resource files (*.rc) are set to use the RC language automatically.
+- **Syntax**: `macro_declare_shared_library(lib_name ...)`
+- **Purpose**: Similar to **[macro_declare_static_library](#macro_declare_static_library)**, for shared libraries. The detected targets are used to link the libraries.
 - **Parameters**:
-  - *lib_name* [in]: The name of the shared library to be declared.
-  - *${ARGN}* [in]: The list of source files, libraries, and resource files. The files can be specified with full or relative paths.
-- **Macro Usage**: *macro_declare_shared_library(<lib_name> <list_of_sources_libraries_and_resources>)*
+  - `lib_name` [in]: Name of the shared library to be declared.
+  - `${ARGN}` [in]: List of source files, libraries, and resource files. Files can be specified with full or relative paths.
+- **Usage**: `macro_declare_shared_library(<lib-name> <sources-targets-resources>)`
 - **Example**:
    ```cmake
    macro_declare_shared_library(mySharedLib src/main.cpp src/resource.rc libSomeDependency)
    ```
 
 ### macro_declare_executable
-
-- **Macro**: macro_declare_executable(exe_name ...)
-- **Description**: This macro declares an executable by processing the provided list of arguments and categorizing them into three main groups:
-            1. **Source Files**: These are the .cpp or .c files used to build the library. The macro supports both absolute paths and paths relative to the current directory.
-            2. **Libraries**: These are existing CMake targets (predefined libraries) that the executable depends on.
-            3. **Resource Files**: These are .rc files (Windows resource files). On Windows systems, the macro ensures they are processed using the appropriate RC language settings.
-       The macro declares a executable target using the collected source files and linked libraries. It also handles resource file configuration on Windows platforms.
-- **Notes**: 
-   - Throws a fatal error if no source files are provided.
-   - On Windows, resource files (*.rc) are set to use the RC language automatically.
+- **Syntax**: `macro_declare_executable(exe_name ...)`
+- **Purpose**: Declares an executable with categorized sources, libraries, and resources. It splits the list of files using **[macro_parse_arguments](#macro_parse_arguments)** macro and declares new executable target. The list of detected targets is used to link the libraries.
 - **Parameters**:
-  - *exe_name* [in]: The name of the executable to be declared.
-  - *${ARGN}* [in]: The list of source files, libraries, and resource files. The files can be specified with full or relative paths.
-- **Macro Usage**: *macro_declare_executable(<lib_name> <list_of_sources_libraries_and_resources>)*
+  - `exe_name` [in]: Name of the executable to be declared.
+  - `${ARGN}` [in]: List of source files, libraries, and resource files. Files can be specified with full or relative paths.
+- **Usage**: `macro_declare_executable(<executable-name> <sources-targets-resources>)`
 - **Example**:
    ```cmake
    macro_declare_executable(myApplication src/main.cpp src/resource.rc libSomeDependency)
    ```
 
 ### macro_setup_compilers_data
-
-- **Macro**: macro_setup_compilers_data(compiler_path compiler_family compiler_short compiler_cxx compiler_c compiler_found)
-- **Description**: This macro identifies the compiler family (e.g., GNU, Clang, MSVC), extracts a short name for the compiler, and attempts to guess the corresponding C compiler based on the provided C++ compiler path or name. It handles cases where only the compiler name is provided (assuming it is available in the system's PATH). If a match is found, it sets the output variables for the compiler family, short name, C++ compiler path, and C compiler path, and marks the process as successful. Otherwise, the output flag indicates failure.
-- **Note**: Beside "gnu", "llvm", "msvc", the compilers for CYGWIN are included in the family "cygwin" to identify that the application is compiled in Windows under CYGWIN platform with GNU compilers.
+- **Syntax**: `macro_setup_compilers_data(compiler_path compiler_family compiler_short compiler_cxx compiler_c is_identified)`
+- **Purpose**: Identifies and sets up compiler family, short names and paths, `compiler_supports` variable stores the flag if compiler is supported by AREG SDK.
+- **Note**: Beside "gnu", "llvm", "msvc", the GNU compilers for CYGWIN are included as a "cygwin" family.
 - **Parameters**: 
-  - *compiler_path* [in]: The name or full path of the C++ compiler executable.
-  - *compiler_family* [out]: Variable to hold the identified compiler family (e.g., "gnu", "msvc").
-  - *compiler_short* [out]: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
-  - *compiler_cxx* [out]: Variable to hold the C++ compiler path (usually same as ${compiler_path}).
-  - *compiler_c* [out]: Variable to hold the corresponding C compiler name or path.
-  - *compiler_supports* [out]: Boolean flag indicating if the compiler was successfully identified ("TRUE" or "FALSE").
-- **Macro Usage**: macro_setup_compilers_data(<compiler with path> <var compiler family> <var compiler short> <var CXX compiler> <var C compiler> <flag compiler supports>)
+  - `compiler_path` [in]: Name or full path of the C++ compiler.
+  - `compiler_family` [out]: Variable to hold identified compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
+  - `compiler_short` [out]: Variable to hold short name of the compiler (e.g., "gcc", "clang").
+  - `compiler_cxx` [out]: Variable to hold C++ compiler name or path (usually same as ${compiler_path}).
+  - `compiler_c` [out]: Variable to hold corresponding C compiler name or path.
+  - `is_identified` [out]: Variable to hold Boolean flag indicating if the compiler was successfully identified ("TRUE" or "FALSE").
+- **Usage**: `macro_setup_compilers_data(<compiler> <compiler-family-var> <compiler-short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)`
 - **Example**:
-   ```cmake
-   macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" AREG_COMPILER_FAMILY AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _compiler_found)
+   ```cmakr
+   macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" AREG_COMPILER_FAMILY AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _is_identified)
    ```
 
 ### macro_setup_compilers_data_by_family
-
-- **Macro**: macro_setup_compilers_data_by_family(compiler_family compiler_short compiler_cxx compiler_c compiler_supports)
-- **Description**: This macro identifies the short name of the C++ and C compilers based on the provided compiler family (e.g., "gnu", "msvc", "llvm", "cygwin"). It assumes that the compiler executables are available in the system's PATH. Once a match is found for the compiler family, it sets the output variables for the short name, C++ compiler name, and C compiler name, and marks the process as successful. If no match is found, it sets the output flag to "FALSE".
+- **Syntax**: `macro_setup_compilers_data_by_family(compiler_family compiler_short compiler_cxx compiler_c is_identified)`
+- **Purpose**: Configures compiler names based on family (e.g., gnu, msvc, llvm, cygwin). Make sure that the compiler path is included in PATH environment variable.
 - **Note**: The "cygwin" family is supported for GNU compilers on the CYGWIN platform in Windows.
 - **Parameters**: 
-  - *compiler_family* [in]: The name of the compiler family (e.g., "gnu", "msvc").
-  - *compiler_short* [out]: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
-  - *compiler_cxx* [out]: Variable to hold the C++ compiler name.
-  - *compiler_c* [out]: Variable to hold the corresponding C compiler name.
-  - *compiler_supports* [out]: Boolean flag indicating whether the compiler was successfully identified ("TRUE" or "FALSE").
-- **Macro Usage**: macro_setup_compilers_data_by_family(<compiler family name> <var compiler short> <var CXX compiler> <var C compiler> <flag compiler supports>)
+  - `compiler_family` [in]: Name of the compiler family (e.g., "gnu", "msvc", "llvm", "cygwin").
+  - `compiler_short` [out]: Variable to hold the short name of the compiler (e.g., "gcc", "clang").
+  - `compiler_cxx` [out]: Variable to hold the C++ compiler name or path.
+  - `compiler_c` [out]: Variable to hold the corresponding C compiler name.
+  - `is_identified` [out]: Variable to hold Boolean flag indicating whether the compiler was successfully identified ("TRUE" or "FALSE").
+- **Usage**: `macro_setup_compilers_data_by_family(<compiler-family> <compiler-short-var> <CXX-compiler-vat> <C-compiler-vat> <identified-var>)`
 - **Example**:
    ```cmake
-   macro_setup_compilers_data_by_family("gnu" AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _compiler_supports)
+   macro_setup_compilers_data_by_family("gnu" AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _is_identified)
    ```
 
 ---
 
-## AREG Framework CMake Functions
-
-Following are the CMake functions with description that can be used by developers:
+## CMake Functions Overview
 
 ### setAppOptions
-
-- **Function**: *setAppOptions(target_name, library_list)*
-- **Description**: Configures the compiler and linker options for target applications. Automatically links the AREG library, along with any additional libraries specified.
+- **Syntax**: `setAppOptions(target_name library_list)`
+- **Purpose**: Configures compiler and linker settings for an application target, imports and auto-linking the AREG Framework library and any additional libraries.
 - **Parameters**:
-  - *target_name* [in]: The name of the target application to apply options to.
-  - *library_list* [in]: The list of additional libraries to link with the target application.
-- **Function Usage**: *setAppOptions(<name of target> <list of libraries>)*
+  - `target_name` [in]: Name of the target application to apply options to.
+  - `library_list` [in]: List of additional libraries to link with the target application.
+- **Usage**: `setAppOptions(<target-name> <library-list>)`
 
 ### addExecutableEx
-
-- **Function**: *addExecutableEx(target_name target_namespace source_list library_list)*
-- **Description**: Creates an target executable, sets its source files, applies necessary options, and links it with the provided list of libraries. The AREG library is automatically linked, so no need to specify it.
+- **Syntax**: `addExecutableEx(target_name target_namespace source_list library_list)`
+- **Purpose**: Creates an executable target, setting sources, options, imports and auto-linking the AREG Framework library and any additional libraries.
 - **Parameters**:
-  - *target_name* [in]: The name of the target executable to build.
-  - *target_namespace* [in]: The namespace of the target, used for aliasing. Pass empty string if has no namespace.
-  - *source_list* [in]: The list of source files used to build the target executable.
-  - *library_list* [in]: The list of libraries to link with the executable.
-- **Function Usage**: *addExecutableEx(<name of target executable> <namespace (optional)> <list of sources> <list of libraries>)*
+  - `target_name` [in]: Name of the target executable to build.
+  - `target_namespace` [in]: Namespace of the target, used for aliasing. Pass empty string if has no aliasing.
+  - `source_list` [in]: List of source files used to build the target executable.
+  - `library_list` [in]: List of libraries to link with the executable.
+- **Usage**: `addExecutableEx(<target-name> <namespace-opt> <sources-list> <libraries-list>)`
 
 ### addExecutable
-
-- **Function**: *addExecutable(target_name source_list)*
-- **Description**: Creates an executable, sets its source files, applies necessary options. The AREG library is automatically linked, so no need to specify it.
+- **Syntax**: `addExecutable(target_name source_list)`
+- **Purpose**: Creates an executable target, setting sources, options, imports and auto-linking the AREG library.
 - **Parameters**:
-  - *target_name* [in]: The name of the executable to build.
-  - *source_list* [in]: The list of source files used to build the executable.
-- **Function Usage**: *addExecutable(<name of executable> <list of sources>)*
+  - `target_name` [in]: Name of the executable to build.
+  - `source_list` [in]: List of source files used to build the executable.
+- **Usage**: `addExecutable(<target-name> <sources-list>)`
 
 ### setStaticLibOptions
-
-- **Function**: setStaticLibOptions(target_name library_list)
-- **Description**: Configures the compiler and linker options for a static library. Automatically links the AREG library and any other specified libraries.
+- **Syntax**: `setStaticLibOptions(target_name library_list)`
+- **Purpose**: Configures compiler and linker settings for a static library, imports and auto-linking the AREG Framework library and any additional libraries.
 - **Parameters**:
-  - *target_name* [in]: The name of the static library to apply options to.
-  - *library_list* [in]: The list of libraries to link with the static library.
-- **Function Usage **: *setStaticLibOptions(<name of static library> <list of libraries>)* 
+  - `target_name` [in]: Name of the static library to apply options to.
+  - `library_list` [in]: List of libraries to link with the static library.
+- **Usage **: `setStaticLibOptions(<target-name> <libraries-list>)` 
 
 ### addStaticLibEx
-
-- **Function**: addStaticLibEx(target_name target_namespace source_list library_list)
-- **Description**: Creates a static library, sets its source files, applies necessary options, and links it with the provided list of libraries. The AREG library is automatically linked, so no need to specify it.
+- **Syntax**: `addStaticLibEx(target_name target_namespace source_list library_list)`
+- **Purpose**: Creates a static library, applying specified sources and options, imports and auto-linking the AREG Framework library and any additional libraries.
 - **Parameters**
-  - *target_name* [in]: The name of the static library to build.
-  - *target_namespace* [in]: (**optional**) The namespace of the static library. Pass empty string if has no namespace.
-  - *source_list* [in]: The list of source files used to build the static library.
-  - *library_list* [in]: The list of libraries to link with the static library.
-- **Function Usage**: *addStaticLibEx(<name of static library> <namespace (optional)> <list of sources> <list of libraries>)*
+  - `target_name` [in]: Name of the static library to build.
+  - `target_namespace` [in]: Namespace of the target, used for aliasing. Pass empty string if has no aliasing.
+  - `source_list` [in]: List of source files to build the static library.
+  - `library_list` [in]: List of libraries for linking.
+- **Usage**: `addStaticLibEx(<target-name> <namespace-opt> <sources-list> <libraries-list>)`
 
 ### addStaticLib
-
-- **Function**: addStaticLib(target_name source_list)
-- **Description**: Creates a static library, sets its source files, applies necessary options. The AREG library is automatically linked, so no need to specify it.
+- **Syntax**: `addStaticLib(target_name source_list)`
+- **Purpose**: Creates a static library, applying specified sources and options, imports and auto-linking the AREG Framework library.
 - **Parameters**
-  - *target_name* [in]: The name of the static library to build.
-  - *source_list* [in]: The list of source files used to build the static library.
-- **Function Usage**: *addStaticLib(<name of static library> <list of sources>)*
+  - `target_name` [in]: Name of the static library to build.
+  - `source_list` [in]: List of source files to build the static library.
+- **Usage**: `addStaticLib(<target-name> <sources-list>)`
 
 ### addStaticLibEx_C
-
-- **Function**: addStaticLibEx_C(target_name target_namespace source_list library_list)
-- **Description**: Creates a static library compiled with C-compiler, sets its source files, applies necessary options, and links it with the provided list of libraries. The AREG library is automatically linked, so no need to specify it.
+- **Syntax**: `addStaticLibEx_C(target_name target_namespace source_list library_list)`
+- **Purpose**: Creates a static library compiled with C, setting sources, imports and auto-linking the AREG Framework library and any additional libraries.
 - **Parameters**:
-  - *target_name* [in]: The name of the static library to build.
-  - *target_namespace* [in]: (**optional**) The namespace of the static library. Pass empty string if has no namespace.
-  - *source_list* [in]: The list of C-code source files used to build the static library.
-  - *library_list* [in]: The list of libraries to link with the static library.
-- **Function Usage**: *addStaticLibEx_C(<name of static library> <namespace (optional)> <list of C-code sources> <list of libraries>)*
+  - `target_name` [in]: Name of the static library to build.
+  - `target_namespace` [in]: Namespace of the target, used for aliasing. Pass empty string if has no aliasing.
+  - `source_list` [in]: List of C-code source files to build the static library.
+  - `library_list` [in]: List of libraries to link with the static library.
+- **Usage**: `addStaticLibEx_C(<target-name> <namespace-opt> <C-sources-list> <libraries-list>)`
 
 ### addStaticLib_C
-
-- **Function**: addStaticLib_C(target_name source_list)
-- **Description**: Creates a static library compiled with C-compiler, sets its source files, applies necessary options. The AREG library is automatically linked, so no need to specify it.
+- **Syntax**: `addStaticLib_C(target_name source_list)`
+- **Purpose**: Creates a static library compiled with C, setting sources, imports and auto-linking the AREG Framework library.
 - **Parameters**:
-  - *target_name* [in]: The name of the static library to build.
-  - *source_list* [in]: The list of C-code source files used to build the static library.
-- **Function Usage**: *addStaticLib_C(<name of static library> <list of C-code sources>)*
+  - `target_name` [in]: Name of the static library to build.
+  - `source_list` [in]: List of C-code source files to build the static library.
+- **Usage**: `addStaticLib_C(<target-name> <C-sources-list>)`
 
 ### setSharedLibOptions
-
-- **Function**: setSharedLibOptions(item_name library_list)
-- **Description**: Configures the compiler and linker options for a shared library. Automatically links the AREG library and any other specified libraries.
+- **Syntax**: `setSharedLibOptions(item_name library_list)`
+- **Purpose**: Configures settings for a shared library, imports and auto-linking the AREG Framework library and any additional libraries.
 - **Parameters**:
-  - target_name [in]: The name of the shared library to apply options to.
-  - *library_list* [in]: The list of libraries to link with the shared library.
-- **Function Usage**: *setSharedLibOptions(<name of shared library> <list of libraries>)* 
+  - `target_name` [in]: Name of the shared library to apply options to.
+  - `library_list` [in]: List of libraries for linking.
+- **Usage**: `setSharedLibOptions(<target-name> <libraries-list>)`
 
 ### addSharedLibEx
-
-- **Function**: addSharedLibEx(target_name target_namespace source_list library_list)
-- **Description**: Creates a shared library, sets its source files, applies necessary options, and links it with the provided list of libraries. The AREG library is automatically linked, so no need to specify it.
+- **Syntax**: `addSharedLibEx(target_name target_namespace source_list library_list)`
+- **Purpose**: Creates a shared library, setting sources, options, imports and auto-linking the AREG Framework library and any additional libraries.
 - **Parameters**:
-  - *target_name* [in]: The name of the shared library to build.
-  - *target_namespace* [in]: The namespace of the shared library (optional for aliasing).
-  - *source_list* [in]: The list of source files used to build the shared library.
-  - *library_list* [in]: The list of libraries to link with the shared library.
-- **Function Usage**: *addSharedLibEx(<name of shared library> <namespace (optional)> <list of sources> <list of libraries>)*
+  - `target_name` [in]: Name of the shared library to build.
+  - `target_namespace` [in]: Namespace of the target, used for aliasing. Pass empty string if has no aliasing.
+  - `source_list` [in]: List of source files to build the shared library.
+  - `library_list` [in]: List of libraries for linking.
+- **Usage**: `addSharedLibEx(<target-name> <namespace-opt> <sources-list> <libraries-list>)`
 
 ### addSharedLib
-- **Function**: addSharedLib(target_name source_list)
-- **Description**: Creates a shared library, sets its source files, applies necessary options. The AREG library is automatically linked, so no need to specify it.
+- **Syntax**: `addSharedLib(target_name source_list)`
+- **Purpose**: Creates a shared library, setting sources, options, imports and auto-linking the AREG Framework library.
 - **Parameters**:
-  - *target_name* [in]: The name of the shared library to build.
-  - *source_list* [in]: The list of source files used to build the shared library.
-- **Function Usage**: *addSharedLib(<name of shared library> <list of sources>)*
+  - `target_name` [in]: Name of the shared library to build.
+  - `source_list` [in]: List of source files to build shared library.
+- **Usage**: `addSharedLib(<target-name> <sources-list>)`
 
 ### addServiceInterfaceEx
-
-- **Function**: addServiceInterfaceEx(lib_name source_root relative_path sub_dir interface_name)
-- **Description**: Generates code for a service interface using a code generator and includes the generated files in a static library.
+- **Syntax**: `addServiceInterfaceEx(lib_name source_root relative_path sub_dir interface_name)`
+- **Purpose**: From given Service Interface document file (`.siml`), generates codes and includes files in a static library.
 - **Parameters**
-  - *lib_name* [in]: The static library name.
-  - *source_root* [in]: The root directory of the source files.
-  - *relative_path* [in]: The relative path to the Service Interface files.
-  - *sub_dir* [in]: Optional sub-directory within relative_path (can be empty).
-  - *interface_name* [in]: The name of the Service Interface (without the '.siml' extension).
-- **Function Usage**: *addServiceInterfaceEx(<static library> <source root> <relative path> <sub-directory> <interface name>)*
+  - `lib_name` [in]: Static library name.
+  - `source_root` [in]: Source root directory.
+  - `relative_path` [in]: Service Interface relative file path.
+  - `sub_dir` [in]: Optional sub-directory within the `relative_path`.
+  - `interface_name` [in]: Service Interface name (without `.siml` extension).
+- **Usage**: `addServiceInterfaceEx(<library-name> <source-root> <relative-path> <sub-dir-opt> <service-interface-name>)`
 - **Example**:
    ```cmake
    addServiceInterfaceEx("fun_library" "/home/develop/project/my-fun/sources" "my/service/interfaces" "" FunInterface)
    ```
 
 ### addServiceInterface
-
-- **Function**: addServiceInterface(lib_name sub_dir interface_name)
-- **Description**: Wrapper for addServiceInterfaceEx, with the source root assumed to be `CMAKE_SOURCE_DIR` and the relative path `CMAKE_CURRENT_LIST_DIR`.
+- **Syntax**: `addServiceInterface(lib_name sub_dir interface_name)`
+- **Purpose**: A wrapper for addServiceInterfaceEx, assuming the source root as `CMAKE_SOURCE_DIR` and relative path as `CMAKE_CURRENT_LIST_DIR`.
 - **Parameters**:
-  - *lib_name* [in]: The name of the static library.
-  - *sub_dir* [in]: The sub-directory of the service interface files.
-  - *interface_name* [in]: The name of the Service Interface (without the '.siml' extension).
-- **Function Usage**: *addServiceInterface(<static library> <sub-directory> <Service Interface name>)*
+  - `lib_name` [in]: Static library name.
+  - `sub_dir` [in]: Optional sub-directory. Can by empty.
+  - `interface_name` [in]: Service Interface name (without `.siml` extension).
+- **Usage**: `addServiceInterface(<library-name> <sub-dir-opt> <service-interface-name>)`
 
 ### removeEmptyDirs
-
-- **Function**: removeEmptyDirs(dir_name)
-- **Description**: Recursively removes empty directories.
+- **Syntax**: `removeEmptyDirs(dir_name)`
+- **Purpose**: Recursively removes empty directories.
 - **Parameters**:
-  - dir_name [in]: The directory path to check and potentially remove.
-- **Function Usage**: *removeEmptyDirs(<directory path>)*
+  - `dir_name` [in]: Directory path to check and potentially remove.
+- **Usage**: `removeEmptyDirs(<dir-path>)`
 
 ### printAregConfigStatus
-
-- **Function**: printAregConfigStatus(var_make_print var_prefix var_header var_footer)
-- **Description**: This function prints a detailed status report for the AREG project's CMake configuration. It provides an overview of the build environment, compiler, output directories, and relevant configuration options such as installed packages and libraries.
+- **Syntax**: `printAregConfigStatus(var_make_print var_prefix var_header var_footer)`
+- **Purpose**: Prints a detailed status of AREG's CMake configuration, including build environment details.
 - **Parameters**: 
-  - *var_make_print* [in]: Boolean flag indicating whether to print the status message. If FALSE, the function exits without printing.
-  - *var_prefix* [in]: A prefix added to each line of the status message (e.g., project name or custom label).
-  - *var_header* [in]: A custom header message displayed at the beginning of the status report.
-  - *var_footer* [in]: A custom footer message displayed at the end of the status report.
-- **Function Usage**: printAregConfigStatus(<flag to print> <prefix name> <header to output> <footer to output>)
+  - `var_make_print` [in]: Boolean flag indicating whether to print the status message. If FALSE, the function exits without printing.
+  - `var_prefix` [in]: A prefix added to each line of the status message (e.g., project name or custom label).
+  - `var_header` [in]: A custom header message displayed at the beginning of the status report.
+  - `var_footer` [in]: A custom footer message displayed at the end of the status report.
+- **Usage**: `printAregConfigStatus(<flag-to-print> <prefix> <header-output> <footer-output>)`
 - **Example**: 
    ```cmake
    printAregConfigStatus(TRUE "AREG"

--- a/docs/wiki/cmake-functions.md
+++ b/docs/wiki/cmake-functions.md
@@ -185,7 +185,7 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
   - `compiler_cxx` [out]: C++ compiler path.
   - `compiler_c` [out]: C compiler path.
   - `is_identified` [out]: Boolean indicating successful identification.
-- **Usage**: `macro_setup_compilers_data(<compiler> <compiler-family-var> <compiler-short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)`
+- **Usage**: `macro_setup_compilers_data(<compiler> <family-var> <short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)`
 - **Example**:
    ```cmakr
    macro_setup_compilers_data("${CMAKE_CXX_COMPILER}" AREG_COMPILER_FAMILY AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _is_identified)
@@ -201,7 +201,7 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
   - `compiler_cxx` [out]: C++ compiler path.
   - `compiler_c` [out]: C compiler path.
   - `is_identified` [out]: Boolean indicating successful identification.
-- **Usage**: `macro_setup_compilers_data_by_family(<compiler-family> <compiler-short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)`
+- **Usage**: `macro_setup_compilers_data_by_family(<compiler-family> <short-var> <CXX-compiler-var> <C-compiler-var> <identified-var>)`
 - **Example**:
    ```cmake
    macro_setup_compilers_data_by_family("gnu" AREG_COMPILER_SHORT AREG_CXX_COMPILER AREG_C_COMPILER _is_identified)

--- a/docs/wiki/cmake-functions.md
+++ b/docs/wiki/cmake-functions.md
@@ -75,8 +75,8 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Usage**: `macro_add_service_interface(<name-lib> <full-path-siml> <root-gen> <relative-path> <codegen-tool>)`
 - **Example**:
    ```cmkae
-   macro_add_service_interface(funlib "~/project/fun/src/service/HelloWorld.siml" "~/project/fun/product" "generate/service" /tools/areg/codegen.jar)
-   macro_add_service_interface(funlib "~/project/fun/src/service/WeHaveFun.siml"  "~/project/fun/product" "generate/service" /tools/areg/codegen.jar)
+   macro_add_service_interface(funlib "/home/dev/project/fun/src/service/HelloWorld.siml" "/home/dev/project/fun/product" "generate/service" /tools/areg/codegen.jar)
+   macro_add_service_interface(funlib "/home/dev/project/fun/src/service/WeHaveFun.siml"  "/home/dev/project/fun/product" "generate/service" /tools/areg/codegen.jar)
    ```
 
 ### `macro_find_package`
@@ -319,7 +319,7 @@ The [functions.cmake](./../../conf/cmake/functions.cmake) file includes reusable
 - **Usage**: `addServiceInterfaceEx(<library-name> <source-root> <relative-path> <sub-dir-opt> <service-interface-name>)`
 - **Example**:
    ```cmake
-   addServiceInterfaceEx("fun_library" "/home/develop/project/fun/src" "my/service/interfaces" "" FunInterface)
+   addServiceInterfaceEx("fun_library" "/home/dev/project/fun/src" "my/service/interfaces" "" FunInterface)
    ```
 
 ### `addServiceInterface`

--- a/framework/areg/system/GEPlatform.h
+++ b/framework/areg/system/GEPlatform.h
@@ -52,6 +52,16 @@
 
     #include "areg/system/windows/GEWindows.h"
 
+#elif (defined(__unix__) || defined(__linux__) || defined(__CYGWIN__) || defined(__FreeBSD__) || defined(__APPLE__))
+
+    #define POSIX
+    #include "areg/system/posix/GEPosix.h"
+
+#elif(defined(_WIN32) || defined(_WIN64))
+
+    #define WINDOWS
+    #include "areg/system/windows/GEWindows.h"
+
 #else // !(defined(_WINDOWS) || defined(WINDOWS))
 
     #error  Unsupported OS.


### PR DESCRIPTION
- Created documentation explaining the macro and functions in the functions.cmake file;
- Slight optimization of CMake functions;
- Fixed Platform detection in areg sdk sources.