### PR TITLE
336 access mcrouter and logger services from wsl

### DIFF
--- a/framework/areg/base/private/NESocket.cpp
+++ b/framework/areg/base/private/NESocket.cpp
@@ -423,7 +423,7 @@ AREG_API_IMPL SOCKETHANDLE NESocket::clientSocketConnect(const std::string_view 
 {
     LOG_SCOPE(areg_base_NESocket_clientSocketConnect);
 
-    const char * host = hostName.empty() ? hostName.data() : NESocket::LocalHost.data();
+    const char * host = hostName.empty() ? NESocket::LocalHost.data() : hostName.data();
 
     LOG_DBG("Creating client socket to connect remote host [ %s ] and port number [ %u ]", host, static_cast<unsigned int>(portNr));
 
@@ -500,7 +500,7 @@ AREG_API_IMPL SOCKETHANDLE NESocket::serverSocketConnect(const std::string_view 
 {
     LOG_SCOPE(areg_base_NESocket_serverSocketConnect);
 
-    const char * host = hostName.empty() == false ? hostName.data() : NESocket::LocalHost.data();
+    const char * host = hostName.empty() ? NESocket::LocalHost.data() : hostName.data();
 
     LOG_DBG("Creating server socket on host [ %s ] and port number [ %u ]", host, static_cast<unsigned int>(portNr));
 

--- a/framework/areg/resources/areg.init
+++ b/framework/areg/resources/areg.init
@@ -177,7 +177,7 @@ service::*::list            = router | logger               # The list of availa
 router::*::service          = mcrouter                      # The name of the message router service (process name)
 router::*::connect          = tcpip			                # The list of supported communication protocols
 router::*::enable::tcpip    = true			                # Communication protocol enable / disable flag
-router::*::address::tcpip   = localhost                     # Protocol specific connection IP-address, default IP is 127.0.0.1
+router::*::address::tcpip   = localhost                     # Protocol specific connection IP-address, default IP is 127.0.0.1. Set the real IP-address.
 router::*::port::tcpip      = 8181			                # Protocol specific connection port number, default port is 8181
 
 # ---------------------------------------------------------------------------
@@ -186,7 +186,7 @@ router::*::port::tcpip      = 8181			                # Protocol specific connect
 logger::*::service          = logcollector                  # The name of the log collector service (process name)
 logger::*::connect          = tcpip			                # The list of supported communication protocols
 logger::*::enable::tcpip    = true			                # Communication protocol enable / disable flag
-logger::*::address::tcpip   = localhost                     # Protocol specific connection IP-address, default IP is 127.0.0.1
+logger::*::address::tcpip   = localhost                     # Protocol specific connection IP-address, default IP is 127.0.0.1. Set the real IP-address.
 logger::*::port::tcpip      = 8282			                # Protocol specific connection port number, default port is 8282
 
 # #######################################

--- a/framework/areg/resources/areg.init
+++ b/framework/areg/resources/areg.init
@@ -22,8 +22,8 @@
 #
 #   Logging to remote host: To log to remote host, specify the IP-address and the port number listed
 #                           in the section of service specified in 'log::*::remote::service'.
-#                           For example, if 'log::*::remote::service = logger', change the settings
-#                           in the section 'logger' to set IP-address and port number.
+#                           For example, if 'log::*::remote::service = logcollector', change the settings
+#                           in the section 'logcollector' to set IP-address and port number.
 #                           The 'log::*::enable::remote' should be enabled to make remote logging.
 #
 #   Log scopes and prio:    To set the logging priority, use logging scopes specified in the 'log' section.
@@ -63,7 +63,7 @@
 #   Meaning of Layout format:
 #       The Layout Format is relevant only when logs the messages in the plain text file.
 #       The Layout Format specification fields are following:
-#           %a      -- outputs the ID of a logging object set by the logger.
+#           %a      -- outputs the ID of a logging object set by the log collector.
 #           %c      -- output tick-count value since process start
 #           %d      -- output day and time data
 #           %e      -- output module (process) ID
@@ -155,7 +155,7 @@ log::logobserver::db::location      = ./logs/log_%time%.sqlite3     # Logobserve
 # Messaging enable states for the logcollector and mcrouter services.
 # ---------------------------------------------------------------------------
 log::logcollector::enable::file     = false     # Log Collector service: do not output log messages in the file
-log::logcollector::enable::debug    = false     # Log Collector service: do not output logs in the debug output
+log::logcollector::enable::debug    = false     # Log Collector service: do not output logs in the debug output window
 log::logcollector::enable::db       = false     # Log Collector service: do not output in the database
 log::mcrouter::enable::file         = false     # MC Router: File logging enable / disable flag
 log::mcrouter::enable::db           = false     # MC Router: Database logging enable / disable flag


### PR DESCRIPTION
Fixed the bug.
It was ignoring the IP-address set in `areg.init` file and it was always using `localhost`. Since there is a known issue that WSL and Windows do not communicate via `localhost`, the processes running on different platforms were not able to send and receive messages. After fixing bug, tested in following way:
1. `mcrouter.exe`, `logobserver.exe` and `12_pubclient.exe` run on Windows;
2. `logobserver.elf` and `12_pubservice.elf` run on WSL.

In `areg.init` file made following changes:
```plaintext
router::*::address::tcpip   = 192.168.178.45   # IP-address on Windows
logger::*::address::tcpip   = 192.168.178.50  # IP-address on WSL
```

The tests passed perfectly without problem.