### PR TITLE
Small fix for posix platforms.

### DIFF
--- a/framework/areg/base/private/posix/ThreadPosix.cpp
+++ b/framework/areg/base/private/posix/ThreadPosix.cpp
@@ -27,13 +27,19 @@
 #include <limits.h>
 #include <pthread.h>
 #include <sched.h>
-#include <time.h> 
+#include <time.h>
 #include <errno.h>
-#include <sys/signal.h>
-#include <sys/unistd.h>
 #include <sys/types.h>
 
-namespace 
+#if __has_include(<sys/unistd.h>)
+#include <sys/signal.h>
+#include <sys/unistd.h>
+#else
+#include <unistd.h>
+#include <signal.h>
+#endif
+
+namespace
 {
 
     //!< POSIX thread structure
@@ -110,7 +116,7 @@ void Thread::_osSleep(unsigned int timeout)
     //      unsigned int micro  = (ms % 1000) * 1000;
     //      sleep(sec);
     //      usleep(micro);
-    
+
     struct timespec ts;
     ts.tv_sec   = timeout / 1'000;
     ts.tv_nsec  = (timeout % 1'000) * 1'000'000 + 1;
@@ -202,7 +208,7 @@ bool Thread::_osCreateSystemThread( void )
 Thread::eThreadPriority Thread::_osSetPriority( eThreadPriority newPriority )
 {
     /**
-     * if priority of a thread is changed, a real-time scheduling policy must be used, 
+     * if priority of a thread is changed, a real-time scheduling policy must be used,
      * possible policies are SCHED_FIFO and SCHED_RR. We use SCHED_RR (round robin) here.
      **/
     static constexpr int schedPolicy{ SCHED_RR };


### PR DESCRIPTION
Actually sys/unistd.h is not present on some posix targets, and when it's not, you also get errors with sys/signal.h. Tgis uses header checl to see if sys/unistd.h exists and falls back to <unistd.h>. Depending on what is done here, it might be safer to use <csignal> ubstead. Or maybe <unistd.h> / <signal.h> should be the default.  Hard to say since I may not test on the same platforms you have, so the header check seemed safest.

Certaiinly with this change it builds straight out of the box on my alpine main branch, and all 359 unit tests do pass. Since its a header conditional (C++17) it should not build differently elsewhere where it used to work:

100% tests passed, 0 tests failed out of 359

Total Test time (real) =   3.93 sec