### PR TITLE
Feature/616 modify ring stack for adding and inserting element

### DIFF
--- a/framework/areg/base/TERingStack.hpp
+++ b/framework/areg/base/TERingStack.hpp
@@ -982,8 +982,11 @@ RSOperationResult<VALUE> TERingStack<VALUE>::push( const VALUE& newElement )
                 NEMemory::constructElems<VALUE>(block, 1);
                 *block = newElement;
                 ++ mElemCount;
+                return RSOperationResult<VALUE>(mElemCount, true, false, removedElement);
+            } else {
+                OUTPUT_WARN("Failed to resize Ring Stack in TERingStack::push() when overlapping is ResizeOnOverlap");
+                return RSOperationResult<VALUE>(mElemCount, false, false, removedElement);
             }
-            return RSOperationResult<VALUE>(mElemCount, true, false, removedElement);
 
         case NECommon::eRingOverlap::StopOnOverlap:
             OUTPUT_WARN("The new element is not set in Ring Stack, there is no more free space for new element");

--- a/framework/areg/base/TERingStack.hpp
+++ b/framework/areg/base/TERingStack.hpp
@@ -281,15 +281,23 @@ public:
      *          3.  If overlap flag is ResizeOnOverlap, it will resize ring stack
      *              by increasing capacity twice. If capacity was zero, it will set to 2.
      * \param   newElement  New element to set at the end of Ring Stack.
-     * \return  Returns size of stack.
-     **/
+     * \return  A struct containing information about operation:
+    *           - `count`    : current number of elements in the stack after the call
+    *           - `isSuccess`: true if the push succeeded (capacity>0 or resizing worked)
+    *           - `isRemoved`: true when an existing element was displaced (shift overlap)
+    *           - `removedElement`: the element that was removed if \c isRemoved is true
+    **/
     RSOperationResult<VALUE> push( const VALUE& newElement );
 
     /**
      * \brief   Removes element from head and returns value, decreases number of element by one.
      *          The stack should not be empty when method is called.
-     * \return  Returns value of remove element.
-     **/
+     * \return  A struct containing information about operation:
+    *           - `count`    : number of elements remaining after the pop
+    *           - `isSuccess`: true if an element was actually removed (stack not empty)
+    *           - `isRemoved`: true when an element was removed (always same as isSuccess)
+    *           - `removedElement`: the element that was popped, valid only if isRemoved is true
+    **/
     RSOperationResult<VALUE> pop( void );
 
     /**

--- a/framework/areg/base/TERingStack.hpp
+++ b/framework/areg/base/TERingStack.hpp
@@ -290,7 +290,7 @@ public:
      *          The stack should not be empty when method is called.
      * \return  Returns value of remove element.
      **/
-    VALUE pop( void );
+    RSOperationResult<VALUE> pop( void );
 
     /**
      * \brief   Removes all elements from Ring stack and makes it empty.
@@ -998,11 +998,11 @@ RSOperationResult<VALUE> TERingStack<VALUE>::push( const VALUE& newElement )
 }
 
 template <typename VALUE>
-VALUE TERingStack<VALUE>::pop( void )
+RSOperationResult<VALUE> TERingStack<VALUE>::pop( void )
 {
     Lock lock(mSyncObj);
     ASSERT( isEmpty() == false );
-    VALUE result{ };
+    VALUE removedElement{ };
 
     if ( mElemCount != 0u )
     {
@@ -1010,7 +1010,7 @@ VALUE TERingStack<VALUE>::pop( void )
         ASSERT( mStackList != nullptr );
         ASSERT((mHeadPos != mTailPos) || (mElemCount == 1u));
 
-        result = mStackList[mHeadPos];
+        removedElement = mStackList[mHeadPos];
         NEMemory::destroyElems<VALUE>( mStackList + mHeadPos, 1 );
         mHeadPos = (mHeadPos + 1u) % mCapacity;
         -- mElemCount;
@@ -1021,7 +1021,7 @@ VALUE TERingStack<VALUE>::pop( void )
         }
     }
 
-    return result;
+    return RSOperationResult<VALUE>(mElemCount, mElemCount > 0, true, removedElement);
 }
 
 template <typename VALUE>

--- a/framework/areg/base/TERingStack.hpp
+++ b/framework/areg/base/TERingStack.hpp
@@ -30,6 +30,39 @@
 #include "areg/base/NEMath.hpp"
 
 /************************************************************************
+ * Ring Stack Operation Result Structure
+ ************************************************************************/
+/**
+ * \brief   Result structure for ring stack insert/remove operations.
+ *          Tracks operation success, current size, and any removed element.
+ **/
+template <typename VALUE>
+struct SRingStackOperationResult
+{
+    /**
+     * \brief   Current number of elements in the ring stack after the operation
+     **/
+    uint32_t        count           { 0u };
+    /**
+     * \brief   True if the operation succeeded (element inserted/removed/popped).
+     *          For insert: always true if capacity > 0.
+     *          For remove/pop: true if element was found/stack not empty.
+     **/
+    bool            isSuccess       { false };
+    /**
+     * \brief   True if an element was removed during the operation.
+     *          For insert: true if ring was full and overlapped.
+     *          For remove/pop: true if element was removed.
+     **/
+    bool            isRemoved       { false };
+    /**
+     * \brief   The element that was removed, if any.
+     *          Valid only if isRemoved is true.
+     **/
+    VALUE           removedElement  { };
+};
+
+/************************************************************************
  * Hierarchies. Following class are declared.
  ************************************************************************/
 template <typename VALUE> class TERingStack;

--- a/framework/areg/base/TERingStack.hpp
+++ b/framework/areg/base/TERingStack.hpp
@@ -37,7 +37,7 @@
  *          Tracks operation success, current size, and any removed element.
  **/
 template <typename VALUE>
