### PR TITLE
Fixed bug of releasing per thread cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .idea
 
 build/*
+build-*/
 out/*
 product/*
 tools/*.zip

--- a/framework/areg/base/SharedBuffer.hpp
+++ b/framework/areg/base/SharedBuffer.hpp
@@ -520,7 +520,7 @@ protected:
      * \return  Returns the current writing position in the initialized buffer; returns
      *          INVALID_CURSOR_POSITION if the buffer is invalid.
      **/
-    virtual uint32_t init_buffer(uint8_t* newBuffer, uint32_t bufLength, bool makeCopy) const noexcept;
+    uint32_t init_buffer(uint8_t* newBuffer, uint32_t bufLength, bool makeCopy) const noexcept final;
 
 protected:
 

--- a/framework/areg/base/private/posix/SyncLockAndWaitPosix.cpp
+++ b/framework/areg/base/private/posix/SyncLockAndWaitPosix.cpp
@@ -25,6 +25,7 @@
 #include "areg/base/SyncPrimitives.hpp"
 #include "areg/base/Thread.hpp"
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <errno.h>
 
@@ -249,7 +250,19 @@ inline uint32_t _wait_any_sleep(std::atomic<uint32_t>& firedWord, uint32_t msTim
 
 } // anonymous namespace
 
