### PR TITLE
522 the process name with extension

### DIFF
--- a/framework/areg/ipc/private/NERemoteService.cpp
+++ b/framework/areg/ipc/private/NERemoteService.cpp
@@ -448,7 +448,7 @@ AREG_API_IMPL RemoteMessage NERemoteService::createConnectRequest(const ITEM_ID 
         instance.ciBitness  = static_cast<NEService::eInstanceBitness>(Process::getInstance().getBitness());
         instance.ciCookie   = source;
         instance.ciTimestamp= static_cast<TIME64>(DateTime::getNow());
-        instance.ciInstance = Process::getInstance().getAppName();
+        instance.ciInstance = Process::getInstance().getName();
         instance.ciLocation = Process::getInstance().getPath();
 
         msgHelloServer << instance;

--- a/framework/areglogger/client/private/LogObserverApi.cpp
+++ b/framework/areglogger/client/private/LogObserverApi.cpp
@@ -118,7 +118,7 @@ LOGGER_API_IMPL bool logObserverInitialize(const sObserverEvents * callbacks, co
         _theObserver.losState = eObserverStates::ObserverDisconnected;
         _setCallbacks(_theObserver.losEvents, callbacks);
         client.setCallbacks(&_theObserver.losEvents);
-        Application::initApplication(true, false, false, true, false, configFilePath, static_cast<IEConfigurationListener *>(&client));
+        Application::initApplication(false, false, false, true, false, configFilePath, static_cast<IEConfigurationListener *>(&client));
     }
 
     return _isInitialized(_theObserver.losState);

--- a/framework/areglogger/client/private/LoggerClient.cpp
+++ b/framework/areglogger/client/private/LoggerClient.cpp
@@ -32,16 +32,16 @@ LoggerClient& LoggerClient::getInstance(void)
 }
 
 LoggerClient::LoggerClient(void)
-    : ServiceClientConnectionBase( TargetID
-                                 , ServiceType
+    : ServiceClientConnectionBase( LoggerClient::TargetID
+                                 , LoggerClient::ServiceType
                                  , static_cast<uint32_t>(ConnectType)
-                                 , SourceType
+                                 , LoggerClient::SourceType
                                  , static_cast<IEServiceConnectionConsumer &>(self())
                                  , static_cast<IERemoteMessageHandler &>(self())
                                  , static_cast<DispatcherThread &>(self())
-                                 , ThreadPrefix)
+                                 , LoggerClient::ThreadPrefix)
     , IEConfigurationListener    ( )
-    , DispatcherThread           ( ThreadName )
+    , DispatcherThread           ( LoggerClient::ThreadName )
     , IEServiceConnectionConsumer( )
     , IERemoteMessageHandler     ( )
 


### PR DESCRIPTION
- Fixed sending the log source name with extension;
- Fixed issue when log observer instances are not listed in the connected instances list.