-struct SRingStackOperationResult
+struct RSOperationResult
 {
     /**
      * \brief   Current number of elements in the ring stack after the operation
@@ -283,7 +283,7 @@ public:
      * \param   newElement  New element to set at the end of Ring Stack.
      * \return  Returns size of stack.
      **/
-    uint32_t push( const VALUE& newElement );
+    RSOperationResult<VALUE> push( const VALUE& newElement );
 
     /**
      * \brief   Removes element from head and returns value, decreases number of element by one.
@@ -922,9 +922,12 @@ void TERingStack<VALUE>::freeExtra(void)
 }
 
 template <typename VALUE>
-uint32_t TERingStack<VALUE>::push( const VALUE& newElement )
+RSOperationResult<VALUE> TERingStack<VALUE>::push( const VALUE& newElement )
 {
     Lock lock(mSyncObj);
+
+    VALUE removedElement{ };
+    bool wasRemoved = false;
 
     if ( mElemCount < mCapacity )
     {
@@ -947,6 +950,8 @@ uint32_t TERingStack<VALUE>::push( const VALUE& newElement )
         NEMemory::constructElems<VALUE>(block, 1);
         *block = newElement;
         ++mElemCount;
+
+        return RSOperationResult<VALUE>(mElemCount, true, wasRemoved, removedElement);
     }
     else
     {
@@ -956,6 +961,8 @@ uint32_t TERingStack<VALUE>::push( const VALUE& newElement )
             if (mCapacity != 0u)
             {
                 ASSERT(mStackList != nullptr);
+                removedElement = mStackList[mHeadPos];
+                wasRemoved = true;
                 mTailPos = (mTailPos + 1u) % mCapacity;
                 mHeadPos = (mHeadPos + 1u) % mCapacity;
                 VALUE* block = mStackList + mTailPos;
@@ -963,8 +970,7 @@ uint32_t TERingStack<VALUE>::push( const VALUE& newElement )
                 NEMemory::constructElems<VALUE>(block, 1);
                 *block = newElement;
             }
-            // else capacity == 0 => nothing to do
-            break;
+            return RSOperationResult<VALUE>(mElemCount, true, wasRemoved, removedElement);
 
         case NECommon::eRingOverlap::ResizeOnOverlap:
             // grow buffer (double or at least 1)
@@ -977,20 +983,18 @@ uint32_t TERingStack<VALUE>::push( const VALUE& newElement )
                 *block = newElement;
                 ++ mElemCount;
             }
-            break;
+            return RSOperationResult<VALUE>(mElemCount, true, false, removedElement);
 
         case NECommon::eRingOverlap::StopOnOverlap:
             OUTPUT_WARN("The new element is not set in Ring Stack, there is no more free space for new element");
-            break;  // do nothing
+            return RSOperationResult<VALUE>(mElemCount, false, false, removedElement);
 
         default:
             OUTPUT_ERR("Invalid Overlap action in TERingStack::push()");
             ASSERT(false);
-            break;
+            return RSOperationResult<VALUE>(mElemCount, false, false, removedElement);
         }
     }
-
-    return mElemCount;
 }
 
 template <typename VALUE>

--- a/framework/areg/base/TERingStack.hpp
+++ b/framework/areg/base/TERingStack.hpp
@@ -44,12 +44,6 @@ struct RSOperationResult
      **/
     uint32_t        count           { 0u };
     /**
-     * \brief   True if the operation succeeded (element inserted/removed/popped).
-     *          For insert: always true if capacity > 0.
-     *          For remove/pop: true if element was found/stack not empty.
-     **/
-    bool            isSuccess       { false };
-    /**
      * \brief   True if an element was removed during the operation.
      *          For insert: true if ring was full and overlapped.
      *          For remove/pop: true if element was removed.
@@ -959,7 +953,7 @@ RSOperationResult<VALUE> TERingStack<VALUE>::push( const VALUE& newElement )
         *block = newElement;
         ++mElemCount;
 
-        return RSOperationResult<VALUE>{ mElemCount, true, wasRemoved, removedElement };
+        return RSOperationResult<VALUE>{ mElemCount, wasRemoved, removedElement };
     }
     else
     {
@@ -978,7 +972,7 @@ RSOperationResult<VALUE> TERingStack<VALUE>::push( const VALUE& newElement )
                 NEMemory::constructElems<VALUE>(block, 1);
                 *block = newElement;
             }
-            return RSOperationResult<VALUE>{ mElemCount, true, wasRemoved, removedElement };
+            return RSOperationResult<VALUE>{ mElemCount, wasRemoved, removedElement };
 
         case NECommon::eRingOverlap::ResizeOnOverlap:
             // grow buffer (double or at least 1)
@@ -990,20 +984,20 @@ RSOperationResult<VALUE> TERingStack<VALUE>::push( const VALUE& newElement )
                 NEMemory::constructElems<VALUE>(block, 1);
                 *block = newElement;
                 ++ mElemCount;
-                return RSOperationResult<VALUE>{ mElemCount, true, false, removedElement };
+                return RSOperationResult<VALUE>{ mElemCount, false, removedElement };
             } else {
                 OUTPUT_WARN("Failed to resize Ring Stack in TERingStack::push() when overlapping is ResizeOnOverlap");
-                return RSOperationResult<VALUE>{ mElemCount, false, false, removedElement };
+                return RSOperationResult<VALUE>{ mElemCount, false, removedElement };
             }
 
         case NECommon::eRingOverlap::StopOnOverlap:
             OUTPUT_WARN("The new element is not set in Ring Stack, there is no more free space for new element");
-            return RSOperationResult<VALUE>{ mElemCount, false, false, removedElement };
+            return RSOperationResult<VALUE>{ mElemCount, false, removedElement };
 
         default:
             OUTPUT_ERR("Invalid Overlap action in TERingStack::push()");
             ASSERT(false);
-            return RSOperationResult<VALUE>{ mElemCount, false, false, removedElement };
+            return RSOperationResult<VALUE>{ mElemCount, false, removedElement };
         }
     }
 }
@@ -1031,10 +1025,10 @@ RSOperationResult<VALUE> TERingStack<VALUE>::pop( void )
             mHeadPos = mTailPos = 0u;
         }
     } else {
-        return RSOperationResult<VALUE>{ 0u, false, false, removedElement };
+        return RSOperationResult<VALUE>{ 0u, false, removedElement };
     }
 
-    return RSOperationResult<VALUE>{ mElemCount, true, true, removedElement };
+    return RSOperationResult<VALUE>{ mElemCount, true, removedElement };
 }
 
 template <typename VALUE>

--- a/framework/areg/base/TERingStack.hpp
+++ b/framework/areg/base/TERingStack.hpp
@@ -951,7 +951,7 @@ RSOperationResult<VALUE> TERingStack<VALUE>::push( const VALUE& newElement )
         *block = newElement;
         ++mElemCount;
 
-        return RSOperationResult<VALUE>(mElemCount, true, wasRemoved, removedElement);
+        return RSOperationResult<VALUE>{ mElemCount, true, wasRemoved, removedElement };
     }
     else
     {
@@ -970,7 +970,7 @@ RSOperationResult<VALUE> TERingStack<VALUE>::push( const VALUE& newElement )
                 NEMemory::constructElems<VALUE>(block, 1);
                 *block = newElement;
             }
-            return RSOperationResult<VALUE>(mElemCount, true, wasRemoved, removedElement);
+            return RSOperationResult<VALUE>{ mElemCount, true, wasRemoved, removedElement };
 
         case NECommon::eRingOverlap::ResizeOnOverlap:
             // grow buffer (double or at least 1)
@@ -982,20 +982,20 @@ RSOperationResult<VALUE> TERingStack<VALUE>::push( const VALUE& newElement )
                 NEMemory::constructElems<VALUE>(block, 1);
                 *block = newElement;
                 ++ mElemCount;
-                return RSOperationResult<VALUE>(mElemCount, true, false, removedElement);
+                return RSOperationResult<VALUE>{ mElemCount, true, false, removedElement };
             } else {
                 OUTPUT_WARN("Failed to resize Ring Stack in TERingStack::push() when overlapping is ResizeOnOverlap");
-                return RSOperationResult<VALUE>(mElemCount, false, false, removedElement);
+                return RSOperationResult<VALUE>{ mElemCount, false, false, removedElement };
             }
 
         case NECommon::eRingOverlap::StopOnOverlap:
             OUTPUT_WARN("The new element is not set in Ring Stack, there is no more free space for new element");
-            return RSOperationResult<VALUE>(mElemCount, false, false, removedElement);
+            return RSOperationResult<VALUE>{ mElemCount, false, false, removedElement };
 
         default:
             OUTPUT_ERR("Invalid Overlap action in TERingStack::push()");
             ASSERT(false);
-            return RSOperationResult<VALUE>(mElemCount, false, false, removedElement);
+            return RSOperationResult<VALUE>{ mElemCount, false, false, removedElement };
         }
     }
 }
@@ -1023,10 +1023,10 @@ RSOperationResult<VALUE> TERingStack<VALUE>::pop( void )
             mHeadPos = mTailPos = 0u;
         }
     } else {
-        return RSOperationResult<VALUE>(0u, false, false, removedElement);
+        return RSOperationResult<VALUE>{ 0u, false, false, removedElement };
     }
 
-    return RSOperationResult<VALUE>(mElemCount, true, true, removedElement);
+    return RSOperationResult<VALUE>{ mElemCount, true, true, removedElement };
 }
 
 template <typename VALUE>

--- a/framework/areg/base/TERingStack.hpp
+++ b/framework/areg/base/TERingStack.hpp
@@ -277,7 +277,6 @@ public:
      * \param   newElement  New element to set at the end of Ring Stack.
      * \return  A struct containing information about operation:
     *           - `count`    : current number of elements in the stack after the call
-    *           - `isSuccess`: true if the push succeeded (capacity>0 or resizing worked)
     *           - `isRemoved`: true when an existing element was displaced (shift overlap)
     *           - `removedElement`: the element that was removed if \c isRemoved is true
     **/
@@ -288,7 +287,6 @@ public:
      *          The stack should not be empty when method is called.
      * \return  A struct containing information about operation:
     *           - `count`    : number of elements remaining after the pop
-    *           - `isSuccess`: true if an element was actually removed (stack not empty)
     *           - `isRemoved`: true when an element was removed (always same as isSuccess)
     *           - `removedElement`: the element that was popped, valid only if isRemoved is true
     **/

--- a/framework/areg/base/TERingStack.hpp
+++ b/framework/areg/base/TERingStack.hpp
@@ -1019,9 +1019,11 @@ RSOperationResult<VALUE> TERingStack<VALUE>::pop( void )
         {
             mHeadPos = mTailPos = 0u;
         }
+    } else {
+        return RSOperationResult<VALUE>(0u, false, false, removedElement);
     }
 
-    return RSOperationResult<VALUE>(mElemCount, mElemCount > 0, true, removedElement);
+    return RSOperationResult<VALUE>(mElemCount, true, true, removedElement);
 }
 
 template <typename VALUE>

--- a/framework/areg/logging/private/NetTcpLogger.cpp
+++ b/framework/areg/logging/private/NetTcpLogger.cpp
@@ -118,7 +118,7 @@ void NetTcpLogger::connectedRemoteServiceChannel(const Channel & channel)
     const ITEM_ID& cookie = channel.getCookie();
     while (mRingStack.isEmpty() == false)
     {
-        RemoteMessage msgLog{ mRingStack.pop() };
+        RemoteMessage msgLog{ mRingStack.pop().removedElement };
         msgLog.setSource(cookie);
         reinterpret_cast<NELogging::sLogMessage*>(msgLog.getBuffer())->logCookie = cookie;
         sendMessage(msgLog, Event::eEventPriority::EventPriorityNormal);

--- a/tests/units/TERingStackTest.cpp
+++ b/tests/units/TERingStackTest.cpp
@@ -47,14 +47,12 @@ TEST(TERingStackTest, TestConstructorsStopOnOverlap)
             EXPECT_FALSE(lock.isFull());
             auto lockResult = lock.push(i);
             EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, false);
             EXPECT_TRUE(lock.contains(i));
 
             EXPECT_FALSE(nolock.isFull());
             auto nolockResult = nolock.push(i + static_cast<int>(count));
             EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockResult.isSuccess, true);
             EXPECT_EQ(nolockResult.isRemoved, false);
             EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
         }
@@ -64,14 +62,12 @@ TEST(TERingStackTest, TestConstructorsStopOnOverlap)
             EXPECT_TRUE(lock.isFull());
             auto lockResult = lock.push(i);
             EXPECT_EQ(lockResult.count, count);
-            EXPECT_EQ(lockResult.isSuccess, false);
             EXPECT_EQ(lockResult.isRemoved, false);
             EXPECT_FALSE(lock.contains(i));
 
             EXPECT_TRUE(nolock.isFull());
             auto nolockResult = nolock.push(i + static_cast<int>(count));
             EXPECT_EQ(nolockResult.count, count);
