### PR TITLE
Fixed cross-compile for x86 with gcc

### DIFF
--- a/framework/areg/base/GETypes.h
+++ b/framework/areg/base/GETypes.h
@@ -81,7 +81,7 @@
         typedef unsigned long   ptr_type;
     #endif  // _UINTPTR_T_DEFINED
 
-#endif  // ptr_type
+#endif  // BIT64
 
 //! The sequence number type.
 typedef uint64_t        SequenceNumber;

--- a/framework/areg/base/NEUtilities.hpp
+++ b/framework/areg/base/NEUtilities.hpp
@@ -692,6 +692,34 @@ namespace   NEUtilities
     #pragma warning(default: 4251)
 #endif  // _MSC_VER
     };
+
+    /**
+     * \brief   Converts given value to pointer type ToPtr.
+     *          If ToPtr is not a pointer type, it will convert
+     *          the value to the given type.
+     * \tparam  ToPtr       The type to convert. If this is a pointer type,
+     *                      it will convert the value to pointer.
+     * \tparam  FromType    The type of value to convert.
+     * \param   value       The value to convert.
+     * \return  Returns converted value to pointer type ToPtr. If ToPtr is not
+     *          a pointer type, it will convert the value to the given type.
+     **/
+    template <typename ToPtr, typename FromType>
+    inline constexpr ToPtr convToPtr( FromType value );
+
+    /**
+     * \brief   Converts given pointer or value to numeric type ToNum.
+     *          If FromType is a pointer type, it will convert
+     *          the pointer to numeric value. Otherwise, it will
+     *          convert the value to the given type.
+     * \tparam  ToNum       The numeric type to convert.
+     * \tparam  FromType    The type of value to convert. If this is a pointer type,
+     *                      it will convert the pointer to numeric value.
+     * \param   ptrValue    The pointer or value to convert.
+     * \return  Returns converted pointer or value to numeric type ToNum.
+     **/
+    template <typename ToNum, typename FromType>
+    inline constexpr ToNum convToNum( FromType ptrValue );
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -769,6 +797,34 @@ inline uint64_t NEUtilities::Duration::passedMinutes( void ) const
 inline uint64_t NEUtilities::Duration::durationSinceStart( void ) const
 {
     return static_cast<uint64_t>((mStop > mStart ? (mStop - mStart).count( ) : (std::chrono::steady_clock::now( ) - mStart).count( )));
+}
+
+// ...existing code...
+
+template <typename ToPtr, typename FromType>
+inline constexpr ToPtr NEUtilities::convToPtr( FromType ptrValue )
+{
+    if constexpr (std::is_pointer_v<ToPtr>)
+    {
+        return reinterpret_cast<ToPtr>(static_cast<std::uintptr_t>(ptrValue));
+    }
+    else
+    {
+        return static_cast<ToPtr>(ptrValue);
+    }
+}
+
+template<typename ToNum, typename FromType>
+inline constexpr ToNum NEUtilities::convToNum(FromType value)
+{
+    if constexpr (std::is_pointer_v<FromType>)
+    {
+        return static_cast<ToNum>(reinterpret_cast<std::uintptr_t>(value));
+    }
+    else
+    {
+        return static_cast<ToNum>(value);
+    }
 }
 
 #endif  // AREG_BASE_NEUTILITIES_HPP

--- a/framework/areg/base/private/posix/ProcessPosix.cpp
+++ b/framework/areg/base/private/posix/ProcessPosix.cpp
@@ -29,6 +29,14 @@
 
 void Process::_osInitilize( void )
 {
+#ifdef BIT64
+    constexpr const char _fmtCmdLine[] = "/proc/%lu/cmdline";
+    constexpr const char _fmtExePath[] = "/proc/%lu/exe";
+#else   // defined(BIT32)
+    constexpr const char _fmtCmdLine[] = "/proc/%u/cmdline";
+    constexpr const char _fmtExePath[] = "/proc/%u/exe";
+#endif  // BIT64
+
     mProcessId = ::getpid( );
     mProcessHandle = static_cast<void *>(&mProcessId);
 
@@ -38,11 +46,11 @@ void Process::_osInitilize( void )
     ::memset( buffer, 0, File::MAXIMUM_PATH );
     ::memset( path, 0, 256 );
 
-    sprintf( path, "/proc/%lu/cmdline", mProcessId );
+    sprintf( path, _fmtCmdLine, mProcessId );
     FILE * file = ::fopen( path, "r" );
     if ( (file == nullptr) || (::fgets( buffer, File::MAXIMUM_PATH, file ) == nullptr))
     {
-        sprintf( path, "/proc/%lu/exe", mProcessId );
+        sprintf( path, _fmtExePath, mProcessId );
         ssize_t len = readlink( path, buffer, File::MAXIMUM_PATH );
         if ((len > 0) && (len < File::MAXIMUM_PATH))
         {

--- a/framework/areg/base/private/posix/SynchObjectsPosix.cpp
+++ b/framework/areg/base/private/posix/SynchObjectsPosix.cpp
@@ -19,6 +19,7 @@
 
 #include "areg/base/Thread.hpp"
 #include "areg/base/NEMemory.hpp"
+#include "areg/base/NEUtilities.hpp"
 #include "areg/base/DateTime.hpp"
 #include "areg/base/IESynchObject.hpp"
 #include "areg/base/private/posix/WaitableEventIX.hpp"
@@ -68,7 +69,7 @@ bool Mutex::_osLockMutex( unsigned int timeout )
 
     if ( NESynchTypesIX::SynchObject0 == SynchLockAndWaitIX::waitForSingleObject(*synchMutex, timeout) )
     {
-        mOwnerThreadId.store(reinterpret_cast<id_type>(synchMutex->getOwningThreadId()));
+        mOwnerThreadId.store(NEUtilities::convToNum<id_type, pthread_t>(synchMutex->getOwningThreadId()));
         result = true;
     }
 


### PR DESCRIPTION
Fixed x86 cross-compile with gcc under Linux.
The reason was `ptrhead_t` type, which is defined as `unsigned long` in Linux and `void *` in Cygwin.
Fixed type conversion.

To test:
```bash
cmake -B ./product/cache/gnu-x86-so -DAREG_COMPILER_FAMILY=gnu -DAREG_PROCESSOR=x86
cmake --build ./product/cache/gnu-x86-so -j 20
```
 