### PR TITLE
Fixed assertion, increased auto-typing timeout

### DIFF
--- a/examples/17_winchat/chatter/ui/PageChat.cpp
+++ b/examples/17_winchat/chatter/ui/PageChat.cpp
@@ -455,15 +455,16 @@ LRESULT PageChat::OnCmdChatJoined( WPARAM wParam, LPARAM /*lParam*/ )
 
 void PageChat::removeTyping( CString nickName, uint32_t cookie )
 {
-    for ( int i = mLastItem; i < mCtrlList.GetItemCount(); ++ i)
+    for ( int i = mLastItem; i < mCtrlList.GetItemCount(); )
     {
         if ( cookie == static_cast<uint32_t>(mCtrlList.GetItemData(i)) )
         {
-            ASSERT( nickName == mCtrlList.GetItemText(i, 0) );
             mCtrlList.DeleteItem(i);
             mCtrlList.EnsureVisible( mCtrlList.GetItemCount( ) - 1, FALSE );
-            break;
+            continue; // Continue to check next items, because the current item is deleted.
         }
+
+        ++i;
     }
 }
 
@@ -548,7 +549,6 @@ void PageChat::OnTimer(UINT_PTR nIDEvent)
             ch = 'a';
     }
     mChatMsg += ch;
-    // mEditEnabled = mChatMsg.IsEmpty() == FALSE;
     UpdateData(FALSE);
     if (mChatMsg.GetLength() >= AUTOMESSAGE_MAX_LEN)
     {

--- a/examples/17_winchat/chatter/ui/PageChat.hpp
+++ b/examples/17_winchat/chatter/ui/PageChat.hpp
@@ -22,7 +22,7 @@ class PageChat  : public CPropertyPage
 private:
     static LPCTSTR HEADER_TITILES[];
 
-    static const USHORT TIMER_MIN_VALUE     = 10;
+    static const USHORT TIMER_MIN_VALUE     = 15;
     static const USHORT TIMER_MAX_VALUE     = 1000;
     static const USHORT AUTOMESSAGE_MAX_LEN = 20;
 

--- a/examples/17_winchat/chatter/ui/PageChat.hpp
+++ b/examples/17_winchat/chatter/ui/PageChat.hpp
@@ -65,6 +65,11 @@ public:
     afx_msg LRESULT OnCmdChatMessage( WPARAM wParam, LPARAM lParam );
     afx_msg LRESULT OnCmdChatTyping( WPARAM wParam, LPARAM lParam );
 
+    afx_msg void OnBnClickedCheckAuto();
+    afx_msg void OnTimer(UINT_PTR nIDEvent);
+    afx_msg void OnEnChangeChatTimer();
+    afx_msg void OnDeltaposChatTimerSpin(NMHDR* pNMHDR, LRESULT* pResult);
+
 private:
     void setHeaders( void );
     void setTabTitle( const String & title );
@@ -108,12 +113,5 @@ private:
     String              mModelName;
 
 private:
-    PageChat( void );
-    PageChat( const PageChat & /*src*/ );
-    const PageChat & operator = ( const PageChat & /*src*/ );
-public:
-    afx_msg void OnBnClickedCheckAuto();
-    afx_msg void OnTimer(UINT_PTR nIDEvent);
-    afx_msg void OnEnChangeChatTimer();
-    afx_msg void OnDeltaposChatTimerSpin(NMHDR* pNMHDR, LRESULT* pResult);
+    DECLARE_NOCOPY_NOMOVE(PageChat);
 };

--- a/examples/17_winchat/chatter/ui/PageChat.hpp
+++ b/examples/17_winchat/chatter/ui/PageChat.hpp
@@ -22,7 +22,7 @@ class PageChat  : public CPropertyPage
 private:
     static LPCTSTR HEADER_TITILES[];
 
-    static const USHORT TIMER_MIN_VALUE     = 1;
+    static const USHORT TIMER_MIN_VALUE     = 10;
     static const USHORT TIMER_MAX_VALUE     = 1000;
     static const USHORT AUTOMESSAGE_MAX_LEN = 20;
 


### PR DESCRIPTION
Fixed the assertion and increased the auto-typing timeout, because in windows it makes no set 1 ms timeout. In Windows it makes sense to set timeout 10 ms and more. 