-            EXPECT_EQ(nolockResult.isSuccess, false);
             EXPECT_EQ(nolockResult.isRemoved, false);
             EXPECT_FALSE(nolock.contains(i + static_cast<int>(count)));
         }
@@ -178,14 +174,12 @@ TEST(TERingStackTest, TestConstructorsShiftOnOverlap)
             EXPECT_FALSE(lock.isFull());
             auto lockResult = lock.push(i);
             EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, false);
             EXPECT_TRUE(lock.contains(i));
 
             EXPECT_FALSE(nolock.isFull());
             auto nolockResult = nolock.push(i + static_cast<int>(count));
             EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockResult.isSuccess, true);
             EXPECT_EQ(nolockResult.isRemoved, false);
             EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
         }
@@ -195,7 +189,6 @@ TEST(TERingStackTest, TestConstructorsShiftOnOverlap)
             EXPECT_TRUE(lock.isFull());
             auto lockResult = lock.push(i);
             EXPECT_EQ(lockResult.count, count);
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, true);
             EXPECT_TRUE(lock.contains(i));
             EXPECT_FALSE(lock.contains(i - static_cast<int>(count)));
@@ -203,7 +196,6 @@ TEST(TERingStackTest, TestConstructorsShiftOnOverlap)
             EXPECT_TRUE(nolock.isFull());
             auto nolockResult = nolock.push(i + static_cast<int>(count));
             EXPECT_EQ(nolockResult.count, count);
-            EXPECT_EQ(nolockResult.isSuccess, true);
             EXPECT_EQ(nolockResult.isRemoved, true);
             EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
             EXPECT_FALSE(nolock.contains(i));
@@ -309,14 +301,12 @@ TEST(TERingStackTest, TestConstructorsResizeOnOverlap)
         EXPECT_FALSE(lock.isFull());
         auto lockResult = lock.push(i);
         EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(lockResult.isSuccess, true);
         EXPECT_EQ(lockResult.isRemoved, false);
         EXPECT_TRUE(lock.contains(i));
 
         EXPECT_FALSE(nolock.isFull());
         auto nolockResult = nolock.push(i + static_cast<int>(count));
         EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(nolockResult.isSuccess, true);
         EXPECT_EQ(nolockResult.isRemoved, false);
         EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
 
@@ -417,19 +407,16 @@ TEST(TERingStackTest, TestOperatorsIndex)
         {
             auto lockResult = lockStop.push(i);
             EXPECT_EQ(lockResult.count, i + 1u);
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, false);
             EXPECT_EQ(lockStop[i], i);
 
             auto lockShiftResult = lockShift.push(i + count);
             EXPECT_EQ(lockShiftResult.count, i + 1u);
-            EXPECT_EQ(lockShiftResult.isSuccess, true);
             EXPECT_EQ(lockShiftResult.isRemoved, false);
             EXPECT_EQ(lockShift[i], i + count);
 
             auto lockResizeResult = lockResize.push(i);
             EXPECT_EQ(lockResizeResult.count, i + 1u);
-            EXPECT_EQ(lockResizeResult.isSuccess, true);
             EXPECT_EQ(lockResizeResult.isRemoved, false);
             EXPECT_EQ(lockResize[i], i);
             lockResize[i] = i + loop;
@@ -437,19 +424,16 @@ TEST(TERingStackTest, TestOperatorsIndex)
 
             auto nolockStopResult = nolockStop.push(i);
             EXPECT_EQ(nolockStopResult.count, i + 1u);
-            EXPECT_EQ(nolockStopResult.isSuccess, true);
             EXPECT_EQ(nolockStopResult.isRemoved, false);
             EXPECT_EQ(nolockStop[i], i);
 
             auto nolockShiftResult = nolockShift.push(i + count);
             EXPECT_EQ(nolockShiftResult.count, i + 1u);
-            EXPECT_EQ(nolockShiftResult.isSuccess, true);
             EXPECT_EQ(nolockShiftResult.isRemoved, false);
             EXPECT_EQ(nolockShift[i], i + count);
 
             auto nolockResizeResult = nolockResize.push(i);
             EXPECT_EQ(nolockResizeResult.count, i + 1u);
-            EXPECT_EQ(nolockResizeResult.isSuccess, true);
             EXPECT_EQ(nolockResizeResult.isRemoved, false);
             EXPECT_EQ(nolockResize[i], i);
             nolockResize[i] = i + loop;
@@ -459,14 +443,12 @@ TEST(TERingStackTest, TestOperatorsIndex)
         {
             auto lockStopResult = lockStop.push(i);
             EXPECT_EQ(lockStopResult.count, count);
-            EXPECT_EQ(lockStopResult.isSuccess, false);
             EXPECT_EQ(lockStopResult.isRemoved, false);
             EXPECT_FALSE(lockStop.isValidIndex(i));
             EXPECT_EQ(lockStop[i - count], i - count);
 
             auto lockShiftResult = lockShift.push(i + count);
             EXPECT_EQ(lockShiftResult.count, count);
-            EXPECT_EQ(lockShiftResult.isSuccess, true);
             EXPECT_EQ(lockShiftResult.isRemoved, true);
             EXPECT_FALSE(lockShift.isValidIndex(i));
             EXPECT_EQ(lockShift[lockShift.getSize() - 1], i + count);
@@ -474,7 +456,6 @@ TEST(TERingStackTest, TestOperatorsIndex)
 
             auto lockResizeResult = lockResize.push(i);
             EXPECT_EQ(lockResizeResult.count, i + 1);
-            EXPECT_EQ(lockResizeResult.isSuccess, true);
             EXPECT_EQ(lockResizeResult.isRemoved, false);
             EXPECT_EQ(lockResize[i], i);
             lockResize[i] = i + loop;
@@ -482,14 +463,12 @@ TEST(TERingStackTest, TestOperatorsIndex)
 
             auto nolockStopResult = nolockStop.push(i);
             EXPECT_EQ(nolockStopResult.count, count);
-            EXPECT_EQ(nolockStopResult.isSuccess, false);
             EXPECT_EQ(nolockStopResult.isRemoved, false);
             EXPECT_FALSE(nolockStop.isValidIndex(i));
             EXPECT_EQ(nolockStop[i - count], i - count);
 
             auto nolockShiftResult = nolockShift.push(i + count);
             EXPECT_EQ(nolockShiftResult.count, count);
-            EXPECT_EQ(nolockShiftResult.isSuccess, true);
             EXPECT_EQ(nolockShiftResult.isRemoved, true);
             EXPECT_FALSE(nolockStop.isValidIndex(i));
             EXPECT_EQ(nolockShift[nolockShift.getSize() - 1], i + count);
@@ -497,7 +476,6 @@ TEST(TERingStackTest, TestOperatorsIndex)
 
             auto nolockResizeResult = nolockResize.push(i);
             EXPECT_EQ(nolockResizeResult.count, i + 1u);
-            EXPECT_EQ(nolockResizeResult.isSuccess, true);
             EXPECT_EQ(nolockResizeResult.isRemoved, false);
             EXPECT_EQ(nolockResize[i], i);
             nolockResize[i] = i + loop;
@@ -590,22 +568,18 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         {
             auto lockResult = lockRing.push(i);
             EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, false);
             auto nolockResult = nolockRing.push(i + static_cast<int>(count));
             EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockResult.isSuccess, true);
             EXPECT_EQ(nolockResult.isRemoved, false);
         }
         else
         {
             auto lockResult = lockRing.push(i);
             EXPECT_EQ(lockResult.count, count);
-            EXPECT_EQ(lockResult.isSuccess, false);
             EXPECT_EQ(lockResult.isRemoved, false);
             auto nolockResult = nolockRing.push(i + static_cast<int>(count));
             EXPECT_EQ(nolockResult.count, count);
-            EXPECT_EQ(nolockResult.isSuccess, false);
             EXPECT_EQ(nolockResult.isRemoved, false);
         }
     }
@@ -621,14 +595,14 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         EXPECT_EQ(valLock, resLock);
         auto lockPopResult = lockRing.pop();
         EXPECT_EQ(lockPopResult.removedElement, resLock);
-        EXPECT_EQ(lockPopResult.isSuccess, true);
+        EXPECT_TRUE(lockPopResult.isRemoved);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + i;
         EXPECT_EQ(valNolock, resNolock);
         auto nolockPopResult = nolockRing.pop();
         EXPECT_EQ(nolockPopResult.removedElement, resNolock);
-        EXPECT_EQ(nolockPopResult.isSuccess, true);
+        EXPECT_TRUE(nolockPopResult.isRemoved);
     }
 
     uint32_t remain = count - static_cast<uint32_t>(half);
@@ -643,22 +617,18 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         {
             auto lockResult = lockRing.push(valLock);
             EXPECT_EQ(lockResult.count, remain + static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, false);
             auto nolockResult = nolockRing.push(valNolock);
             EXPECT_EQ(nolockResult.count, remain + static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockResult.isSuccess, true);
             EXPECT_EQ(nolockResult.isRemoved, false);
         }
         else
         {
             auto lockResult = lockRing.push(valLock);
             EXPECT_EQ(lockResult.count, count);
-            EXPECT_EQ(lockResult.isSuccess, false);
             EXPECT_EQ(lockResult.isRemoved, false);
             auto nolockResult = nolockRing.push(valNolock);
             EXPECT_EQ(nolockResult.count, count);
-            EXPECT_EQ(nolockResult.isSuccess, false);
             EXPECT_EQ(nolockResult.isRemoved, false);
         }
     }