-// WaitAny path: register nodes, early-exit check, sleep, deregister.
+// WaitAny path: register nodes, then loop { arm, try-acquire, sleep } until a
+// waitable is actually owned, the wait times out, or an async signal arrives.
+//
+// CRITICAL: being woken because a waitable became signaled does NOT mean this
+// thread owns it. Between the owner releasing (mutex owner -> 0, auto-reset
+// event / semaphore count -> available) and this thread claiming it, another
+// thread -- including the releaser itself re-locking through the early acquire
+// scan below -- can take it first. When that happens notify_request_ownership()
+// returns false and the thread MUST wait again. Returning success on a failed
+// ownership request lets two threads both believe they hold the same mutex, or
+// lets several threads pass the same auto-reset event (can_signal_threads() is
+// true for events/semaphores, so notify_any_waiters() wakes them all and only
+// the notify_request_ownership() winner is the real owner).
 int32_t SyncLockAndWaitPosix::_wait_any_new(WaitablePosix** listWaitables, int32_t count, uint32_t msTimeout) noexcept
 {
     const pthread_t self{ ::pthread_self() };
@@ -258,8 +271,8 @@ int32_t SyncLockAndWaitPosix::_wait_any_new(WaitablePosix** listWaitables, int32
     alignas(64) std::atomic<uint32_t> firedWord{ SYNC_FIRE_INVALID };
     WaiterNode nodes[areg::MAXIMUM_WAITING_OBJECTS];
 
-    // Registration:
-    // Register BEFORE checking signaled state.
+    // Register the waiter nodes once for the whole call, BEFORE checking the
+    // signaled state, so no wake-up can be lost while we contend below.
     for (int32_t i{ 0 }; i < count; ++i)
     {
         nodes[i].mFiredWord  = &firedWord;
@@ -267,56 +280,86 @@ int32_t SyncLockAndWaitPosix::_wait_any_new(WaitablePosix** listWaitables, int32
         listWaitables[i]->register_waiter(&nodes[i]);
     }
 
-    // Early-exit check (already signaled)
-    int32_t ownedIndex{ areg::INVALID_INDEX };
-    for (int32_t i{ 0 }; i < count; ++i)
+    // Absolute deadline computed once: a re-wait after a lost ownership race
+    // must not restart the timeout, otherwise a contended timed wait could
+    // block far longer than the caller requested.
+    using Clock = std::chrono::steady_clock;
+    const bool              infinite{ msTimeout == areg::WAIT_INFINITE };
+    const Clock::time_point deadline{ infinite
+                                    ? Clock::time_point::max()
+                                    : Clock::now() + std::chrono::milliseconds(msTimeout) };
+
+    int32_t resultCode{ static_cast<int32_t>(areg::os::SyncSignal::Timeout) };
+
+    for ( ; ; )
     {
-        WaitablePosix* w{ listWaitables[i] };
-        if (w->check_signaled(self) && w->notify_request_ownership(self))
+        // Arm the fire word BEFORE re-checking the signaled state. A signal that
+        // arrives after this point is either observed by the acquire scan below
+        // or leaves firedWord != SYNC_FIRE_INVALID so the futex wait returns at
+        // once -- in neither case is the wake-up lost.
+        firedWord.store(SYNC_FIRE_INVALID, std::memory_order_release);
+
+        // Try to actually take ownership of any currently-signaled waitable.
+        int32_t acquired{ areg::INVALID_INDEX };
+        for (int32_t i{ 0 }; i < count; ++i)
         {
-            ownedIndex = i;
-            uint32_t expected{ SYNC_FIRE_INVALID };
-            if (firedWord.compare_exchange_strong(
-                    expected, static_cast<uint32_t>(i),
-                    std::memory_order_acq_rel, std::memory_order_relaxed))
+            WaitablePosix* w{ listWaitables[i] };
+            if (w->check_signaled(self) && w->notify_request_ownership(self))
             {
                 w->notify_released_threads(1);
+                acquired = i;
+                break;
             }
+        }
+
+        if (acquired != areg::INVALID_INDEX)
+        {
+            resultCode = acquired;
             break;
         }
-    }
 
-    // Sleep if not already fired:
-    if (firedWord.load(std::memory_order_acquire) == SYNC_FIRE_INVALID)
-    {
-        // Register in the WaitAny registry so notify_async_signal() can reach us.
+        // Remaining time for this sleep (honours the absolute deadline).
+        uint32_t remaining{ areg::WAIT_INFINITE };
+        if (!infinite)
+        {
+            const Clock::time_point now{ Clock::now() };
+            if (now >= deadline)
+            {
+                resultCode = static_cast<int32_t>(areg::os::SyncSignal::Timeout);
+                break;
+            }
+
+            const int64_t ms{ std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count() };
+            remaining = static_cast<uint32_t>(ms <= 0 ? 1 : ms);
+        }
+
+        // Register in the WaitAny registry so notify_async_signal() can reach
+        // this thread, sleep until firedWord changes, then deregister.
         WaitAnyRegistryMap& mapAny{ SyncLockAndWaitPosix::_map_wait_any_ids() };
         mapAny.register_resource_object(to_num<ptr_type>(self), &firedWord);
-        const uint32_t woken{ _wait_any_sleep(firedWord, msTimeout) };
+        const uint32_t woken{ _wait_any_sleep(firedWord, remaining) };
         mapAny.unregister_resource_object(to_num<ptr_type>(self));
 
         if (woken == SYNC_FIRE_INVALID)
         {
-            uint32_t expected{ SYNC_FIRE_INVALID };
-            firedWord.compare_exchange_strong(
-                expected,
-                static_cast<uint32_t>(areg::os::SyncSignal::Timeout),
-                std::memory_order_acq_rel,
-                std::memory_order_relaxed);
+            resultCode = static_cast<int32_t>(areg::os::SyncSignal::Timeout);
+            break;
         }
+
+        if (woken == static_cast<uint32_t>(areg::os::SyncSignal::AsyncSignal))
+        {
+            resultCode = static_cast<int32_t>(areg::os::SyncSignal::AsyncSignal);
+            break;
+        }
+
+        // A waitable fired: loop back and try to claim it. It may have been
+        // stolen meanwhile, in which case we arm and wait again.
     }
 
     for (int32_t i{ 0 }; i < count; ++i)
         listWaitables[i]->unregister_waiter(&nodes[i]);
 
-    // Acquire the winning waitable, unless the early-exit above already took this very one.
-    const uint32_t result{ firedWord.load(std::memory_order_acquire) };
-    if ((static_cast<int32_t>(result) != ownedIndex) && (result < static_cast<uint32_t>(areg::MAXIMUM_WAITING_OBJECTS)))
-    {
-        listWaitables[static_cast<int32_t>(result)]->notify_request_ownership(self);
-    }
-
-    return static_cast<int32_t>(result);
+    return resultCode;
 }
 
 #endif  // defined(__linux__) || defined(__APPLE__) || defined(__CYGWIN__)

--- a/framework/areg/base/private/posix/SyncLockAndWaitPosix.cpp
+++ b/framework/areg/base/private/posix/SyncLockAndWaitPosix.cpp
@@ -250,29 +250,13 @@ inline uint32_t _wait_any_sleep(std::atomic<uint32_t>& firedWord, uint32_t msTim
 
 } // anonymous namespace
 
-// WaitAny path: register nodes, then loop { arm, try-acquire, sleep } until a
-// waitable is actually owned, the wait times out, or an async signal arrives.
-//
-// CRITICAL: being woken because a waitable became signaled does NOT mean this
-// thread owns it. Between the owner releasing (mutex owner -> 0, auto-reset
-// event / semaphore count -> available) and this thread claiming it, another
-// thread -- including the releaser itself re-locking through the early acquire
-// scan below -- can take it first. When that happens notify_request_ownership()
-// returns false and the thread MUST wait again. Returning success on a failed
-// ownership request lets two threads both believe they hold the same mutex, or
-// lets several threads pass the same auto-reset event (can_signal_threads() is
-// true for events/semaphores, so notify_any_waiters() wakes them all and only
-// the notify_request_ownership() winner is the real owner).
 int32_t SyncLockAndWaitPosix::_wait_any_new(WaitablePosix** listWaitables, int32_t count, uint32_t msTimeout) noexcept
 {
     const pthread_t self{ ::pthread_self() };
 
-    // Stack-allocated fire word and waiter nodes.
     alignas(64) std::atomic<uint32_t> firedWord{ SYNC_FIRE_INVALID };
     WaiterNode nodes[areg::MAXIMUM_WAITING_OBJECTS];
 
-    // Register the waiter nodes once for the whole call, BEFORE checking the
-    // signaled state, so no wake-up can be lost while we contend below.
     for (int32_t i{ 0 }; i < count; ++i)
     {
         nodes[i].mFiredWord  = &firedWord;
@@ -280,9 +264,6 @@ int32_t SyncLockAndWaitPosix::_wait_any_new(WaitablePosix** listWaitables, int32
         listWaitables[i]->register_waiter(&nodes[i]);
     }
 
-    // Absolute deadline computed once: a re-wait after a lost ownership race
-    // must not restart the timeout, otherwise a contended timed wait could
-    // block far longer than the caller requested.
     using Clock = std::chrono::steady_clock;
     const bool              infinite{ msTimeout == areg::WAIT_INFINITE };
     const Clock::time_point deadline{ infinite
@@ -293,10 +274,6 @@ int32_t SyncLockAndWaitPosix::_wait_any_new(WaitablePosix** listWaitables, int32
 
     for ( ; ; )
     {
-        // Arm the fire word BEFORE re-checking the signaled state. A signal that
-        // arrives after this point is either observed by the acquire scan below
-        // or leaves firedWord != SYNC_FIRE_INVALID so the futex wait returns at
-        // once -- in neither case is the wake-up lost.
         firedWord.store(SYNC_FIRE_INVALID, std::memory_order_release);
 
         // Try to actually take ownership of any currently-signaled waitable.
@@ -318,7 +295,6 @@ int32_t SyncLockAndWaitPosix::_wait_any_new(WaitablePosix** listWaitables, int32
             break;
         }
 
-        // Remaining time for this sleep (honours the absolute deadline).
         uint32_t remaining{ areg::WAIT_INFINITE };
         if (!infinite)
         {
@@ -333,8 +309,6 @@ int32_t SyncLockAndWaitPosix::_wait_any_new(WaitablePosix** listWaitables, int32
             remaining = static_cast<uint32_t>(ms <= 0 ? 1 : ms);
         }
 
-        // Register in the WaitAny registry so notify_async_signal() can reach
-        // this thread, sleep until firedWord changes, then deregister.
         WaitAnyRegistryMap& mapAny{ SyncLockAndWaitPosix::_map_wait_any_ids() };
         mapAny.register_resource_object(to_num<ptr_type>(self), &firedWord);
         const uint32_t woken{ _wait_any_sleep(firedWord, remaining) };
@@ -351,9 +325,6 @@ int32_t SyncLockAndWaitPosix::_wait_any_new(WaitablePosix** listWaitables, int32
             resultCode = static_cast<int32_t>(areg::os::SyncSignal::AsyncSignal);
             break;
         }
-
-        // A waitable fired: loop back and try to claim it. It may have been
-        // stolen meanwhile, in which case we arm and wait again.
     }
 
     for (int32_t i{ 0 }; i < count; ++i)

--- a/framework/aregextend/service/private/PoolReceiveThread.cpp
+++ b/framework/aregextend/service/private/PoolReceiveThread.cpp
@@ -167,9 +167,6 @@ bool PoolReceiveThread::run_dispatcher()
                 {
                     mMux.unregister_socket(hReady);
                     mRemoteService.failed_receive_message(clientSocket);
-                    // Free this socket's thread-local read-ahead cache (256 KB). The MultiCache map
-                    // never erases an entry on its own, so a closed socket would pin its cache for the
-                    // receive thread's lifetime (and a reused fd would resurrect stale head/unread cursors).
                     areg::thread_rx_cache_release(hReady);
                 }
             }

--- a/framework/aregextend/service/private/PoolReceiveThread.cpp
+++ b/framework/aregextend/service/private/PoolReceiveThread.cpp
@@ -167,6 +167,10 @@ bool PoolReceiveThread::run_dispatcher()
                 {
                     mMux.unregister_socket(hReady);
                     mRemoteService.failed_receive_message(clientSocket);
+                    // Free this socket's thread-local read-ahead cache (256 KB). The MultiCache map
+                    // never erases an entry on its own, so a closed socket would pin its cache for the
+                    // receive thread's lifetime (and a reused fd would resurrect stale head/unread cursors).
+                    areg::thread_rx_cache_release(hReady);
                 }
             }
             else
@@ -177,6 +181,7 @@ bool PoolReceiveThread::run_dispatcher()
 
                 mMux.unregister_socket(hReady);
                 mRemoteService.failed_receive_message(clientSocket);
+                areg::thread_rx_cache_release(hReady);
             }
 
 #if defined(AREG_LOG_DEBUG) && (AREG_LOG_DEBUG != 0)
@@ -210,6 +215,7 @@ bool PoolReceiveThread::run_dispatcher()
                     {
                         mMux.unregister_socket(hDrain);
                         mRemoteService.failed_receive_message(drainSocket);
+                        areg::thread_rx_cache_release(hDrain);
                     }
                 }
                 else
@@ -217,6 +223,7 @@ bool PoolReceiveThread::run_dispatcher()
                     DEBUG_LOG_WARN("Pool receive thread [ %s ]: receive failed on drain socket [ %u ], notifying connection_lost", name().as_string(), static_cast<uint32_t>(hDrain));
                     mMux.unregister_socket(hDrain);
                     mRemoteService.failed_receive_message(drainSocket);
+                    areg::thread_rx_cache_release(hDrain);
                 }
             }
 

--- a/framework/aregextend/service/private/PoolSendThread.cpp
+++ b/framework/aregextend/service/private/PoolSendThread.cpp
@@ -154,6 +154,15 @@ void PoolSendThread::start_event_processing( areg::Event & eventElem )
         areg::ext::send_pending_groups(mBatch.data(), validCount, mConnection, mRemoteService,
             [this](uint64_t bytes, uint32_t msgs) { mGlobalStats.accumulate_sent(bytes, msgs); });
     }
