### PR TITLE
Was not able to reconnect to log observer.

### DIFF
--- a/framework/areglogger/client/private/LoggerClient.hpp
+++ b/framework/areglogger/client/private/LoggerClient.hpp
@@ -62,7 +62,7 @@ class LoggerClient  : public    ServiceClientConnectionBase
 //////////////////////////////////////////////////////////////////////////
 private:
     //!< The name of the observer dispatcher thread
-    static constexpr std::string_view                   ThreadName      { "LogObserverThread" };
+    static constexpr std::string_view                   ThreadName      { "AREG_LogObserverThread" };
 
     //!< The prefix to add to the send and receive threads.
     static constexpr std::string_view                   ThreadPrefix    { "Observer" };


### PR DESCRIPTION
The problem was in the conflict of the thread names. Both, `areglogger` and `lusan` application where using `LogObserverThread` name to create threads. Fixed by adding prefix to the thread name.