@@ -670,14 +640,14 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         EXPECT_EQ(valLock, resLock);
         auto lockPopResult = lockRing.pop();
         EXPECT_EQ(lockPopResult.removedElement, resLock);
-        EXPECT_EQ(lockPopResult.isSuccess, true);
+        EXPECT_TRUE(lockPopResult.isRemoved);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + half + i;
         EXPECT_EQ(valNolock, resNolock);
         auto nolockPopResult = nolockRing.pop();
         EXPECT_EQ(nolockPopResult.removedElement, resNolock);
-        EXPECT_EQ(nolockPopResult.isSuccess, true);
+        EXPECT_TRUE(nolockPopResult.isRemoved);
     }
 
     for (int i = 0; i < static_cast<int>(half); ++i)
@@ -687,20 +657,20 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         EXPECT_EQ(valLock, resLock);
         auto lockPopResult = lockRing.pop();
         EXPECT_EQ(lockPopResult.removedElement, resLock);
-        EXPECT_EQ(lockPopResult.isSuccess, true);
+        EXPECT_TRUE(lockPopResult.isRemoved);
 
         int valNolock = nolockRing[0];
         int resNolock = -1 * i;
         EXPECT_EQ(valNolock, resNolock);
         auto nolockPopResult = nolockRing.pop();
         EXPECT_EQ(nolockPopResult.removedElement, resNolock);
-        EXPECT_EQ(nolockPopResult.isSuccess, true);
+        EXPECT_TRUE(nolockPopResult.isRemoved);
     }
 
     EXPECT_TRUE(lockRing.isEmpty());
     EXPECT_TRUE(nolockRing.isEmpty());