+
+    // Phase 5: release every wire buffer touched this cycle now that it has been sent (or its
+    // target was dropped). Covers [0, batchCount): valid entries, discarded slots that Phase 3
+    // skipped with `continue`, and moved-from slots (destroy_event() is a no-op on those).
+    // Without this the array retains the last batch's envelopes (up to DEFAULT_DRAIN_LIMIT) until
+    // a later, equally large batch overwrites the slots -- a high-water-mark retention that pins
+    // hundreds of MB of already-sent payloads in RAM after a throughput burst subsides.
+    for ( uint32_t i{ 0u }; i < batchCount; ++i )
+        mBatch[i].msg.destroy_event();
 }
 
 bool PoolSendThread::post_event( Event & eventElem )

--- a/framework/aregextend/service/private/PoolSendThread.cpp
+++ b/framework/aregextend/service/private/PoolSendThread.cpp
@@ -85,9 +85,7 @@ void PoolSendThread::start_event_processing( areg::Event & eventElem )
     mBatch[batchCount].msg    = eventElem.envelope();  // fields already zeroed
     ++batchCount;
 
-    // Phase 1: drain additional queued events straight into mBatch (the persistent batch list retains
-    // each buffer). No Event array -- one transient Event per popped message. The common single-message
-    // relay finds the queue empty and skips the loop.
+    // Phase 1: drain additional queued events straight into mBatch
     while ( batchCount < areg::DEFAULT_DRAIN_LIMIT )
     {
         areg::Event evt{ pick_event() };
@@ -112,7 +110,7 @@ void PoolSendThread::start_event_processing( areg::Event & eventElem )
 
         mTargets[batchCount]      = static_cast<ITEM_ID>(hdr->target);
         mBatch[batchCount].socket = areg::InvalidSocketHandle;
-        mBatch[batchCount].msg    = evt.envelope();  // O(1) shared_ptr copy; mBatch keeps the buffer alive
+        mBatch[batchCount].msg    = evt.envelope();
         ++batchCount;
     }
 
@@ -139,7 +137,7 @@ void PoolSendThread::start_event_processing( areg::Event & eventElem )
             mBatch[mid].socket <= entry.socket ? lo = mid + 1u : hi = mid;
         }
 
-        // Shift right using move-assignment (PendingSend has MessageEnvelope -- memmove is unsafe).
+        // Shift right using move-assignment
         for ( uint32_t j{ validCount }; j > lo; --j )
             mBatch[j] = std::move(mBatch[j - 1]);
 
@@ -155,12 +153,7 @@ void PoolSendThread::start_event_processing( areg::Event & eventElem )
             [this](uint64_t bytes, uint32_t msgs) { mGlobalStats.accumulate_sent(bytes, msgs); });
     }
 
-    // Phase 5: release every wire buffer touched this cycle now that it has been sent (or its
-    // target was dropped). Covers [0, batchCount): valid entries, discarded slots that Phase 3
-    // skipped with `continue`, and moved-from slots (destroy_event() is a no-op on those).
-    // Without this the array retains the last batch's envelopes (up to DEFAULT_DRAIN_LIMIT) until
-    // a later, equally large batch overwrites the slots -- a high-water-mark retention that pins
-    // hundreds of MB of already-sent payloads in RAM after a throughput burst subsides.
+    // Phase 5: release every wire buffer
     for ( uint32_t i{ 0u }; i < batchCount; ++i )
         mBatch[i].msg.destroy_event();
 }

--- a/framework/aregextend/service/private/ServerReceiveThread.cpp
+++ b/framework/aregextend/service/private/ServerReceiveThread.cpp
@@ -122,9 +122,6 @@ void ServerReceiveThread::_process_connection_event(SOCKETHANDLE hSocket, const 
                 msgReceived, [this](uint64_t bytes, uint32_t msgs) { accumulate_received(bytes, msgs); }))
         {
             mRemoteService.failed_receive_message(clientSocket);
-            // Free this socket's thread-local read-ahead cache (256 KB). The MultiCache map never
-            // erases an entry on its own, so a closed socket would pin its cache for the lifetime
-            // of the receive thread (and a reused fd would resurrect stale head/unread cursors).
             areg::thread_rx_cache_release(clientSocket.handle());
         }
     }
@@ -137,7 +134,6 @@ void ServerReceiveThread::_process_connection_event(SOCKETHANDLE hSocket, const 
                         , mConnection.is_valid() ? "YES" : "NO");
 
         mRemoteService.failed_receive_message(clientSocket);
-        // Free this socket's thread-local read-ahead cache (see note above).
         areg::thread_rx_cache_release(clientSocket.handle());
     }
 }

--- a/framework/aregextend/service/private/ServerReceiveThread.cpp
+++ b/framework/aregextend/service/private/ServerReceiveThread.cpp
@@ -122,6 +122,10 @@ void ServerReceiveThread::_process_connection_event(SOCKETHANDLE hSocket, const 
                 msgReceived, [this](uint64_t bytes, uint32_t msgs) { accumulate_received(bytes, msgs); }))
         {
             mRemoteService.failed_receive_message(clientSocket);
+            // Free this socket's thread-local read-ahead cache (256 KB). The MultiCache map never
+            // erases an entry on its own, so a closed socket would pin its cache for the lifetime
+            // of the receive thread (and a reused fd would resurrect stale head/unread cursors).
+            areg::thread_rx_cache_release(clientSocket.handle());
         }
     }
     else
@@ -133,6 +137,8 @@ void ServerReceiveThread::_process_connection_event(SOCKETHANDLE hSocket, const 
                         , mConnection.is_valid() ? "YES" : "NO");
 
         mRemoteService.failed_receive_message(clientSocket);
+        // Free this socket's thread-local read-ahead cache (see note above).
+        areg::thread_rx_cache_release(clientSocket.handle());
     }
 }
 

--- a/framework/aregextend/service/private/ServerSendThread.cpp
+++ b/framework/aregextend/service/private/ServerSendThread.cpp
@@ -152,6 +152,15 @@ void ServerSendThread::start_event_processing( areg::Event & eventElem )
         areg::ext::send_pending_groups(mBatch.data(), validCount, mConnection, mRemoteService,
             [this](uint64_t bytes, uint32_t msgs) { accumulate_sent(bytes, msgs); });
     }
+
+    // Phase 5: release every wire buffer touched this cycle now that it has been sent (or its
+    // target was dropped). Covers [0, batchCount): valid entries, discarded slots that Phase 3
+    // skipped with `continue`, and moved-from slots (destroy_event() is a no-op on those).
+    // Without this the array retains the last batch's envelopes (up to DEFAULT_DRAIN_LIMIT) until
+    // a later, equally large batch overwrites the slots -- a high-water-mark retention that pins
+    // hundreds of MB of already-sent payloads in RAM after a throughput burst subsides.
+    for ( uint32_t i{ 0u }; i < batchCount; ++i )
+        mBatch[i].msg.destroy_event();
 }
 
 bool ServerSendThread::post_event( Event & eventElem )

--- a/framework/aregextend/service/private/ServerSendThread.cpp
+++ b/framework/aregextend/service/private/ServerSendThread.cpp
@@ -81,9 +81,7 @@ void ServerSendThread::start_event_processing( areg::Event & eventElem )
     mBatch[batchCount].msg    = eventElem.envelope();  // O(1) shared_ptr copy; fields already zeroed
     ++batchCount;
 
