### PR TITLE
Fixed the bug, related with copy memory in i386 platform

### DIFF
--- a/framework/areg/base/NEString.hpp
+++ b/framework/areg/base/NEString.hpp
@@ -1678,12 +1678,11 @@ void NEString::trimAll( CharType * strBuffer, NEString::CharCount strLen /*= NES
 
             if (strLen != NEString::COUNT_ALL)
             {
-                NEString::copyStringFast<CharType>(buf, next, NEString::COUNT_ALL);
+                while (*next != static_cast<CharType>(NEString::EndOfString))
+                    *buf ++ = *next ++;
             }
-            else
-            {
-                *buf = static_cast<CharType>(NEString::EndOfString);
-            }
+
+            *buf = static_cast<CharType>(NEString::EndOfString);
         }
     }
 }
@@ -1749,7 +1748,10 @@ void NEString::trimRight( CharType * strBuffer, NEString::CharCount strLen /*= N
             }
             else
             {
-                NEString::copyStringFast<CharType>(NEString::isWhitespace<CharType>(*end) ? end : ++end, next, NEString::COUNT_ALL);
+                CharType * dst = NEString::isWhitespace<CharType>(*end) ? end : ++end;
+                while(*next != static_cast<CharType>(NEString::EndOfString))
+                    *dst ++ = *next ++;
+                *(dst) = static_cast<CharType>(NEString::EndOfString);
             }
         }
     }
@@ -1805,14 +1807,14 @@ void NEString::trimLeft( CharType * strBuffer, NEString::CharCount strLen /*= NE
                 while ( begin < end)
                     *buf ++ = *begin ++;
 
-                if (strLen == NEString::COUNT_ALL)
+                if (strLen != NEString::COUNT_ALL)
                 {
-                    *buf = static_cast<CharType>(NEString::EndOfString);
+                    const CharType* src = strBuffer + strLen;
+                    while (*src != static_cast<CharType>(NEString::EndOfString))
+                        *buf ++ = *src ++;
                 }
-                else
-                {
-                    NEString::copyStringFast<CharType>(buf, strBuffer + strLen, NEString::COUNT_ALL);
-                }
+
+                *buf = static_cast<CharType>(NEString::EndOfString);
             }
         }
     }


### PR DESCRIPTION
It seems that the `memcpy` method of i386 platform contains a bug. The bug is happens if a memory copied within same buffer, i.e. like moving memory. This happens when "trim" whitespace in the string. Because of this, stopped using copy method and instead implemented copying data in the pointer.