-    EXPECT_FALSE(lockRing.pop().isSuccess);
-    EXPECT_FALSE(nolockRing.pop().isSuccess);
+    EXPECT_FALSE(lockRing.pop().isRemoved);
+    EXPECT_FALSE(nolockRing.pop().isRemoved);
 }
 
 /**
@@ -721,22 +691,18 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         {
             auto lockResult = lockRing.push(i);
             EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, false);
             auto nolockResult = nolockRing.push(i + static_cast<int>(count));
             EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockResult.isSuccess, true);
             EXPECT_EQ(nolockResult.isRemoved, false);
         }
         else
         {
             auto lockResult = lockRing.push(i);
             EXPECT_EQ(lockResult.count, count);
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, true);
             auto nolockResult = nolockRing.push(i + static_cast<int>(count));
             EXPECT_EQ(nolockResult.count, count);
-            EXPECT_EQ(nolockResult.isSuccess, true);
             EXPECT_EQ(nolockResult.isRemoved, true);
         }
     }
@@ -752,14 +718,14 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         EXPECT_EQ(valLock, resLock);
         auto lockPopResult = lockRing.pop();
         EXPECT_EQ(lockPopResult.removedElement, resLock);
-        EXPECT_EQ(lockPopResult.isSuccess, true);
+        EXPECT_TRUE(lockPopResult.isRemoved);
 
         int valNolock = nolockRing[0];
         int resNolock = 2 * static_cast<int>(count) + i;
         EXPECT_EQ(valNolock, resNolock);
         auto nolockPopResult = nolockRing.pop();
         EXPECT_EQ(nolockPopResult.removedElement, resNolock);
-        EXPECT_EQ(nolockPopResult.isSuccess, true);
+        EXPECT_TRUE(nolockPopResult.isRemoved);
     }
 
     uint32_t remain = count - static_cast<uint32_t>(half);
@@ -774,24 +740,20 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         {
             auto lockResult = lockRing.push(valLock);
             EXPECT_EQ(lockResult.count, remain + static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, false);
 
             auto nolockResult = nolockRing.push(valNolock);
             EXPECT_EQ(nolockResult.count, remain + static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockResult.isSuccess, true);
             EXPECT_EQ(nolockResult.isRemoved, false);
         }
         else
         {
             auto lockResult = lockRing.push(valLock);
             EXPECT_EQ(lockResult.count, count);
-            EXPECT_EQ(lockResult.isSuccess, true);
             EXPECT_EQ(lockResult.isRemoved, true);
 
             auto nolockResult = nolockRing.push(valNolock);
             EXPECT_EQ(nolockResult.count, count);
-            EXPECT_EQ(nolockResult.isSuccess, true);
             EXPECT_EQ(nolockResult.isRemoved, true);
         }
     }
@@ -806,20 +768,20 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         EXPECT_EQ(valLock, resLock);
         auto lockPopResult = lockRing.pop();
         EXPECT_EQ(lockPopResult.removedElement, resLock);
-        EXPECT_EQ(lockPopResult.isSuccess, true);
+        EXPECT_TRUE(lockPopResult.isRemoved);
 
         int valNolock = nolockRing[0];
         int resNolock = -1 * i;
         EXPECT_EQ(valNolock, resNolock);
         auto nolockPopResult = nolockRing.pop();
         EXPECT_EQ(nolockPopResult.removedElement, resNolock);
-        EXPECT_EQ(nolockPopResult.isSuccess, true);
+        EXPECT_TRUE(nolockPopResult.isRemoved);
     }
 
     EXPECT_TRUE(lockRing.isEmpty());
     EXPECT_TRUE(nolockRing.isEmpty());
-    EXPECT_FALSE(lockRing.pop().isSuccess);
-    EXPECT_FALSE(nolockRing.pop().isSuccess);
+    EXPECT_FALSE(lockRing.pop().isRemoved);
+    EXPECT_FALSE(nolockRing.pop().isRemoved);
 }
 
 /**
@@ -838,12 +800,10 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
     {
         auto lockResult = lockRing.push(i);
         EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(lockResult.isSuccess, true);
         EXPECT_EQ(lockResult.isRemoved, false);
 
         auto nolockResult = nolockRing.push(i + static_cast<int>(count));
         EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(nolockResult.isSuccess, true);
         EXPECT_EQ(nolockResult.isRemoved, false);
     }
 
@@ -858,14 +818,14 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         EXPECT_EQ(valLock, resLock);
         auto lockPopResult = lockRing.pop();
         EXPECT_EQ(lockPopResult.removedElement, resLock);
-        EXPECT_EQ(lockPopResult.isSuccess, true);
+        EXPECT_TRUE(lockPopResult.isRemoved);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + i;
         EXPECT_EQ(valNolock, resNolock);
         auto nolockPopResult = nolockRing.pop();
         EXPECT_EQ(nolockPopResult.removedElement, resNolock);
-        EXPECT_EQ(nolockPopResult.isSuccess, true);
+        EXPECT_TRUE(nolockPopResult.isRemoved);
     }
 
     uint32_t remain = static_cast<uint32_t>(loop - half);
@@ -878,11 +838,9 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         int valNolock = -1 * i;
         auto lockResult = lockRing.push(valLock);
         EXPECT_EQ(lockResult.count, remain + static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(lockResult.isSuccess, true);
         EXPECT_EQ(lockResult.isRemoved, false);
         auto nolockResult = nolockRing.push(valNolock);
         EXPECT_EQ(nolockResult.count, remain + static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(nolockResult.isSuccess, true);
         EXPECT_EQ(nolockResult.isRemoved, false);
     }
 
@@ -897,14 +855,14 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         EXPECT_EQ(valLock, resLock);
         auto lockPopResult = lockRing.pop();
         EXPECT_EQ(lockPopResult.removedElement, resLock);
-        EXPECT_EQ(lockPopResult.isSuccess, true);
+        EXPECT_TRUE(lockPopResult.isRemoved);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + half + i;
         EXPECT_EQ(valNolock, resNolock);
         auto nolockPopResult = nolockRing.pop();
         EXPECT_EQ(nolockPopResult.removedElement, resNolock);
-        EXPECT_EQ(nolockPopResult.isSuccess, true);
+        EXPECT_TRUE(nolockPopResult.isRemoved);
     }
 
     EXPECT_EQ(lockRing.getSize(), count);
@@ -917,20 +875,20 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         EXPECT_EQ(valLock, resLock);
         auto lockPopResult = lockRing.pop();
         EXPECT_EQ(lockPopResult.removedElement, resLock);
-        EXPECT_EQ(lockPopResult.isSuccess, true);
+        EXPECT_TRUE(lockPopResult.isRemoved);
 
         int valNolock = nolockRing[0];
         int resNolock = -1 * i;
         EXPECT_EQ(valNolock, resNolock);
         auto nolockPopResult = nolockRing.pop();
         EXPECT_EQ(nolockPopResult.removedElement, resNolock);
-        EXPECT_EQ(nolockPopResult.isSuccess, true);
+        EXPECT_TRUE(nolockPopResult.isRemoved);
     }
 
     EXPECT_TRUE(lockRing.isEmpty());
     EXPECT_TRUE(nolockRing.isEmpty());
-    EXPECT_FALSE(lockRing.pop().isSuccess);
-    EXPECT_FALSE(nolockRing.pop().isSuccess);
+    EXPECT_FALSE(lockRing.pop().isRemoved);
+    EXPECT_FALSE(nolockRing.pop().isRemoved);
 }
 
 /**

--- a/tests/units/TERingStackTest.cpp
+++ b/tests/units/TERingStackTest.cpp
@@ -45,22 +45,34 @@ TEST(TERingStackTest, TestConstructorsStopOnOverlap)
         if (i < static_cast<int>(count))
         {
             EXPECT_FALSE(lock.isFull());
-            EXPECT_EQ(lock.push(i).count, static_cast<uint32_t>(i + 1));
+            auto lockResult = lock.push(i);
+            EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, false);
             EXPECT_TRUE(lock.contains(i));
 
             EXPECT_FALSE(nolock.isFull());
-            EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
+            auto nolockResult = nolock.push(i + static_cast<int>(count));
+            EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockResult.isSuccess, true);
+            EXPECT_EQ(nolockResult.isRemoved, false);
             EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
         }
         else
         {
             // no more space
             EXPECT_TRUE(lock.isFull());
-            EXPECT_EQ(lock.push(i).count, count);
+            auto lockResult = lock.push(i);
+            EXPECT_EQ(lockResult.count, count);
+            EXPECT_EQ(lockResult.isSuccess, false);
+            EXPECT_EQ(lockResult.isRemoved, false);
             EXPECT_FALSE(lock.contains(i));
 
             EXPECT_TRUE(nolock.isFull());
-            EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, count);
+            auto nolockResult = nolock.push(i + static_cast<int>(count));
+            EXPECT_EQ(nolockResult.count, count);
+            EXPECT_EQ(nolockResult.isSuccess, false);
+            EXPECT_EQ(nolockResult.isRemoved, false);
             EXPECT_FALSE(nolock.contains(i + static_cast<int>(count)));
         }
     }
@@ -164,23 +176,35 @@ TEST(TERingStackTest, TestConstructorsShiftOnOverlap)
         if (i < static_cast<int>(count))
         {
             EXPECT_FALSE(lock.isFull());
-            EXPECT_EQ(lock.push(i).count, static_cast<uint32_t>(i + 1));
+            auto lockResult = lock.push(i);
+            EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, false);
             EXPECT_TRUE(lock.contains(i));
 
             EXPECT_FALSE(nolock.isFull());
-            EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
+            auto nolockResult = nolock.push(i + static_cast<int>(count));
+            EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockResult.isSuccess, true);
+            EXPECT_EQ(nolockResult.isRemoved, false);
             EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
         }
         else
         {
             // no more space
             EXPECT_TRUE(lock.isFull());
-            EXPECT_EQ(lock.push(i).count, count);
+            auto lockResult = lock.push(i);
+            EXPECT_EQ(lockResult.count, count);
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, true);
             EXPECT_TRUE(lock.contains(i));
             EXPECT_FALSE(lock.contains(i - static_cast<int>(count)));
 
             EXPECT_TRUE(nolock.isFull());
-            EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, count);
+            auto nolockResult = nolock.push(i + static_cast<int>(count));
+            EXPECT_EQ(nolockResult.count, count);
+            EXPECT_EQ(nolockResult.isSuccess, true);
+            EXPECT_EQ(nolockResult.isRemoved, true);
             EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
             EXPECT_FALSE(nolock.contains(i));
         }
@@ -283,11 +307,17 @@ TEST(TERingStackTest, TestConstructorsResizeOnOverlap)
     for (int i = 0; i < loop; ++i)
     {
         EXPECT_FALSE(lock.isFull());
-        EXPECT_EQ(lock.push(i).count, static_cast<uint32_t>(i + 1));
+        auto lockResult = lock.push(i);
+        EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(lockResult.isSuccess, true);
+        EXPECT_EQ(lockResult.isRemoved, false);
         EXPECT_TRUE(lock.contains(i));
 
         EXPECT_FALSE(nolock.isFull());
-        EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
+        auto nolockResult = nolock.push(i + static_cast<int>(count));
+        EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(nolockResult.isSuccess, true);
+        EXPECT_EQ(nolockResult.isRemoved, false);
         EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
 
         if (i >= static_cast<int>(count))
@@ -385,54 +415,90 @@ TEST(TERingStackTest, TestOperatorsIndex)
     {
         if (i < count)
         {
-            EXPECT_EQ(lockStop.push(i).count, i + 1u);
+            auto lockResult = lockStop.push(i);
+            EXPECT_EQ(lockResult.count, i + 1u);
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, false);
             EXPECT_EQ(lockStop[i], i);
 
-            EXPECT_EQ(lockShift.push(i + count).count, i + 1u);
+            auto lockShiftResult = lockShift.push(i + count);
+            EXPECT_EQ(lockShiftResult.count, i + 1u);
+            EXPECT_EQ(lockShiftResult.isSuccess, true);
+            EXPECT_EQ(lockShiftResult.isRemoved, false);
             EXPECT_EQ(lockShift[i], i + count);
 
-            EXPECT_EQ(lockResize.push(i).count, i + 1u);
+            auto lockResizeResult = lockResize.push(i);
+            EXPECT_EQ(lockResizeResult.count, i + 1u);
+            EXPECT_EQ(lockResizeResult.isSuccess, true);
+            EXPECT_EQ(lockResizeResult.isRemoved, false);
             EXPECT_EQ(lockResize[i], i);
             lockResize[i] = i + loop;
             EXPECT_EQ(lockResize[i], i + loop);
 
-            EXPECT_EQ(nolockStop.push(i).count, i + 1u);
+            auto nolockStopResult = nolockStop.push(i);
+            EXPECT_EQ(nolockStopResult.count, i + 1u);
+            EXPECT_EQ(nolockStopResult.isSuccess, true);
+            EXPECT_EQ(nolockStopResult.isRemoved, false);
             EXPECT_EQ(nolockStop[i], i);
 
-            EXPECT_EQ(nolockShift.push(i + count).count, i + 1u);
+            auto nolockShiftResult = nolockShift.push(i + count);
+            EXPECT_EQ(nolockShiftResult.count, i + 1u);
+            EXPECT_EQ(nolockShiftResult.isSuccess, true);
+            EXPECT_EQ(nolockShiftResult.isRemoved, false);
             EXPECT_EQ(nolockShift[i], i + count);
 
-            EXPECT_EQ(nolockResize.push(i).count, i + 1u);
+            auto nolockResizeResult = nolockResize.push(i);
+            EXPECT_EQ(nolockResizeResult.count, i + 1u);
+            EXPECT_EQ(nolockResizeResult.isSuccess, true);
+            EXPECT_EQ(nolockResizeResult.isRemoved, false);
             EXPECT_EQ(nolockResize[i], i);
             nolockResize[i] = i + loop;
             EXPECT_EQ(nolockResize[i], i + loop);
         }
         else
         {
-            EXPECT_EQ(lockStop.push(i).count, count);
+            auto lockStopResult = lockStop.push(i);
+            EXPECT_EQ(lockStopResult.count, count);
+            EXPECT_EQ(lockStopResult.isSuccess, false);
+            EXPECT_EQ(lockStopResult.isRemoved, false);
             EXPECT_FALSE(lockStop.isValidIndex(i));
             EXPECT_EQ(lockStop[i - count], i - count);
 
-            EXPECT_EQ(lockShift.push(i + count).count, count);
-            EXPECT_FALSE(lockStop.isValidIndex(i));
+            auto lockShiftResult = lockShift.push(i + count);
+            EXPECT_EQ(lockShiftResult.count, count);
+            EXPECT_EQ(lockShiftResult.isSuccess, true);
+            EXPECT_EQ(lockShiftResult.isRemoved, true);
+            EXPECT_FALSE(lockShift.isValidIndex(i));
             EXPECT_EQ(lockShift[lockShift.getSize() - 1], i + count);
             EXPECT_EQ(lockShift[0], i + 1);
 
-            EXPECT_EQ(lockResize.push(i).count, i + 1);
+            auto lockResizeResult = lockResize.push(i);
+            EXPECT_EQ(lockResizeResult.count, i + 1);
+            EXPECT_EQ(lockResizeResult.isSuccess, true);
+            EXPECT_EQ(lockResizeResult.isRemoved, false);
             EXPECT_EQ(lockResize[i], i);
             lockResize[i] = i + loop;
             EXPECT_EQ(lockResize[i], i + loop);
 
-            EXPECT_EQ(nolockStop.push(i).count, count);
+            auto nolockStopResult = nolockStop.push(i);
+            EXPECT_EQ(nolockStopResult.count, count);
+            EXPECT_EQ(nolockStopResult.isSuccess, false);
+            EXPECT_EQ(nolockStopResult.isRemoved, false);
             EXPECT_FALSE(nolockStop.isValidIndex(i));
             EXPECT_EQ(nolockStop[i - count], i - count);
 
-            EXPECT_EQ(nolockShift.push(i + count).count, count);
+            auto nolockShiftResult = nolockShift.push(i + count);
+            EXPECT_EQ(nolockShiftResult.count, count);
+            EXPECT_EQ(nolockShiftResult.isSuccess, true);
+            EXPECT_EQ(nolockShiftResult.isRemoved, true);
             EXPECT_FALSE(nolockStop.isValidIndex(i));
-            EXPECT_EQ(nolockShift[lockShift.getSize() - 1], i + count);
+            EXPECT_EQ(nolockShift[nolockShift.getSize() - 1], i + count);
             EXPECT_EQ(nolockShift[0], i + 1);
 
-            EXPECT_EQ(nolockResize.push(i).count, i + 1);
+            auto nolockResizeResult = nolockResize.push(i);
+            EXPECT_EQ(nolockResizeResult.count, i + 1u);
+            EXPECT_EQ(nolockResizeResult.isSuccess, true);
+            EXPECT_EQ(nolockResizeResult.isRemoved, false);
             EXPECT_EQ(nolockResize[i], i);
             nolockResize[i] = i + loop;
             EXPECT_EQ(nolockResize[i], i + loop);
@@ -522,13 +588,25 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
     {
         if (i < static_cast<int>(count))
         {
-            EXPECT_EQ(lockRing.push(i).count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
+            auto lockResult = lockRing.push(i);
+            EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, false);
+            auto nolockResult = nolockRing.push(i + static_cast<int>(count));
+            EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockResult.isSuccess, true);
+            EXPECT_EQ(nolockResult.isRemoved, false);
         }
         else
         {
-            EXPECT_EQ(lockRing.push(i).count, count);
-            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, count);
+            auto lockResult = lockRing.push(i);
+            EXPECT_EQ(lockResult.count, count);
+            EXPECT_EQ(lockResult.isSuccess, false);
+            EXPECT_EQ(lockResult.isRemoved, false);
+            auto nolockResult = nolockRing.push(i + static_cast<int>(count));
+            EXPECT_EQ(nolockResult.count, count);
+            EXPECT_EQ(nolockResult.isSuccess, false);
+            EXPECT_EQ(nolockResult.isRemoved, false);
         }
     }
 
@@ -541,12 +619,16 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         int valLock = lockRing[0];
         int resLock = i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop().removedElement, resLock);
+        auto lockPopResult = lockRing.pop();
+        EXPECT_EQ(lockPopResult.removedElement, resLock);
+        EXPECT_EQ(lockPopResult.isSuccess, true);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
+        auto nolockPopResult = nolockRing.pop();
+        EXPECT_EQ(nolockPopResult.removedElement, resNolock);
+        EXPECT_EQ(nolockPopResult.isSuccess, true);
     }
 
     uint32_t remain = count - static_cast<uint32_t>(half);
@@ -559,13 +641,25 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         int valNolock = -1 * i;
         if (i < half)
         {
-            EXPECT_EQ(lockRing.push(valLock).count, remain + static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockRing.push(valNolock).count, remain + static_cast<uint32_t>(i + 1));
+            auto lockResult = lockRing.push(valLock);
+            EXPECT_EQ(lockResult.count, remain + static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, false);
+            auto nolockResult = nolockRing.push(valNolock);
+            EXPECT_EQ(nolockResult.count, remain + static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockResult.isSuccess, true);
+            EXPECT_EQ(nolockResult.isRemoved, false);
         }
         else
         {
-            EXPECT_EQ(lockRing.push(valLock).count, count);
-            EXPECT_EQ(nolockRing.push(valNolock).count, count);
+            auto lockResult = lockRing.push(valLock);
+            EXPECT_EQ(lockResult.count, count);
+            EXPECT_EQ(lockResult.isSuccess, false);
+            EXPECT_EQ(lockResult.isRemoved, false);
+            auto nolockResult = nolockRing.push(valNolock);
+            EXPECT_EQ(nolockResult.count, count);
+            EXPECT_EQ(nolockResult.isSuccess, false);
+            EXPECT_EQ(nolockResult.isRemoved, false);
         }
     }
 
@@ -574,12 +668,16 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         int valLock = lockRing[0];
         int resLock = static_cast<int>(half) + i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop().removedElement, resLock);
+        auto lockPopResult = lockRing.pop();
+        EXPECT_EQ(lockPopResult.removedElement, resLock);
+        EXPECT_EQ(lockPopResult.isSuccess, true);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + half + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
+        auto nolockPopResult = nolockRing.pop();
+        EXPECT_EQ(nolockPopResult.removedElement, resNolock);
+        EXPECT_EQ(nolockPopResult.isSuccess, true);
     }
 
     for (int i = 0; i < static_cast<int>(half); ++i)
@@ -587,12 +685,16 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         int valLock = lockRing[0];
         int resLock = -1 * (static_cast<int>(count) + i);
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop().removedElement, resLock);
+        auto lockPopResult = lockRing.pop();
+        EXPECT_EQ(lockPopResult.removedElement, resLock);
+        EXPECT_EQ(lockPopResult.isSuccess, true);
 
         int valNolock = nolockRing[0];
         int resNolock = -1 * i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
+        auto nolockPopResult = nolockRing.pop();
+        EXPECT_EQ(nolockPopResult.removedElement, resNolock);
+        EXPECT_EQ(nolockPopResult.isSuccess, true);
     }
 
     EXPECT_TRUE(lockRing.isEmpty());
@@ -615,13 +717,25 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
     {
         if (i < static_cast<int>(count))
         {
-            EXPECT_EQ(lockRing.push(i).count, static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
+            auto lockResult = lockRing.push(i);
+            EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, false);
+            auto nolockResult = nolockRing.push(i + static_cast<int>(count));
+            EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockResult.isSuccess, true);
+            EXPECT_EQ(nolockResult.isRemoved, false);
         }
         else
         {
-            EXPECT_EQ(lockRing.push(i).count, count);
-            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, count);
+            auto lockResult = lockRing.push(i);
+            EXPECT_EQ(lockResult.count, count);
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, true);
+            auto nolockResult = nolockRing.push(i + static_cast<int>(count));
+            EXPECT_EQ(nolockResult.count, count);
+            EXPECT_EQ(nolockResult.isSuccess, true);
+            EXPECT_EQ(nolockResult.isRemoved, true);
         }
     }
 
@@ -634,12 +748,16 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         int valLock = lockRing[0];
         int resLock = static_cast<int>(count) + i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop().removedElement, resLock);
+        auto lockPopResult = lockRing.pop();
+        EXPECT_EQ(lockPopResult.removedElement, resLock);
+        EXPECT_EQ(lockPopResult.isSuccess, true);
 
         int valNolock = nolockRing[0];
         int resNolock = 2 * static_cast<int>(count) + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
+        auto nolockPopResult = nolockRing.pop();
+        EXPECT_EQ(nolockPopResult.removedElement, resNolock);
+        EXPECT_EQ(nolockPopResult.isSuccess, true);
     }
 
     uint32_t remain = count - static_cast<uint32_t>(half);
@@ -652,13 +770,27 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         int valNolock = -1 * i;
         if (i < half)
         {
-            EXPECT_EQ(lockRing.push(valLock).count, remain + static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockRing.push(valNolock).count, remain + static_cast<uint32_t>(i + 1));
+            auto lockResult = lockRing.push(valLock);
+            EXPECT_EQ(lockResult.count, remain + static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, false);
+
+            auto nolockResult = nolockRing.push(valNolock);
+            EXPECT_EQ(nolockResult.count, remain + static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockResult.isSuccess, true);
+            EXPECT_EQ(nolockResult.isRemoved, false);
         }
         else
         {
-            EXPECT_EQ(lockRing.push(valLock).count, count);
-            EXPECT_EQ(nolockRing.push(valNolock).count, count);
+            auto lockResult = lockRing.push(valLock);
+            EXPECT_EQ(lockResult.count, count);
+            EXPECT_EQ(lockResult.isSuccess, true);
+            EXPECT_EQ(lockResult.isRemoved, true);
+
+            auto nolockResult = nolockRing.push(valNolock);
+            EXPECT_EQ(nolockResult.count, count);
+            EXPECT_EQ(nolockResult.isSuccess, true);
+            EXPECT_EQ(nolockResult.isRemoved, true);
         }
     }
 
@@ -670,12 +802,16 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         int valLock = lockRing[0];
         int resLock = -1 * (static_cast<int>(count) + i);
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop().removedElement, resLock);
+        auto lockPopResult = lockRing.pop();
+        EXPECT_EQ(lockPopResult.removedElement, resLock);
+        EXPECT_EQ(lockPopResult.isSuccess, true);
 
         int valNolock = nolockRing[0];
         int resNolock = -1 * i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
+        auto nolockPopResult = nolockRing.pop();
+        EXPECT_EQ(nolockPopResult.removedElement, resNolock);
+        EXPECT_EQ(nolockPopResult.isSuccess, true);
     }
 
     EXPECT_TRUE(lockRing.isEmpty());
@@ -696,8 +832,15 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
     int loop = static_cast<int>(count) * 2;
     for (int i = 0; i < loop; ++i)
     {
-        EXPECT_EQ(lockRing.push(i).count, static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
+        auto lockResult = lockRing.push(i);
+        EXPECT_EQ(lockResult.count, static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(lockResult.isSuccess, true);
+        EXPECT_EQ(lockResult.isRemoved, false);
+
+        auto nolockResult = nolockRing.push(i + static_cast<int>(count));
+        EXPECT_EQ(nolockResult.count, static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(nolockResult.isSuccess, true);
+        EXPECT_EQ(nolockResult.isRemoved, false);
     }
 
     EXPECT_EQ(lockRing.getSize(), static_cast<uint32_t>(loop));
@@ -709,12 +852,16 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         int valLock = lockRing[0];
         int resLock = i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop().removedElement, resLock);
+        auto lockPopResult = lockRing.pop();
+        EXPECT_EQ(lockPopResult.removedElement, resLock);
+        EXPECT_EQ(lockPopResult.isSuccess, true);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
+        auto nolockPopResult = nolockRing.pop();
+        EXPECT_EQ(nolockPopResult.removedElement, resNolock);
+        EXPECT_EQ(nolockPopResult.isSuccess, true);
     }
 
     uint32_t remain = static_cast<uint32_t>(loop - half);
@@ -725,8 +872,14 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
     {
         int valLock = -1 * (static_cast<int>(count) + i);
         int valNolock = -1 * i;
-        EXPECT_EQ(lockRing.push(valLock).count, remain + static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(nolockRing.push(valNolock).count, remain + static_cast<uint32_t>(i + 1));
+        auto lockResult = lockRing.push(valLock);
+        EXPECT_EQ(lockResult.count, remain + static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(lockResult.isSuccess, true);
+        EXPECT_EQ(lockResult.isRemoved, false);
+        auto nolockResult = nolockRing.push(valNolock);
+        EXPECT_EQ(nolockResult.count, remain + static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(nolockResult.isSuccess, true);
+        EXPECT_EQ(nolockResult.isRemoved, false);
     }
 
     uint32_t size = remain + count;
@@ -738,12 +891,16 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         int valLock = lockRing[0];
         int resLock = static_cast<int>(half) + i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop().removedElement, resLock);
+        auto lockPopResult = lockRing.pop();
+        EXPECT_EQ(lockPopResult.removedElement, resLock);
+        EXPECT_EQ(lockPopResult.isSuccess, true);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + half + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
+        auto nolockPopResult = nolockRing.pop();
+        EXPECT_EQ(nolockPopResult.removedElement, resNolock);
+        EXPECT_EQ(nolockPopResult.isSuccess, true);
     }
 
     EXPECT_EQ(lockRing.getSize(), count);
@@ -754,12 +911,16 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         int valLock = lockRing[0];
         int resLock = -1 * (static_cast<int>(count) + i);
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop().removedElement, resLock);
+        auto lockPopResult = lockRing.pop();
+        EXPECT_EQ(lockPopResult.removedElement, resLock);
+        EXPECT_EQ(lockPopResult.isSuccess, true);
 
         int valNolock = nolockRing[0];
         int resNolock = -1 * i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
+        auto nolockPopResult = nolockRing.pop();
+        EXPECT_EQ(nolockPopResult.removedElement, resNolock);
+        EXPECT_EQ(nolockPopResult.isSuccess, true);
     }
 
     EXPECT_TRUE(lockRing.isEmpty());

--- a/tests/units/TERingStackTest.cpp
+++ b/tests/units/TERingStackTest.cpp
@@ -45,22 +45,22 @@ TEST(TERingStackTest, TestConstructorsStopOnOverlap)
         if (i < static_cast<int>(count))
         {
             EXPECT_FALSE(lock.isFull());
-            EXPECT_EQ(lock.push(i), static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lock.push(i).count, static_cast<uint32_t>(i + 1));
             EXPECT_TRUE(lock.contains(i));
 
             EXPECT_FALSE(nolock.isFull());
-            EXPECT_EQ(nolock.push(i + static_cast<int>(count)), static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
             EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
         }
         else
         {
             // no more space
             EXPECT_TRUE(lock.isFull());
-            EXPECT_EQ(lock.push(i), count);
+            EXPECT_EQ(lock.push(i).count, count);
             EXPECT_FALSE(lock.contains(i));
 
             EXPECT_TRUE(nolock.isFull());
-            EXPECT_EQ(nolock.push(i + static_cast<int>(count)), count);
+            EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, count);
             EXPECT_FALSE(nolock.contains(i + static_cast<int>(count)));
         }
     }
@@ -164,23 +164,23 @@ TEST(TERingStackTest, TestConstructorsShiftOnOverlap)
         if (i < static_cast<int>(count))
         {
             EXPECT_FALSE(lock.isFull());
-            EXPECT_EQ(lock.push(i), static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lock.push(i).count, static_cast<uint32_t>(i + 1));
             EXPECT_TRUE(lock.contains(i));
 
             EXPECT_FALSE(nolock.isFull());
-            EXPECT_EQ(nolock.push(i + static_cast<int>(count)), static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
             EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
         }
         else
         {
             // no more space
             EXPECT_TRUE(lock.isFull());
-            EXPECT_EQ(lock.push(i), count);
+            EXPECT_EQ(lock.push(i).count, count);
             EXPECT_TRUE(lock.contains(i));
             EXPECT_FALSE(lock.contains(i - static_cast<int>(count)));
 
             EXPECT_TRUE(nolock.isFull());
-            EXPECT_EQ(nolock.push(i + static_cast<int>(count)), count);
+            EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, count);
             EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
             EXPECT_FALSE(nolock.contains(i));
         }
@@ -283,11 +283,11 @@ TEST(TERingStackTest, TestConstructorsResizeOnOverlap)
     for (int i = 0; i < loop; ++i)
     {
         EXPECT_FALSE(lock.isFull());
-        EXPECT_EQ(lock.push(i), static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(lock.push(i).count, static_cast<uint32_t>(i + 1));
         EXPECT_TRUE(lock.contains(i));
 
         EXPECT_FALSE(nolock.isFull());
-        EXPECT_EQ(nolock.push(i + static_cast<int>(count)), static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(nolock.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
         EXPECT_TRUE(nolock.contains(i + static_cast<int>(count)));
 
         if (i >= static_cast<int>(count))
@@ -385,54 +385,54 @@ TEST(TERingStackTest, TestOperatorsIndex)
     {
         if (i < count)
         {
-            EXPECT_EQ(lockStop.push(i), i + 1u);
+            EXPECT_EQ(lockStop.push(i).count, i + 1u);
             EXPECT_EQ(lockStop[i], i);
 
-            EXPECT_EQ(lockShift.push(i + count), i + 1u);
+            EXPECT_EQ(lockShift.push(i + count).count, i + 1u);
             EXPECT_EQ(lockShift[i], i + count);
 
-            EXPECT_EQ(lockResize.push(i), i + 1u);
+            EXPECT_EQ(lockResize.push(i).count, i + 1u);
             EXPECT_EQ(lockResize[i], i);
             lockResize[i] = i + loop;
             EXPECT_EQ(lockResize[i], i + loop);
 
-            EXPECT_EQ(nolockStop.push(i), i + 1u);
+            EXPECT_EQ(nolockStop.push(i).count, i + 1u);
             EXPECT_EQ(nolockStop[i], i);
 
-            EXPECT_EQ(nolockShift.push(i + count), i + 1u);
+            EXPECT_EQ(nolockShift.push(i + count).count, i + 1u);
             EXPECT_EQ(nolockShift[i], i + count);
 
-            EXPECT_EQ(nolockResize.push(i), i + 1u);
+            EXPECT_EQ(nolockResize.push(i).count, i + 1u);
             EXPECT_EQ(nolockResize[i], i);
             nolockResize[i] = i + loop;
             EXPECT_EQ(nolockResize[i], i + loop);
         }
         else
         {
-            EXPECT_EQ(lockStop.push(i), count);
+            EXPECT_EQ(lockStop.push(i).count, count);
             EXPECT_FALSE(lockStop.isValidIndex(i));
             EXPECT_EQ(lockStop[i - count], i - count);
 
-            EXPECT_EQ(lockShift.push(i + count), count);
+            EXPECT_EQ(lockShift.push(i + count).count, count);
             EXPECT_FALSE(lockStop.isValidIndex(i));
             EXPECT_EQ(lockShift[lockShift.getSize() - 1], i + count);
             EXPECT_EQ(lockShift[0], i + 1);
 
-            EXPECT_EQ(lockResize.push(i), i + 1);
+            EXPECT_EQ(lockResize.push(i).count, i + 1);
             EXPECT_EQ(lockResize[i], i);
             lockResize[i] = i + loop;
             EXPECT_EQ(lockResize[i], i + loop);
 
-            EXPECT_EQ(nolockStop.push(i), count);
+            EXPECT_EQ(nolockStop.push(i).count, count);
             EXPECT_FALSE(nolockStop.isValidIndex(i));
             EXPECT_EQ(nolockStop[i - count], i - count);
 
-            EXPECT_EQ(nolockShift.push(i + count), count);
+            EXPECT_EQ(nolockShift.push(i + count).count, count);
             EXPECT_FALSE(nolockStop.isValidIndex(i));
             EXPECT_EQ(nolockShift[lockShift.getSize() - 1], i + count);
             EXPECT_EQ(nolockShift[0], i + 1);
 
-            EXPECT_EQ(nolockResize.push(i), i + 1);
+            EXPECT_EQ(nolockResize.push(i).count, i + 1);
             EXPECT_EQ(nolockResize[i], i);
             nolockResize[i] = i + loop;
             EXPECT_EQ(nolockResize[i], i + loop);
@@ -522,13 +522,13 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
     {
         if (i < static_cast<int>(count))
         {
-            EXPECT_EQ(lockRing.push(i), static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)), static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockRing.push(i).count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
         }
         else
         {
-            EXPECT_EQ(lockRing.push(i), count);
-            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)), count);
+            EXPECT_EQ(lockRing.push(i).count, count);
+            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, count);
         }
     }
 
@@ -541,12 +541,12 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         int valLock = lockRing[0];
         int resLock = i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop(), resLock);
+        EXPECT_EQ(lockRing.pop().removedElement, resLock);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop(), resNolock);
+        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
     }
 
     uint32_t remain = count - static_cast<uint32_t>(half);
@@ -559,13 +559,13 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         int valNolock = -1 * i;
         if (i < half)
         {
-            EXPECT_EQ(lockRing.push(valLock), remain + static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockRing.push(valNolock), remain + static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockRing.push(valLock).count, remain + static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockRing.push(valNolock).count, remain + static_cast<uint32_t>(i + 1));
         }
         else
         {
-            EXPECT_EQ(lockRing.push(valLock), count);
-            EXPECT_EQ(nolockRing.push(valNolock), count);
+            EXPECT_EQ(lockRing.push(valLock).count, count);
+            EXPECT_EQ(nolockRing.push(valNolock).count, count);
         }
     }
 
@@ -574,12 +574,12 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         int valLock = lockRing[0];
         int resLock = static_cast<int>(half) + i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop(), resLock);
+        EXPECT_EQ(lockRing.pop().removedElement, resLock);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + half + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop(), resNolock);
+        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
     }
 
     for (int i = 0; i < static_cast<int>(half); ++i)
@@ -587,12 +587,12 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
         int valLock = lockRing[0];
         int resLock = -1 * (static_cast<int>(count) + i);
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop(), resLock);
+        EXPECT_EQ(lockRing.pop().removedElement, resLock);
 
         int valNolock = nolockRing[0];
         int resNolock = -1 * i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop(), resNolock);
+        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
     }
 
     EXPECT_TRUE(lockRing.isEmpty());
@@ -615,13 +615,13 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
     {
         if (i < static_cast<int>(count))
         {
-            EXPECT_EQ(lockRing.push(i), static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)), static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockRing.push(i).count, static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
         }
         else
         {
-            EXPECT_EQ(lockRing.push(i), count);
-            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)), count);
+            EXPECT_EQ(lockRing.push(i).count, count);
+            EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, count);
         }
     }
 
@@ -634,12 +634,12 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         int valLock = lockRing[0];
         int resLock = static_cast<int>(count) + i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop(), resLock);
+        EXPECT_EQ(lockRing.pop().removedElement, resLock);
 
         int valNolock = nolockRing[0];
         int resNolock = 2 * static_cast<int>(count) + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop(), resNolock);
+        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
     }
 
     uint32_t remain = count - static_cast<uint32_t>(half);
@@ -652,13 +652,13 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         int valNolock = -1 * i;
         if (i < half)
         {
-            EXPECT_EQ(lockRing.push(valLock), remain + static_cast<uint32_t>(i + 1));
-            EXPECT_EQ(nolockRing.push(valNolock), remain + static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(lockRing.push(valLock).count, remain + static_cast<uint32_t>(i + 1));
+            EXPECT_EQ(nolockRing.push(valNolock).count, remain + static_cast<uint32_t>(i + 1));
         }
         else
         {
-            EXPECT_EQ(lockRing.push(valLock), count);
-            EXPECT_EQ(nolockRing.push(valNolock), count);
+            EXPECT_EQ(lockRing.push(valLock).count, count);
+            EXPECT_EQ(nolockRing.push(valNolock).count, count);
         }
     }
 
@@ -670,12 +670,12 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
         int valLock = lockRing[0];
         int resLock = -1 * (static_cast<int>(count) + i);
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop(), resLock);
+        EXPECT_EQ(lockRing.pop().removedElement, resLock);
 
         int valNolock = nolockRing[0];
         int resNolock = -1 * i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop(), resNolock);
+        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
     }
 
     EXPECT_TRUE(lockRing.isEmpty());
@@ -696,8 +696,8 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
     int loop = static_cast<int>(count) * 2;
     for (int i = 0; i < loop; ++i)
     {
-        EXPECT_EQ(lockRing.push(i), static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)), static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(lockRing.push(i).count, static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(nolockRing.push(i + static_cast<int>(count)).count, static_cast<uint32_t>(i + 1));
     }
 
     EXPECT_EQ(lockRing.getSize(), static_cast<uint32_t>(loop));
@@ -709,12 +709,12 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         int valLock = lockRing[0];
         int resLock = i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop(), resLock);
+        EXPECT_EQ(lockRing.pop().removedElement, resLock);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop(), resNolock);
+        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
     }
 
     uint32_t remain = static_cast<uint32_t>(loop - half);
@@ -725,8 +725,8 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
     {
         int valLock = -1 * (static_cast<int>(count) + i);
         int valNolock = -1 * i;
-        EXPECT_EQ(lockRing.push(valLock), remain + static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(nolockRing.push(valNolock), remain + static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(lockRing.push(valLock).count, remain + static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(nolockRing.push(valNolock).count, remain + static_cast<uint32_t>(i + 1));
     }
 
     uint32_t size = remain + count;
@@ -738,12 +738,12 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         int valLock = lockRing[0];
         int resLock = static_cast<int>(half) + i;
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop(), resLock);
+        EXPECT_EQ(lockRing.pop().removedElement, resLock);
 
         int valNolock = nolockRing[0];
         int resNolock = static_cast<int>(count) + half + i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop(), resNolock);
+        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
     }
 
     EXPECT_EQ(lockRing.getSize(), count);
@@ -754,12 +754,12 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
         int valLock = lockRing[0];
         int resLock = -1 * (static_cast<int>(count) + i);
         EXPECT_EQ(valLock, resLock);
-        EXPECT_EQ(lockRing.pop(), resLock);
+        EXPECT_EQ(lockRing.pop().removedElement, resLock);
 
         int valNolock = nolockRing[0];
         int resNolock = -1 * i;
         EXPECT_EQ(valNolock, resNolock);
-        EXPECT_EQ(nolockRing.pop(), resNolock);
+        EXPECT_EQ(nolockRing.pop().removedElement, resNolock);
     }
 
     EXPECT_TRUE(lockRing.isEmpty());
@@ -1051,8 +1051,8 @@ TEST(TERingStackTest, TestStreaming)
     LockRing lockStop(count, NECommon::eRingOverlap::StopOnOverlap), lockShift(0, NECommon::eRingOverlap::ShiftOnOverlap);
     for (int i = 0; i < static_cast<int>(count); ++i)
     {
-        EXPECT_EQ(lockStop.push(i), static_cast<uint32_t>(i + 1));
-        EXPECT_EQ(lockShift.push(i), 0u);
+        EXPECT_EQ(lockStop.push(i).count, static_cast<uint32_t>(i + 1));
+        EXPECT_EQ(lockShift.push(i).count, 0u);
     }
 
     SharedBuffer stream;

--- a/tests/units/TERingStackTest.cpp
+++ b/tests/units/TERingStackTest.cpp
@@ -699,6 +699,8 @@ TEST(TERingStackTest, TestPushPopStopOnOverlap)
 
     EXPECT_TRUE(lockRing.isEmpty());
     EXPECT_TRUE(nolockRing.isEmpty());
+    EXPECT_FALSE(lockRing.pop().isSuccess);
+    EXPECT_FALSE(nolockRing.pop().isSuccess);
 }
 
 /**
@@ -816,6 +818,8 @@ TEST(TERingStackTest, TestPushPopShiftOnOverlap)
 
     EXPECT_TRUE(lockRing.isEmpty());
     EXPECT_TRUE(nolockRing.isEmpty());
+    EXPECT_FALSE(lockRing.pop().isSuccess);
+    EXPECT_FALSE(nolockRing.pop().isSuccess);
 }
 
 /**
@@ -925,6 +929,8 @@ TEST(TERingStackTest, TestPushPopResizeOnOverlap)
 
     EXPECT_TRUE(lockRing.isEmpty());
     EXPECT_TRUE(nolockRing.isEmpty());
+    EXPECT_FALSE(lockRing.pop().isSuccess);
+    EXPECT_FALSE(nolockRing.pop().isSuccess);
 }
 
 /**


### PR DESCRIPTION
## Summary
Modifies the push and pop methods to return a struct containing additional useful information.

Closes [#616](https://github.com/aregtech/areg-sdk/issues/616)

## Changes
- Added struct, `RSOperationResult`, containing the following information to `TERingStack.cpp`:
  1. `count` : The number of elements in the Ring Stack after a push/pop operation
  2. `isRemoved` : A flag that is true when an element is removed (shift overlap, or pop on non-empty Ring Stack)
  3. `removedElement` : The element that was removed, if any
- `push` and `pop` methods now return the above struct
- Modified existing tests to handle the new return struct
- Added additional checks to tests for new variables in the struct
- Updated line 121 of `NetTcpLogger.cpp` to handle the new return struct from pop

## Testing
Build:
```cmake -B .\build ` ```
```cmake --build .\build --config Release```
Test:
`.\product\build\msvc-cl\windows-64-x86_64-release-shared\bin\areg-unit-tests.exe --gtest_filter="TERingStackTest*"`

Project builds and all 14 TERingStack tests pass.
All 359 tests from the full testing suite still pass.

## Checklist
[x] I have read CONTRIBUTING.md

Signed-off-by: Collin Shields