-    // Phase 1: drain additional queued events straight into mBatch (the persistent batch list retains
-    // each buffer). No Event array -- one transient Event per popped message. The common single-message
-    // relay finds the queue empty and skips the loop.
+    // Phase 1: drain additional queued events straight into mBatch
     while ( batchCount < areg::DEFAULT_DRAIN_LIMIT )
     {
         areg::Event evt{ pick_event() };
@@ -137,7 +135,7 @@ void ServerSendThread::start_event_processing( areg::Event & eventElem )
             mBatch[mid].socket <= entry.socket ? lo = mid + 1u : hi = mid;
         }
 
-        // Shift right using move-assignment (PendingSend has MessageEnvelope -- memmove is unsafe)
+        // Shift right using move-assignment
         for ( uint32_t j{ validCount }; j > lo; --j )
             mBatch[j] = std::move(mBatch[j - 1]);
 
@@ -153,12 +151,7 @@ void ServerSendThread::start_event_processing( areg::Event & eventElem )
             [this](uint64_t bytes, uint32_t msgs) { accumulate_sent(bytes, msgs); });
     }
 
-    // Phase 5: release every wire buffer touched this cycle now that it has been sent (or its
-    // target was dropped). Covers [0, batchCount): valid entries, discarded slots that Phase 3
-    // skipped with `continue`, and moved-from slots (destroy_event() is a no-op on those).
-    // Without this the array retains the last batch's envelopes (up to DEFAULT_DRAIN_LIMIT) until
-    // a later, equally large batch overwrites the slots -- a high-water-mark retention that pins
-    // hundreds of MB of already-sent payloads in RAM after a throughput burst subsides.
+    // Phase 5: release every wire buffer
     for ( uint32_t i{ 0u }; i < batchCount; ++i )
         mBatch[i].msg.destroy_event();
 }

--- a/framework/logcollector/app/private/LogCollector.cpp
+++ b/framework/logcollector/app/private/LogCollector.cpp
@@ -171,10 +171,7 @@ void LogCollector::run_console_io()
                                       areg::ext::COORD_USER_INPUT.posY });
     console.refresh_screen();
 
-    // Background thread: refresh all four stat rows every second.
-    // The 1s tick is interruptible via a condition_variable so that '-q' stops the thread
-    // immediately instead of joining through the remainder of an in-flight sleep_for(1s)
-    // (which delayed quit by up to ~1 second).
+    // refresh all four stat rows every second.
     std::mutex rate_mtx;
     std::condition_variable rate_cv;
     bool rate_running{ true };                  // guarded by rate_mtx
@@ -192,7 +189,7 @@ void LogCollector::run_console_io()
             if (rate_cv.wait_for(lock, std::chrono::seconds(1), [&]() { return !rate_running; }))
                 break;
 
-            lock.unlock();                      // release during the slower console I/O
+            lock.unlock();
             helper.query_data_sent(sizeSent, msgSent);
             helper.query_data_received(sizeRecv, msgRecv);
 

--- a/framework/logcollector/app/private/LogCollector.cpp
+++ b/framework/logcollector/app/private/LogCollector.cpp
@@ -27,6 +27,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 #include <stdio.h>
 
@@ -170,7 +172,12 @@ void LogCollector::run_console_io()
     console.refresh_screen();
 
     // Background thread: refresh all four stat rows every second.
-    std::atomic_bool rate_running{ true };
+    // The 1s tick is interruptible via a condition_variable so that '-q' stops the thread
+    // immediately instead of joining through the remainder of an in-flight sleep_for(1s)
+    // (which delayed quit by up to ~1 second).
+    std::mutex rate_mtx;
+    std::condition_variable rate_cv;
+    bool rate_running{ true };                  // guarded by rate_mtx
     std::thread rate_thread([&]()
     {
         DataRateHelper& helper = data_rate_helper();
@@ -178,12 +185,14 @@ void LogCollector::run_console_io()
         uint64_t sizeSent{ 0u }, sizeRecv{ 0u };
         uint32_t msgSent{ 0u }, msgRecv{ 0u };
 
-        while (rate_running.load(std::memory_order_relaxed))
+        std::unique_lock<std::mutex> lock(rate_mtx);
+        while (rate_running)
         {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            if (rate_running.load(std::memory_order_relaxed) == false)
+            // Wake after 1s for the periodic refresh, or immediately when rate_running is cleared.
+            if (rate_cv.wait_for(lock, std::chrono::seconds(1), [&]() { return !rate_running; }))
                 break;
 
+            lock.unlock();                      // release during the slower console I/O
             helper.query_data_sent(sizeSent, msgSent);
             helper.query_data_received(sizeRecv, msgRecv);
 
@@ -195,13 +204,18 @@ void LogCollector::run_console_io()
             console.output_msg(areg::ext::COORD_SEND_MSGS, areg::ext::FORMAT_SEND_MSGS.data(), msgSent);
             console.output_msg(areg::ext::COORD_RECV_MSGS, areg::ext::FORMAT_RECV_MSGS.data(), msgRecv);
             console.refresh_screen();
+            lock.lock();
         }
     });
 
     // Block until the user types '-q' / '--quit'.
     console.wait_for_input(option_check_callback());
 
-    rate_running.store(false, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lock(rate_mtx);
+        rate_running = false;
+    }
+    rate_cv.notify_one();
     rate_thread.join();
 
     console.uninitialize();

--- a/framework/mtrouter/app/private/MultitargetRouter.cpp
+++ b/framework/mtrouter/app/private/MultitargetRouter.cpp
@@ -161,10 +161,7 @@ void MultitargetRouter::run_console_io()
                                       areg::ext::COORD_USER_INPUT.posY });
     console.refresh_screen();
 
-    // Background thread: update all four stat rows every second.
-    // The 1s tick is interruptible via a condition_variable so that '-q' stops the thread
-    // immediately instead of joining through the remainder of an in-flight sleep_for(1s)
-    // (which delayed quit by up to ~1 second).
+    // update all four stat rows every second
     std::mutex rate_mtx;
     std::condition_variable rate_cv;
     bool rate_running{ true };                  // guarded by rate_mtx
@@ -178,11 +175,10 @@ void MultitargetRouter::run_console_io()
             std::unique_lock<std::mutex> lock(rate_mtx);
             while (rate_running)
             {
-                // Wake after 1s for the periodic refresh, or immediately when rate_running is cleared.
                 if (rate_cv.wait_for(lock, std::chrono::seconds(1), [&]() { return !rate_running; }))
                     break;
 
-                lock.unlock();                  // release during the slower console I/O
+                lock.unlock();
                 helper.query_data_sent(sizeSent, msgSent);
                 helper.query_data_received(sizeRecv, msgRecv);
 

--- a/framework/mtrouter/app/private/MultitargetRouter.cpp
+++ b/framework/mtrouter/app/private/MultitargetRouter.cpp
@@ -27,6 +27,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 #include <stdio.h>
 
@@ -159,8 +161,13 @@ void MultitargetRouter::run_console_io()
                                       areg::ext::COORD_USER_INPUT.posY });
     console.refresh_screen();
 
-    // Background thread: update all four stat rows every second
-    std::atomic_bool rate_running{ true };
+    // Background thread: update all four stat rows every second.
+    // The 1s tick is interruptible via a condition_variable so that '-q' stops the thread
+    // immediately instead of joining through the remainder of an in-flight sleep_for(1s)
+    // (which delayed quit by up to ~1 second).
+    std::mutex rate_mtx;
+    std::condition_variable rate_cv;
+    bool rate_running{ true };                  // guarded by rate_mtx
     std::thread rate_thread([&]()
         {
             areg::ext::DataRateHelper& helper = data_rate_helper();
@@ -168,12 +175,14 @@ void MultitargetRouter::run_console_io()
             uint64_t sizeSent{ 0u }, sizeRecv{ 0u };
             uint32_t msgSent{ 0u }, msgRecv{ 0u };
 
-            while (rate_running.load(std::memory_order_relaxed))
+            std::unique_lock<std::mutex> lock(rate_mtx);
+            while (rate_running)
             {
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-                if (!rate_running.load(std::memory_order_relaxed))
+                // Wake after 1s for the periodic refresh, or immediately when rate_running is cleared.
+                if (rate_cv.wait_for(lock, std::chrono::seconds(1), [&]() { return !rate_running; }))
                     break;
 
+                lock.unlock();                  // release during the slower console I/O
                 helper.query_data_sent(sizeSent, msgSent);
                 helper.query_data_received(sizeRecv, msgRecv);
 
@@ -185,13 +194,18 @@ void MultitargetRouter::run_console_io()
                 console.output_msg(areg::ext::COORD_SEND_MSGS, areg::ext::FORMAT_SEND_MSGS.data(), msgSent);
                 console.output_msg(areg::ext::COORD_RECV_MSGS, areg::ext::FORMAT_RECV_MSGS.data(), msgRecv);
                 console.refresh_screen();
+                lock.lock();
             }
         });
 
     // Block until the user types '-q' / '--quit'.
     console.wait_for_input(option_check_callback());
 
-    rate_running.store(false, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lock(rate_mtx);
+        rate_running = false;
+    }
+    rate_cv.notify_one();
     rate_thread.join();
 
     console.uninitialize();

--- a/tools/README.md
+++ b/tools/README.md
@@ -18,6 +18,8 @@ This directory contains **developer tools** shipped with the **Areg SDK**, desig
 | `codegen.jar`        | Generates C++ service code from `.siml` files          |
 | `setup-project.bat`  | Creates a ready-to-build Areg project on Windows       |
 | `setup-project.sh`   | Creates a ready-to-build Areg project on Linux/macOS   |
+| `sanitize.sh`        | Builds/runs the SDK under a sanitizer or profiler      |
+| `sanitizer/*.supp`   | Suppression files for LeakSanitizer / ThreadSanitizer  |
 | `conf/cmake/*.cmake` | CMake helper functions used by Areg projects           |
 
 ---
@@ -213,7 +215,139 @@ This produces a **fully functional Areg RPC example**.
 
 ---
 
-## 7. Summary
+## 7. Quality & Performance: Sanitizers and Profilers
+
+`sanitize.sh` builds the SDK in an **isolated, throw-away build tree** (`build-asan/`,
+`build-tsan/`, `build-perf/`) and runs a target under a compiler sanitizer or a
+profiler. It never edits the build-system files and never touches your normal
+`build/` tree — every flag is passed on the CMake command line only.
+
+> Sanitizers ship **inside** GCC/Clang, so nothing extra needs to be installed.
+> Profilers (`perf`, `heaptrack`, `valgrind`) are optional system tools; the
+> script detects a missing one and prints the exact `apt-get` line.
+
+### Prerequisites and environment setup
+
+`sanitize.sh` **does not install anything**. It only verifies that a tool is
+present and, if not, prints the exact install command and stops. You install the
+prerequisites once, up front. There is no separate "setup" step beyond this — the
+script configures and builds an isolated CMake tree itself.
+
+**1. Compiler with sanitizer runtimes (required).** The sanitizers are part of the
+compiler toolchain, not a separate download:
+
+| Toolchain | What provides the sanitizers | Install on Debian/Ubuntu | Install on Fedora/RHEL |
+|-----------|------------------------------|--------------------------|------------------------|
+| GCC (`--compiler gnu`, default) | `libasan`, `libubsan`, `libtsan` runtimes shipped with `g++` | `sudo apt-get install g++` (runtimes included) | `sudo dnf install gcc-c++ libasan libubsan libtsan` |
+| Clang (`--compiler llvm`) | `compiler-rt` shipped with `clang` | `sudo apt-get install clang` | `sudo dnf install clang compiler-rt` |
+
+Verify the runtime is actually available before the first run:
+
+```bash
+g++     -print-file-name=libasan.so      # prints a real path, not just "libasan.so"
+g++     -print-file-name=libtsan.so      # TSan runtime
+clang++ -print-file-name=libclang_rt.asan-x86_64.so   # for --compiler llvm
+```
+
+If a command echoes the bare file name, the runtime package is missing — install it
+from the table above.
+
+**2. CMake 3.20+ (required)** — the same version the SDK already needs. No extra
+build dependency is introduced by the script.
+
+**3. Profilers (optional, only for the `perf` / `heaptrack` / `callgrind` modes).**
+These are real system packages; install only the one you intend to use:
+
+| Mode | Tool | Debian/Ubuntu package |
+|------|------|-----------------------|
+| `perf` | `perf` | `sudo apt-get install linux-tools-common linux-tools-$(uname -r)` |
+| `heaptrack` | `heaptrack` | `sudo apt-get install heaptrack` |
+| `callgrind` | `valgrind` | `sudo apt-get install valgrind` |
+
+> `perf` usually also needs `linux-tools-$(uname -r)` (the kernel-matched package),
+> and `kernel.perf_event_paranoid` low enough to record:
+> `sudo sysctl kernel.perf_event_paranoid=1`. Under WSL2 `perf` requires a kernel
+> built with perf support.
+
+**4. ThreadSanitizer needs a compatible address-space layout.** See the dedicated
+note below — `sanitize.sh tsan` handles it automatically with `setarch -R` (provided
+by `util-linux`, already present on any normal Linux). No root required.
+
+**5. WSL2 / `/mnt/c` (drvfs) caveat.** Building the SDK on a Windows-mounted drive
+works, but the large (>150 MB) instrumented `libareg.a` can intermittently fail its
+**first** link with `file format not recognized` — a drvfs write-visibility race, not
+a real corruption. Re-run the same `sanitize.sh` command (or build on a native Linux
+filesystem such as `~/`) and it links cleanly.
+
+### Usage
+
+```bash
+tools/sanitize.sh <mode> [options] [-- <args forwarded to the binary>]
+```
+
+| Mode         | What it catches / does                                                      |
+|--------------|-----------------------------------------------------------------------------|
+| `asan`       | **AddressSanitizer + LeakSanitizer + UBSan** — use-after-free/scope, heap/stack overflow, leaks, undefined behavior. *Primary memory tool.* |
+| `tsan`       | **ThreadSanitizer** — data races and lock-order inversions (separate build; cannot be combined with `asan`). |
+| `ubsan`      | UndefinedBehaviorSanitizer only — cheap, no ASan slowdown.                  |
+| `build-only` | Configure + build the instrumented target without running.                 |
+| `perf`       | `perf stat -d -d` on an optimized (`RelWithDebInfo`) build — IPC/CPU profiling. |
+| `heaptrack`  | Allocation profiling: peak RSS and allocation hot spots — the memory-retention lens. |
+| `callgrind`  | `valgrind --tool=callgrind` instruction/call-graph profile.                 |
+
+| Option            | Default            | Meaning                                          |
+|-------------------|--------------------|--------------------------------------------------|
+| `--compiler`      | `gnu`              | `gnu` (g++) or `llvm` (clang++).                 |
+| `--target`        | `areg-unit-tests`  | CMake target to build.                           |
+| `--run`           | `auto`             | `ctest`, an explicit binary path, `auto`, or `none`. |
+| `--lib`           | `static`           | `static` (most robust for ASan) or `shared`.     |
+| `--examples`      | off                | Also build the `examples/` tree.                 |
+| `--jobs N`        | `nproc`            | Parallel build jobs.                             |
+| `--keep`          | off                | Reuse the existing build dir (skip reconfigure). |
+
+### Examples
+
+```bash
+# Run the whole unit-test suite under ASan/LSan/UBSan:
+tools/sanitize.sh asan --run ctest
+
+# Hunt data races across the test suite:
+tools/sanitize.sh tsan --run ctest
+
+# Memory + concurrency check of a live IPC client (needs mtrouter running):
+tools/sanitize.sh asan --target 23_pubclient --examples -- <client args>
+
+# Allocation / peak-RSS profile of the router under load:
+tools/sanitize.sh heaptrack --target mtrouter --examples -- -e
+```
+
+### Latency-focused profiling tips
+
+For the sub-millisecond IPC dispatch work, the highest-value `perf` views are:
+
+```bash
+perf stat -d -d   <bin>          # IPC, cache-miss and branch-miss rates
+perf c2c record   <bin>          # cache-line contention / false sharing (MPSC queues, refcounts)
+perf record -e cache-misses <bin>; perf report
+perf sched record <bin>; perf sched latency   # scheduler wake-up latency
+```
+
+`perf c2c` is especially relevant here: it pinpoints cache lines bounced
+between cores — the classic cost in lock-free queues and intrusive refcounts.
+
+### Note: ThreadSanitizer and ASLR
+
+On modern kernels (Ubuntu 24.04 / WSL2 default `vm.mmap_rnd_bits=32`) TSan
+aborts at startup with `FATAL: ThreadSanitizer: unexpected memory mapping`
+because the high-entropy address layout does not fit its shadow memory.
+`sanitize.sh tsan` works around this automatically by running the target under
+`setarch -R` (disables ASLR for that process — no root needed). If you run a
+TSan binary by hand and hit this, either prefix it with `setarch "$(uname -m)" -R`
+or lower the entropy once with `sudo sysctl vm.mmap_rnd_bits=28`.
+
+---
+
+## 8. Summary
 
 * Use `.siml` to define services
 * Prefer **CMake integration** over manual code generation

--- a/tools/sanitize.sh
+++ b/tools/sanitize.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# ===========================================================================
+# Areg SDK - sanitizer & profiler driver
+# ---------------------------------------------------------------------------
+# Configures an isolated CMake build that instruments the framework with a
+# compiler sanitizer (or wires a binary into a profiler), builds the chosen
+# target and runs it.  Nothing in the normal build tree or the build system
+# files is touched: every mode uses its own throw-away build directory and
+# passes flags on the CMake command line only.
+#
+# Sanitizers ship with the compiler (GCC/Clang) - no package install needed.
+# Profilers (perf, heaptrack, valgrind) are optional system tools; the script
+# detects them and tells you the exact apt line if one is missing.
+#
+#   Usage:  tools/sanitize.sh <mode> [options] [-- <args passed to the binary>]
+#
+#   Modes
+#     asan        AddressSanitizer + LeakSanitizer + UndefinedBehavior (memory
+#                 errors, use-after-free/scope, leaks, UB).  Primary tool.
+#     tsan        ThreadSanitizer (data races, lock-order inversions).
+#                 Mutually exclusive with asan - separate build.
+#     ubsan       UndefinedBehaviorSanitizer only (cheap; no ASan slowdown).
+#     build-only  Configure + build the instrumented target, do not run.
+#     perf        Run <target binary> under `perf stat`/`perf record` (CPU,
+#                 cache misses, context switches) - latency/throughput work.
+#     heaptrack   Run <target binary> under heaptrack (allocation profiling;
+#                 peak RSS, alloc hot spots) - the memory-retention lens.
+#     callgrind   Run <target binary> under valgrind --tool=callgrind.
+#     help        This text.
+#
+#   Options
+#     --compiler gnu|llvm   Toolchain family (default: gnu).
+#     --target  <name>      CMake target to build (default: areg-unit-tests).
+#     --run     <what>      What to execute after build:
+#                             ctest      -> ctest in the build dir (default for tests)
+#                             <path>     -> an explicit binary path
+#                             auto       -> locate the built target binary (default)
+#                             none       -> build only
+#     --lib     shared|static  Library type (default: static - robust for ASan).
+#     --examples            Also build examples (default: off, tests only).
+#     --jobs N              Parallel build jobs (default: nproc).
+#     --keep                Reuse an existing build dir (skip reconfigure).
+#     --                    Everything after is forwarded to the run binary.
+#
+#   Examples
+#     tools/sanitize.sh asan                         # build+run unit tests under ASan/LSan/UBSan
+#     tools/sanitize.sh tsan --run ctest             # data-race scan over the test suite
+#     tools/sanitize.sh asan --target 23_pubclient --examples -- --some-arg
+#     tools/sanitize.sh heaptrack --target mtrouter --examples -- -e
+# ===========================================================================
+
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Locate the repository root (this script lives in <root>/tools/).
+# --------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SUPP_DIR="${SCRIPT_DIR}/sanitizer"
+
+# --------------------------------------------------------------------------
+# Colours (disabled when stdout is not a TTY).
+# --------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+    C_RED=$'\033[31m'; C_GRN=$'\033[32m'; C_YEL=$'\033[33m'; C_CYN=$'\033[36m'; C_BLD=$'\033[1m'; C_RST=$'\033[0m'
+else
+    C_RED=; C_GRN=; C_YEL=; C_CYN=; C_BLD=; C_RST=
+fi
+info() { printf '%s==>%s %s\n' "${C_CYN}${C_BLD}" "${C_RST}" "$*"; }
+warn() { printf '%s[warn]%s %s\n' "${C_YEL}" "${C_RST}" "$*" >&2; }
+die()  { printf '%s[error]%s %s\n' "${C_RED}" "${C_RST}" "$*" >&2; exit 1; }
+
+# --------------------------------------------------------------------------
+# Defaults.
+# --------------------------------------------------------------------------
+MODE=""
+COMPILER="gnu"
+TARGET="areg-unit-tests"
+RUN="auto"
+LIBTYPE="static"
+EXAMPLES="OFF"
+JOBS="$(nproc 2>/dev/null || echo 4)"
+KEEP=0
+RUN_ARGS=()
+
+# --------------------------------------------------------------------------
+# Parse arguments.
+# --------------------------------------------------------------------------
+[[ $# -ge 1 ]] || { sed -n '2,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 1; }
+MODE="$1"; shift
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --compiler) COMPILER="$2"; shift 2;;
+        --target)   TARGET="$2";   shift 2;;
+        --run)      RUN="$2";      shift 2;;
+        --lib)      LIBTYPE="$2";  shift 2;;
+        --examples) EXAMPLES="ON"; shift;;
+        --jobs)     JOBS="$2";     shift 2;;
+        --keep)     KEEP=1;        shift;;
+        --)         shift; RUN_ARGS=("$@"); break;;
+        *) die "Unknown option: $1 (run 'tools/sanitize.sh help')";;
+    esac
+done
+
+case "${MODE}" in
+    help|-h|--help) sed -n '2,60p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0;;
+esac
+
+# --------------------------------------------------------------------------
+# Map compiler family to CMake variables.
+# --------------------------------------------------------------------------
+case "${COMPILER}" in
+    gnu)  CC_BIN="gcc";   CXX_BIN="g++";     FAMILY="gnu";;
+    llvm) CC_BIN="clang"; CXX_BIN="clang++"; FAMILY="llvm";;
+    *) die "Unknown --compiler '${COMPILER}' (use gnu or llvm)";;
+esac
+command -v "${CXX_BIN}" >/dev/null 2>&1 || die "Compiler '${CXX_BIN}' not found in PATH."
+
+# --------------------------------------------------------------------------
+# Sanitizer flag sets.
+#   -O1, frame pointers and no tail-call merging give readable, accurate
+#   stacks without hiding frames.  -g keeps line info.
+# --------------------------------------------------------------------------
+COMMON_DBG="-g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls"
+ASAN_FLAGS="-fsanitize=address,undefined -fsanitize-address-use-after-scope ${COMMON_DBG}"
+TSAN_FLAGS="-fsanitize=thread ${COMMON_DBG}"
+UBSAN_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all ${COMMON_DBG}"
+
+# --------------------------------------------------------------------------
+# Runtime option strings + suppression files.
+# --------------------------------------------------------------------------
+export ASAN_OPTIONS="detect_leaks=1:halt_on_error=0:abort_on_error=0:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:print_stats=1:log_threads=1"
+export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0"
+export TSAN_OPTIONS="second_deadlock_stack=1:history_size=7:halt_on_error=0"
+[[ -f "${SUPP_DIR}/lsan.supp" ]] && export LSAN_OPTIONS="suppressions=${SUPP_DIR}/lsan.supp:print_suppressions=0"
+[[ -f "${SUPP_DIR}/tsan.supp" ]] && export TSAN_OPTIONS="${TSAN_OPTIONS}:suppressions=${SUPP_DIR}/tsan.supp"
+[[ -f "${SUPP_DIR}/ubsan.supp" ]] && export UBSAN_OPTIONS="${UBSAN_OPTIONS}:suppressions=${SUPP_DIR}/ubsan.supp"
+
+# --------------------------------------------------------------------------
+# Helper: configure + build an instrumented tree.
+#   $1 build dir, $2 sanitizer flags.
+# --------------------------------------------------------------------------
+configure_build() {
+    local build_dir="$1" flags="$2"
+    if [[ ${KEEP} -eq 0 || ! -d "${build_dir}" ]]; then
+        info "Configuring ${build_dir} (compiler=${FAMILY}, lib=${LIBTYPE}, examples=${EXAMPLES})"
+        # AREG_OUTPUT_DIR keeps each sanitizer's binaries/libs in its own tree.
+        # Without it every build emits to the same product/<compiler>-<cfg> path
+        # and the asan / tsan executables clobber each other.
+        cmake -B "${build_dir}" -S "${ROOT_DIR}" \
+            -DAREG_COMPILER_FAMILY="${FAMILY}" \
+            -DCMAKE_C_COMPILER="${CC_BIN}" \
+            -DCMAKE_CXX_COMPILER="${CXX_BIN}" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DAREG_LIB_TYPE="${LIBTYPE}" \
+            -DAREG_TESTS=ON \
+            -DAREG_EXAMPLES="${EXAMPLES}" \
+            -DAREG_OUTPUT_DIR="${build_dir}/product" \
+            -DCMAKE_C_FLAGS="${flags}" \
+            -DCMAKE_CXX_FLAGS="${flags}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${flags}" \
+            -DCMAKE_SHARED_LINKER_FLAGS="${flags}"
+    else
+        info "Reusing existing ${build_dir} (--keep)"
+    fi
+    info "Building target '${TARGET}' with ${JOBS} jobs"
+    cmake --build "${build_dir}" -j"${JOBS}" --target "${TARGET}"
+}
+
+# --------------------------------------------------------------------------
+# Helper: find the binary produced for ${TARGET} inside a build dir.
+# --------------------------------------------------------------------------
+locate_binary() {
+    local build_dir="$1"
+    # Each sanitizer build emits into <build_dir>/product/bin (see AREG_OUTPUT_DIR).
+    local found
+    found="$(find "${build_dir}/product" -type f -name "${TARGET}*" -perm -u+x 2>/dev/null \
+             | grep -vE '\.(so|a|o)(\.|$)' | head -1 || true)"
+    [[ -n "${found}" ]] || found="$(find "${build_dir}" -type f -name "${TARGET}*" -perm -u+x 2>/dev/null | grep -vE '\.(so|a|o)(\.|$)' | head -1 || true)"
+    printf '%s' "${found}"
+}
+
+# --------------------------------------------------------------------------
+# Helper: run whatever --run asks for.
+# --------------------------------------------------------------------------
+do_run() {
+    local build_dir="$1"; local prefix=("${@:2}")
+    case "${RUN}" in
+        none) info "Run skipped (--run none)"; return 0;;
+        ctest)
+            info "Running ctest in ${build_dir}"
+            ( cd "${build_dir}" && "${prefix[@]}" ctest --output-on-failure ) ;;
+        auto)
+            local bin; bin="$(locate_binary "${build_dir}")"
+            [[ -n "${bin}" ]] || die "Could not locate the '${TARGET}' binary; pass --run <path>."
+            info "Running ${bin} ${RUN_ARGS[*]:-}"
+            "${prefix[@]}" "${bin}" "${RUN_ARGS[@]:-}";;
+        *)
+            [[ -x "${RUN}" ]] || die "--run '${RUN}' is not an executable path."
+            info "Running ${RUN} ${RUN_ARGS[*]:-}"
+            "${prefix[@]}" "${RUN}" "${RUN_ARGS[@]:-}";;
+    esac
+}
+
+# --------------------------------------------------------------------------
+# Helper: ensure an optional profiler tool exists, else explain how to get it.
+# --------------------------------------------------------------------------
+require_tool() {
+    local tool="$1" apt_pkg="$2"
+    command -v "${tool}" >/dev/null 2>&1 && return 0
+    warn "'${tool}' is not installed."
+    warn "Install it with:  sudo apt-get install ${apt_pkg}"
+    die  "Profiler '${tool}' unavailable."
+}
+
+# ==========================================================================
+# Dispatch.
+# ==========================================================================
+case "${MODE}" in
+    asan)
+        BUILD_DIR="${ROOT_DIR}/build-asan"
+        configure_build "${BUILD_DIR}" "${ASAN_FLAGS}"
+        info "ASAN_OPTIONS=${ASAN_OPTIONS}"
+        [[ -n "${LSAN_OPTIONS:-}" ]] && info "LSAN_OPTIONS=${LSAN_OPTIONS}"
+        do_run "${BUILD_DIR}"
+        ;;
+    tsan)
+        BUILD_DIR="${ROOT_DIR}/build-tsan"
+        configure_build "${BUILD_DIR}" "${TSAN_FLAGS}"
+        info "TSAN_OPTIONS=${TSAN_OPTIONS}"
+        # Modern kernels (Ubuntu 24.04 / WSL2: vm.mmap_rnd_bits=32) hand out address
+        # layouts TSan's shadow memory cannot map -> "FATAL: unexpected memory mapping"
+        # and the process aborts before running. Disabling ASLR for the child via
+        # `setarch -R` fixes it without root. (Alternative: sudo sysctl vm.mmap_rnd_bits=28.)
+        if command -v setarch >/dev/null 2>&1; then
+            info "Disabling ASLR for the run (setarch -R) to satisfy TSan's shadow layout"
+            do_run "${BUILD_DIR}" setarch "$(uname -m)" -R
+        else
+            warn "setarch not found; if you hit 'unexpected memory mapping', run: sudo sysctl vm.mmap_rnd_bits=28"
+            do_run "${BUILD_DIR}"
+        fi
+        ;;
+    ubsan)
+        BUILD_DIR="${ROOT_DIR}/build-ubsan"
+        configure_build "${BUILD_DIR}" "${UBSAN_FLAGS}"
+        info "UBSAN_OPTIONS=${UBSAN_OPTIONS}"
+        do_run "${BUILD_DIR}"
+        ;;
+    build-only)
+        BUILD_DIR="${ROOT_DIR}/build-asan"
+        RUN="none"
+        configure_build "${BUILD_DIR}" "${ASAN_FLAGS}"
+        ;;
+    perf)
+        require_tool perf linux-tools-common
+        BUILD_DIR="${ROOT_DIR}/build-perf"
+        # Profile an optimized build, not an instrumented one.
+        if [[ ${KEEP} -eq 0 || ! -d "${BUILD_DIR}" ]]; then
+            info "Configuring optimized build for profiling"
+            cmake -B "${BUILD_DIR}" -S "${ROOT_DIR}" -DAREG_COMPILER_FAMILY="${FAMILY}" \
+                -DCMAKE_C_COMPILER="${CC_BIN}" -DCMAKE_CXX_COMPILER="${CXX_BIN}" \
+                -DCMAKE_BUILD_TYPE=RelWithDebInfo -DAREG_LIB_TYPE="${LIBTYPE}" \
+                -DAREG_EXAMPLES="${EXAMPLES}" -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer"
+        fi
+        cmake --build "${BUILD_DIR}" -j"${JOBS}" --target "${TARGET}"
+        BIN="$(locate_binary "${BUILD_DIR}")"; [[ -n "${BIN}" ]] || die "binary not found"
+        info "perf stat ${BIN}"
+        perf stat -d -d -- "${BIN}" "${RUN_ARGS[@]:-}"
+        ;;
+    heaptrack)
+        require_tool heaptrack heaptrack
+        BUILD_DIR="${ROOT_DIR}/build-perf"
+        cmake -B "${BUILD_DIR}" -S "${ROOT_DIR}" -DAREG_COMPILER_FAMILY="${FAMILY}" \
+            -DCMAKE_C_COMPILER="${CC_BIN}" -DCMAKE_CXX_COMPILER="${CXX_BIN}" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo -DAREG_LIB_TYPE="${LIBTYPE}" \
+            -DAREG_EXAMPLES="${EXAMPLES}" >/dev/null
+        cmake --build "${BUILD_DIR}" -j"${JOBS}" --target "${TARGET}"
+        BIN="$(locate_binary "${BUILD_DIR}")"; [[ -n "${BIN}" ]] || die "binary not found"
+        info "heaptrack ${BIN}  (analyse with: heaptrack_gui / heaptrack_print)"
+        heaptrack "${BIN}" "${RUN_ARGS[@]:-}"
+        ;;
+    callgrind)
+        require_tool valgrind valgrind
+        BUILD_DIR="${ROOT_DIR}/build-perf"
+        cmake -B "${BUILD_DIR}" -S "${ROOT_DIR}" -DAREG_COMPILER_FAMILY="${FAMILY}" \
+            -DCMAKE_C_COMPILER="${CC_BIN}" -DCMAKE_CXX_COMPILER="${CXX_BIN}" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo -DAREG_LIB_TYPE="${LIBTYPE}" \
+            -DAREG_EXAMPLES="${EXAMPLES}" >/dev/null
+        cmake --build "${BUILD_DIR}" -j"${JOBS}" --target "${TARGET}"
+        BIN="$(locate_binary "${BUILD_DIR}")"; [[ -n "${BIN}" ]] || die "binary not found"
+        info "valgrind --tool=callgrind ${BIN}"
+        valgrind --tool=callgrind --callgrind-out-file="${BUILD_DIR}/callgrind.out" -- "${BIN}" "${RUN_ARGS[@]:-}"
+        ;;
+    *)
+        die "Unknown mode '${MODE}' (run 'tools/sanitize.sh help')"
+        ;;
+esac
+
+info "${C_GRN}Done.${C_RST}"

--- a/tools/sanitizer/lsan.supp
+++ b/tools/sanitizer/lsan.supp
@@ -1,0 +1,19 @@
+# LeakSanitizer suppressions for the Areg SDK.
+# ---------------------------------------------------------------------------
+# Format:  leak:<substring matched against a frame in the leak's stack>
+#
+# Keep this list MINIMAL and only for proven third-party / runtime noise.
+# A leak inside framework/areg, framework/aregextend, mtrouter, logcollector
+# is a real defect - never suppress it here, fix it.
+#
+# Enable an entry by removing the leading '#'.  The first run is intentionally
+# left un-suppressed so every report is visible.
+
+# --- Examples of third-party noise that may appear (uncomment if seen) ---
+# GoogleTest one-time global registrations (freed at exit by the OS only):
+#leak:testing::internal
+# SQLite static mutex / page-cache allocations on some builds:
+#leak:sqlite3
+# glibc dynamic-loader / locale one-time allocations:
+#leak:_dl_
+#leak:__new_exitfn

--- a/tools/sanitizer/tsan.supp
+++ b/tools/sanitizer/tsan.supp
@@ -1,0 +1,14 @@
+# ThreadSanitizer suppressions for the Areg SDK.
+# ---------------------------------------------------------------------------
+# Format (see https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions):
+#   race:<func/file substring>          suppress a data-race report
+#   deadlock:<substring>                suppress a lock-order report
+#   called_from_lib:<lib name>          ignore races originating in a library
+#
+# Keep MINIMAL.  A race inside the framework is a real defect - fix it, do not
+# hide it.  The first run is intentionally left un-suppressed.
+
+# --- Examples (uncomment only if proven benign) ---
+# Benign stats counters updated without a lock for telemetry only:
+#race:accumulate_sent
+#race:accumulate_received

--- a/tools/sanitizer/tsan_lock_probe.cpp
+++ b/tools/sanitizer/tsan_lock_probe.cpp
@@ -1,0 +1,68 @@
+/************************************************************************
+ * TSan visibility probe for areg's custom Mutex.
+ * ---------------------------------------------------------------------
+ * Two threads increment a shared counter, each access guarded by a single
+ * shared areg::Mutex. The program is race-FREE by construction.
+ *
+ * Build it with ThreadSanitizer against the TSan-instrumented libareg and run:
+ *   - If TSan reports a data race on g_shared, it proves TSan cannot observe
+ *     areg's futex/__ulock-based Mutex handoff as a happens-before edge -> every
+ *     "race" TSan reports on areg-Mutex-protected data is a FALSE POSITIVE.
+ *   - If TSan stays silent, areg's Mutex IS visible to TSan and such reports
+ *     would be genuine.
+ *
+ * Compile (see tools/sanitize.sh for the libareg path):
+ *   g++ -std=c++17 -fsanitize=thread -g -I framework tools/sanitizer/tsan_lock_probe.cpp \
+ *       <libareg.a> -lpthread -lrt -o /tmp/tsan_lock_probe
+ ************************************************************************/
+#include <thread>
+#include <cstdio>
+
+// Build with -DUSE_STD_MUTEX to validate the harness with a known-good std::mutex
+// (must yield exactly 400000); default uses areg::Mutex.
+#if defined(USE_STD_MUTEX)
+#  include <mutex>
+#else
+#  include "areg/base/SyncPrimitives.hpp"
+#endif
+
+namespace
+{
+#if defined(USE_STD_MUTEX)
+    using LockType = std::mutex;
+#else
+    using LockType = areg::Mutex;
+#endif
+
+    int g_shared{ 0 };
+
+    void worker( LockType& lk )
+    {
+        for ( int i = 0; i < 200000; ++i )
+        {
+#if defined(USE_STD_MUTEX)
+            std::lock_guard<std::mutex> lock( lk );
+#else
+            areg::Lock lock( lk );
+#endif
+            ++g_shared;                // protected by lk on every access
+        }
+    }
+}
+
+int main()
+{
+    // Construct the lock locally (after main starts) to avoid any static-init-order
+    // confound. areg::Mutex(false) = created, not initially owned.
+#if defined(USE_STD_MUTEX)
+    LockType lk;
+#else
+    LockType lk( false );
+#endif
+    std::thread a( worker, std::ref( lk ) );
+    std::thread b( worker, std::ref( lk ) );
+    a.join();
+    b.join();
+    std::printf( "g_shared = %d (expected 400000)\n", g_shared );
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Fixed per thread cache bug: the cache is released when socket is not valid anymore. The batch array is released, then events are processed. This keeps mtrouter and logcollector to use less RAM when apps quit.
- Fixed but related with mutext lock -- some lock where missed.
- Added sanitizer tool to run

[x] I have read CONTRIBUTING.md

Signed-off-by: Artak Avetyan
