### PR TITLE
Bugfixes: 746 fix examples

### DIFF
--- a/examples/19_pubfsm/pubclient/src/TrafficLightClient.cpp
+++ b/examples/19_pubfsm/pubclient/src/TrafficLightClient.cpp
@@ -22,7 +22,7 @@ DEF_LOG_SCOPE(pubclient_src_TrafficLightClient, service_connected);
 
 TrafficLightClient::TrafficLightClient(const areg::ComponentEntry & entry, areg::ComponentThread & owner)
     : areg::Component                     ( entry, owner )
-    , TrafficControllerConsumerBase   (entry.mDependencyServices[0].mRoleName)
+    , TrafficControllerConsumerBase   (entry.mDependencyServices[0].mRoleName, static_cast<areg::Component &>(*this))
     , mIsEastWest                   (std::any_cast<bool>(entry.data()))
 {
 }

--- a/examples/19_pubfsm/pubclient/src/TrafficLightClient.cpp
+++ b/examples/19_pubfsm/pubclient/src/TrafficLightClient.cpp
@@ -104,7 +104,7 @@ bool TrafficLightClient::service_connected( areg::ServiceConnectionState status,
         printf( "\tVehicle Light: %12s    |\tPedestrian Light: %s\n"
                 , fsm::name( TrafficController::VehicleTrafficLight::Off )
                 , fsm::name( TrafficController::PedestrianTrafficLight::Off ) );
-        printf( "\nClose the application ..." );
+        printf( "\nClose the application ...\n" );
 
         notify_on_traffic_east_west_update( false );
         notify_on_broadcast_east_west( false );

--- a/examples/19_pubfsm/pubservice/src/PowerControllerClient.cpp
+++ b/examples/19_pubfsm/pubservice/src/PowerControllerClient.cpp
@@ -110,7 +110,7 @@ void PowerControllerClient::on_run()
         printf("\n");
     } while (loop);
 
-    printf("Quiting the Traffic Light Controller application ...");
+    printf("Quiting the Traffic Light Controller application ...\n");
     areg::Application::signal_quit();
 }
 

--- a/framework/areg/appbase/Application.hpp
+++ b/framework/areg/appbase/Application.hpp
@@ -352,6 +352,15 @@ public:
     static bool is_servicing_ready();
 
     /**
+     * \brief   Returns true while servicing can start or retry connections, i.e. the application
+     *          is initializing or ready (not releasing, stopped or in failure).
+     *
+     * \return  Returns true if the application state is Initializing or Ready.
+     **/
+    [[nodiscard]]
+    static bool is_servicing_available();
+
+    /**
      * \brief   Queries the amount of sent data in bytes and sent messages since the last call, and resets counters.
      *
      * \param[out] sizeSend     On output, contains the size of data in bytes sent since the last call.

--- a/framework/areg/appbase/private/Application.cpp
+++ b/framework/areg/appbase/private/Application.cpp
@@ -371,6 +371,12 @@ bool Application::is_servicing_ready()
     return (theApp.mAppState == areg::AppState::Ready);
 }
 
+bool Application::is_servicing_available()
+{
+    const areg::AppState state{ Application::instance().mAppState };
+    return (state == areg::AppState::Initializing) || (state == areg::AppState::Ready);
+}
+
 void Application::query_data_sent(uint64_t& sizeSent, uint32_t& msgSent) noexcept
 {
     ServiceManager::query_data_sent(sizeSent, msgSent);

--- a/framework/areg/appbase/private/posix/ApplicationPosix.cpp
+++ b/framework/areg/appbase/private/posix/ApplicationPosix.cpp
@@ -41,7 +41,7 @@ namespace {
         if (sysctl(mib, 4, nullptr, &size, nullptr, 0) < 0)
             return -1;
 
-        uint8_t* buffer = size != 0 ? DEBUG_NEW uint8_t[size] : nullptr;
+        uint8_t* buffer = size != 0 ? new uint8_t[size] : nullptr;
         if (buffer == nullptr)
             return -1;
 
@@ -80,7 +80,7 @@ namespace {
         int pid {-1};
 
         DIR* dir = opendir(dirProc);
-        char* buffer = dir != nullptr ? DEBUG_NEW char[areg::File::MAXIMUM_PATH + 1] : nullptr;
+        char* buffer = dir != nullptr ? new char[areg::File::MAXIMUM_PATH + 1] : nullptr;
         if (buffer == nullptr)
             return pid;
 

--- a/framework/areg/base/FixedArray.hpp
+++ b/framework/areg/base/FixedArray.hpp
@@ -323,14 +323,14 @@ protected:
 
 template< typename VALUE >
 FixedArray<VALUE>::FixedArray(uint32_t elemCount /*= 0*/ )
-    : mValueList( elemCount != 0 ? DEBUG_NEW VALUE[elemCount] : nullptr )
+    : mValueList( elemCount != 0 ? new VALUE[elemCount] : nullptr )
     , mElemCount( mValueList != nullptr ? elemCount : 0 )
 {
 }
 
 template< typename VALUE >
 FixedArray<VALUE>::FixedArray( const FixedArray<VALUE>& src )
-    : mValueList( src.mElemCount != 0 ? DEBUG_NEW VALUE[src.mElemCount] : nullptr )
+    : mValueList( src.mElemCount != 0 ? new VALUE[src.mElemCount] : nullptr )
     , mElemCount( mValueList != nullptr ? src.mElemCount : 0 )
 {
     areg::copy_elems<VALUE>(mValueList, src.mValueList, mElemCount);
@@ -347,7 +347,7 @@ FixedArray<VALUE>::FixedArray( FixedArray<VALUE> && src ) noexcept
 
 template<typename VALUE>
 FixedArray<VALUE>::FixedArray(const VALUE* list, uint32_t count)
-    : mValueList(count ? DEBUG_NEW VALUE[count] : nullptr)
+    : mValueList(count ? new VALUE[count] : nullptr)
     , mElemCount(mValueList != nullptr ? count : 0)
 {
     areg::copy_elems<VALUE>(mValueList, list, mElemCount);
@@ -479,7 +479,7 @@ void FixedArray<VALUE>::copy(const FixedArray< VALUE >& src)
         if (mElemCount != src.size())
         {
             clear();
-            mValueList = src.size() > 0 ? DEBUG_NEW VALUE[src.size()] : nullptr;
+            mValueList = src.size() > 0 ? new VALUE[src.size()] : nullptr;
             mElemCount = mValueList != nullptr ? src.size() : 0;
         }
 
@@ -517,7 +517,7 @@ inline int32_t FixedArray<VALUE>::find(const VALUE& elemSearch, uint32_t startAt
 template< typename VALUE >
 void FixedArray<VALUE>::resize(uint32_t newLength)
 {
-    VALUE * newList = newLength != 0 ? DEBUG_NEW VALUE[newLength] : nullptr;
+    VALUE * newList = newLength != 0 ? new VALUE[newLength] : nullptr;
     uint32_t count = std::min(newLength, mElemCount);
     areg::copy_elems<VALUE>(newList, mValueList, count);
     delete [] mValueList;

--- a/framework/areg/base/MemoryDefs.hpp
+++ b/framework/areg/base/MemoryDefs.hpp
@@ -1156,7 +1156,7 @@ inline void zero_elements( ELEM * elemList, uint32_t elemCount )
 template<typename BufType>
 BufType* areg::BufferAllocator<BufType>::operator ( ) (uint32_t space)
 {
-    uint8_t* result = DEBUG_NEW uint8_t[space];
+    uint8_t* result = new uint8_t[space];
     return ::new(result) BufType;
 }
 

--- a/framework/areg/base/RingStack.hpp
+++ b/framework/areg/base/RingStack.hpp
@@ -613,7 +613,7 @@ template <typename VALUE>
 RingStackBase<VALUE>::RingStackBase( Lockable & syncObject, uint32_t initCapacity /*= 0*/, areg::OverlapPolicy onOverlap /*= areg::OverlapPolicy::Stop*/ )
     : mSyncObj  ( syncObject )
     , mOnOverlap( onOverlap )
-    , mStackList( initCapacity != 0 ? reinterpret_cast<VALUE*>(DEBUG_NEW uint8_t[initCapacity * sizeof(VALUE)]) : nullptr )
+    , mStackList( initCapacity != 0 ? reinterpret_cast<VALUE*>(new uint8_t[initCapacity * sizeof(VALUE)]) : nullptr )
     , mElemCount( 0u )
     , mCapacity ( mStackList != nullptr ? initCapacity : 0 )
     , mHeadPos  ( 0u )
@@ -832,7 +832,7 @@ void RingStackBase<VALUE>::free_extra()
         return;
 
     uint32_t capacity = mElemCount;
-    VALUE* newList = capacity != 0 ? reinterpret_cast<VALUE*>(DEBUG_NEW uint8_t[capacity * sizeof(VALUE)]) : nullptr;
+    VALUE* newList = capacity != 0 ? reinterpret_cast<VALUE*>(new uint8_t[capacity * sizeof(VALUE)]) : nullptr;
     if (newList != nullptr)
     {
         if (mStackList != nullptr)
@@ -985,7 +985,7 @@ uint32_t RingStackBase<VALUE>::reserve(uint32_t newCapacity )
     if (mCapacity >= newCapacity)
         return mCapacity;
 
-    VALUE* newList = newCapacity != 0 ? reinterpret_cast<VALUE*>(DEBUG_NEW uint8_t[newCapacity * sizeof(VALUE)]) : nullptr;
+    VALUE* newList = newCapacity != 0 ? reinterpret_cast<VALUE*>(new uint8_t[newCapacity * sizeof(VALUE)]) : nullptr;
     if (newList == nullptr)
         return mCapacity;
 
@@ -1147,7 +1147,7 @@ void RingStackBase<VALUE>::_copy_stack(const RingStackBase<VALUE>& source)
     {
         delete[] reinterpret_cast<uint8_t*>(mStackList);
         mStackList  = nullptr;
-        newList     = srcCapacity != 0 ? reinterpret_cast<VALUE*>(DEBUG_NEW uint8_t[srcCapacity * sizeof(VALUE)]) : nullptr;
+        newList     = srcCapacity != 0 ? reinterpret_cast<VALUE*>(new uint8_t[srcCapacity * sizeof(VALUE)]) : nullptr;
         mCapacity   = srcCapacity;
     }
 

--- a/framework/areg/base/areg_macros.h
+++ b/framework/areg/base/areg_macros.h
@@ -153,9 +153,9 @@
       #define DEBUG_NEW    new(_NORMAL_BLOCK, __FILE__, __LINE__)
    #endif   // DEBUG_NEW
 #else // _DEBUG
-   #ifndef DEBUG_NEW
-      #define DEBUG_NEW    new
-   #endif   // DEBUG_NEW
+#ifndef DEBUG_NEW
+    #define DEBUG_NEW    new
+#endif   // DEBUG_NEW
 #endif   // _DEBUG
 
 /**

--- a/framework/areg/base/private/BufferBase.cpp
+++ b/framework/areg/base/private/BufferBase.cpp
@@ -236,7 +236,7 @@ uint32_t BufferBase::reserve(uint32_t size, bool copy)
 
     total = areg::align_size(total, block_size());
     const uint32_t sizeBuffer = header_size() + total;
-    uint8_t* buffer = DEBUG_NEW uint8_t[sizeBuffer];
+    uint8_t* buffer = new uint8_t[sizeBuffer];
     const uint32_t position = init_buffer(buffer, sizeBuffer, preserveData);
     if (position != Cursor::INVALID_CURSOR_POSITION)
     {

--- a/framework/areg/base/private/FileBase.cpp
+++ b/framework/areg/base/private/FileBase.cpp
@@ -374,7 +374,7 @@ int32_t FileBase::write_invert( const uint8_t * buffer, uint32_t length )
     uint32_t result = 0;
     if ((length != 0) && (buffer != nullptr) && is_opened() && can_write())
     {
-        uint8_t* temp = (buffer != nullptr) && (length > 0) ? DEBUG_NEW uint8_t[length] : nullptr;
+        uint8_t* temp = (buffer != nullptr) && (length > 0) ? new uint8_t[length] : nullptr;
         if (temp != nullptr )
         {
             for (uint32_t i = 0; i < length; ++ i)

--- a/framework/areg/base/private/MessageEnvelope.cpp
+++ b/framework/areg/base/private/MessageEnvelope.cpp
@@ -65,7 +65,7 @@ MessageEnvelope::MessageEnvelope(const areg::EventHeader& evtHeader, uint32_t re
     sizeUsed = areg::align_size(sizeUsed, block_size());
 
     const uint32_t sizeBuffer{ sizeUsed + static_cast<uint32_t>(sizeof(areg::EventHeader)) };
-    uint8_t* result{ DEBUG_NEW uint8_t[sizeBuffer] };
+    uint8_t* result{ new uint8_t[sizeBuffer] };
     if (result != nullptr)
     {
         areg::RawEnvelope* env{ reinterpret_cast<areg::RawEnvelope*>(result) };
@@ -152,7 +152,7 @@ uint8_t* MessageEnvelope::init_envelope(const areg::EventHeader& evtHeader, uint
     invalidate();
 
     const uint32_t sizeBuffer{ sizeUsed + static_cast<uint32_t>(sizeof(areg::EventHeader)) };
-    uint8_t* result{ DEBUG_NEW uint8_t[sizeBuffer] };
+    uint8_t* result{ new uint8_t[sizeBuffer] };
     if (result == nullptr)
         return nullptr;
 

--- a/framework/areg/base/private/SharedBuffer.cpp
+++ b/framework/areg/base/private/SharedBuffer.cpp
@@ -256,7 +256,7 @@ uint32_t SharedBuffer::reserve(uint32_t size, bool copy)
 
     total = areg::align_size(total, block_size());
     const uint32_t sizeBuffer = header_size() + total;
-    uint8_t* buffer = DEBUG_NEW uint8_t[sizeBuffer];
+    uint8_t* buffer = new uint8_t[sizeBuffer];
     const uint32_t position = init_buffer(buffer, sizeBuffer, preserveData);
     if (position != Cursor::INVALID_CURSOR_POSITION)
     {

--- a/framework/areg/base/private/SocketDefs.cpp
+++ b/framework/areg/base/private/SocketDefs.cpp
@@ -678,17 +678,8 @@ AREG_API_IMPL SOCKETHANDLE areg::server_connect(const areg::SocketAddress & peer
         {
             areg::socket_configure(result);
 
-            int32_t yes = 1;
-// #ifdef _WIN32
-#if 0
-            // On Windows SO_REUSEADDR lets a second process hijack a live listening port; use
-            // SO_EXCLUSIVEADDRUSE so a duplicate server fails to bind instead of silently stealing
-            // connections from the running instance.
-            ::setsockopt( result, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, reinterpret_cast<const char *>(&yes), sizeof(int32_t) );
-#else   // _WIN32
-            // POSIX: allow fast rebind after restart (TIME_WAIT); this does not permit a second listener.
+            int32_t yes = 1; // avoid the "address already in use" error message
             ::setsockopt( result, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&yes), sizeof(int32_t) );
-#endif  // _WIN32
             if (areg::RETURNED_OK != bind(result, reinterpret_cast<sockaddr *>(&serverAddr), sizeof(sockaddr_in)) )
             {
                 LOG_ERR("Server failed to bind on host [ %s ] and port number [ %u ]. Closing socket [ %u ]"

--- a/framework/areg/base/private/SocketDefs.cpp
+++ b/framework/areg/base/private/SocketDefs.cpp
@@ -678,8 +678,17 @@ AREG_API_IMPL SOCKETHANDLE areg::server_connect(const areg::SocketAddress & peer
         {
             areg::socket_configure(result);
 
-            int32_t yes = 1;    // avoid the "address already in use" error message
+            int32_t yes = 1;
+// #ifdef _WIN32
+#if 0
+            // On Windows SO_REUSEADDR lets a second process hijack a live listening port; use
+            // SO_EXCLUSIVEADDRUSE so a duplicate server fails to bind instead of silently stealing
+            // connections from the running instance.
+            ::setsockopt( result, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, reinterpret_cast<const char *>(&yes), sizeof(int32_t) );
+#else   // _WIN32
+            // POSIX: allow fast rebind after restart (TIME_WAIT); this does not permit a second listener.
             ::setsockopt( result, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&yes), sizeof(int32_t) );
+#endif  // _WIN32
             if (areg::RETURNED_OK != bind(result, reinterpret_cast<sockaddr *>(&serverAddr), sizeof(sockaddr_in)) )
             {
                 LOG_ERR("Server failed to bind on host [ %s ] and port number [ %u ]. Closing socket [ %u ]"

--- a/framework/areg/base/private/Thread.cpp
+++ b/framework/areg/base/private/Thread.cpp
@@ -115,7 +115,7 @@ ThreadLocalStorage* Thread::_thread_local_storage( Thread* ownThread )
     {
         // called only once, when thread starts.
         ASSERT(_localStorage == nullptr );
-        _localStorage = DEBUG_NEW ThreadLocalStorage( *ownThread );
+        _localStorage = new ThreadLocalStorage( *ownThread );
     }
     else
     {

--- a/framework/areg/base/private/posix/SyncPrimitivesPosix.cpp
+++ b/framework/areg/base/private/posix/SyncPrimitivesPosix.cpp
@@ -64,7 +64,7 @@ void SyncObject::_os_destroy()
 
 void Mutex::_os_create_mutex( bool initLock )
 {
-    mSyncObject = DEBUG_NEW areg::os::WaitableMutexPosix(initLock);
+    mSyncObject = new areg::os::WaitableMutexPosix(initLock);
 }
 
 bool Mutex::_os_lock_mutex( uint32_t timeout )
@@ -101,7 +101,7 @@ bool Mutex::_os_unlock_mutex()
 
 void SyncEvent::_os_create_event( bool initLock )
 {
-    mSyncObject    = static_cast<void *>( DEBUG_NEW areg::os::WaitableEventPosix(!initLock, mAutoReset) );
+    mSyncObject    = static_cast<void *>( new areg::os::WaitableEventPosix(!initLock, mAutoReset) );
 }
 
 bool SyncEvent::_os_unlock_event( void * eventHandle ) noexcept
@@ -148,7 +148,7 @@ int32_t SyncEvent::_os_wait_any( SyncEvent** events, int32_t count, uint32_t tim
 
 void Semaphore::_os_create_semaphore( )
 {
-    mSyncObject = DEBUG_NEW areg::os::WaitableSemaphorePosix(static_cast<int32_t>(mMaxCount), static_cast<int32_t>(mCurrCount.load()));
+    mSyncObject = new areg::os::WaitableSemaphorePosix(static_cast<int32_t>(mMaxCount), static_cast<int32_t>(mCurrCount.load()));
 }
 
 void Semaphore::_os_release_semaphore()
@@ -174,7 +174,7 @@ bool Semaphore::_os_unlock()
 
 void CriticalSection::_os_create_critical_section()
 {
-    mSyncObject = static_cast<void *>( DEBUG_NEW areg::os::CriticalSectionPosix(false) );
+    mSyncObject = static_cast<void *>( new areg::os::CriticalSectionPosix(false) );
 }
 
 void CriticalSection::_os_release_critical_section()
@@ -203,7 +203,7 @@ bool CriticalSection::_os_try_lock()
 
 void SyncTimer::_os_create_timer( bool /* isSteady */ )
 {
-    mSyncObject= static_cast<void *>(DEBUG_NEW areg::os::WaitableTimerPosix( mIsAutoReset ));
+    mSyncObject= static_cast<void *>(new areg::os::WaitableTimerPosix( mIsAutoReset ));
 }
 
 void SyncTimer::_os_release_time()

--- a/framework/areg/base/private/win32/FileWin32.cpp
+++ b/framework/areg/base/private/win32/FileWin32.cpp
@@ -75,7 +75,7 @@ static areg::String _searchFile( const char* fileName, const char* fileExtension
     {
         fileExtension = fileExtension != nullptr && *fileExtension == '.' ? fileExtension : nullptr;
         String searchPath = File::NameHasCurrentFolder(searchInDirectory) ? File::GetCurrentDir() : searchInDirectory;
-        char * buffer = DEBUG_NEW char[File::MAXIMUM_PATH + 1];
+        char * buffer = new char[File::MAXIMUM_PATH + 1];
         uint32_t length = ::SearchPathA(searchPath, fileName, fileExtension, File::MAXIMUM_PATH, buffer, &fileName);
         result = length != 0 && length <= File::MAXIMUM_PATH ? buffer : "";
 

--- a/framework/areg/base/private/win32/ProcessWin32.cpp
+++ b/framework/areg/base/private/win32/ProcessWin32.cpp
@@ -63,7 +63,7 @@ String Process::_os_env_variable( const char* var ) const
     uint32_t size = length + 1u;
     if (size > 1)
     {
-        char *buffer = DEBUG_NEW char[size];
+        char *buffer = new char[size];
         ::GetEnvironmentVariableA(var, buffer, length);
         result = buffer;
         delete [] buffer;

--- a/framework/areg/base/private/win32/SyncPrimitivesWin32.cpp
+++ b/framework/areg/base/private/win32/SyncPrimitivesWin32.cpp
@@ -179,7 +179,7 @@ bool Semaphore::_os_unlock()
 
 void CriticalSection::_os_create_critical_section()
 {
-    mSyncObject = static_cast<void *>( DEBUG_NEW uint8_t [sizeof(CRITICAL_SECTION)] );
+    mSyncObject = static_cast<void *>( new uint8_t [sizeof(CRITICAL_SECTION)] );
     areg::construct_elems<CRITICAL_SECTION>( mSyncObject, 1 );
     InitializeCriticalSection( reinterpret_cast<LPCRITICAL_SECTION>(mSyncObject) );
 }

--- a/framework/areg/component/private/Component.cpp
+++ b/framework/areg/component/private/Component.cpp
@@ -150,7 +150,7 @@ WorkerThread* Component::create_worker_thread(  const String & threadName
     if (workThread != nullptr)
         return workThread;
 
-    workThread = DEBUG_NEW WorkerThread(threadName, self(), consumer, watchdogTimeout, stackSizeKb, maxQeueue, dropOnFull, waitMs);
+    workThread = new WorkerThread(threadName, self(), consumer, watchdogTimeout, stackSizeKb, maxQeueue, dropOnFull, waitMs);
     if (workThread == nullptr)
         return nullptr;
     

--- a/framework/areg/component/private/ComponentLoader.cpp
+++ b/framework/areg/component/private/ComponentLoader.cpp
@@ -416,7 +416,7 @@ bool ComponentLoader::load_model( areg::Model & whichModel ) const
             continue;
         }
 
-        ComponentThread* thrObject = DEBUG_NEW ComponentThread( entry.mThreadName, entry.mWatchdogTimeout, entry.mStackSizeKB, entry.mMaxQueue, entry.mDropOnFull, entry.mQueueTimeout );
+        ComponentThread* thrObject = new ComponentThread( entry.mThreadName, entry.mWatchdogTimeout, entry.mStackSizeKB, entry.mMaxQueue, entry.mDropOnFull, entry.mQueueTimeout );
         if (thrObject == nullptr)
             result = false;
 

--- a/framework/areg/component/private/ProxyBase.cpp
+++ b/framework/areg/component/private/ProxyBase.cpp
@@ -88,7 +88,10 @@ std::shared_ptr<ProxyBase> ProxyBase::acquire_proxy( const String & roleName
                                                    , FuncCreateProxy funcCreate
                                                    , const String & ownerThread /*= String::empty_string()*/)
 {
-    return ProxyBase::acquire_proxy(roleName, serviceIfData, connect, funcCreate, DispatcherThread::dispatcher_thread(ThreadAddress(ownerThread)) );
+    DispatcherThread & owner = ownerThread.is_empty()
+                                    ? DispatcherThread::current_dispatcher_thread()
+                                    : DispatcherThread::dispatcher_thread(ThreadAddress(ownerThread));
+    return ProxyBase::acquire_proxy(roleName, serviceIfData, connect, funcCreate, owner);
 }
 
 std::shared_ptr<ProxyBase> ProxyBase::acquire_proxy(const String& roleName, const areg::InterfaceData& serviceIfData, ProxyListener& connect, FuncCreateProxy funcCreate, const UniqueNumber ownerThread)
@@ -104,9 +107,13 @@ std::shared_ptr<ProxyBase> ProxyBase::acquire_proxy( const String & roleName
 {
     LOG_SCOPE( areg_component_ProxyBase, acquire_proxy );
 
+    ASSERT( !roleName.is_empty() );     // a proxy without a service role name is invalid
     std::shared_ptr<ProxyBase> proxy{ nullptr };
     if (!ownerThread.is_valid())
+    {
+        ASSERT( false );                // owner dispatcher thread did not resolve (unnamed or unknown)
         return proxy;
+    }
 
     MapProxyResource& mapProxies{ map_proxies() };
     ProxyAddress Key(serviceIfData, roleName, ownerThread.name() );

--- a/framework/areg/component/private/ServiceDefs.cpp
+++ b/framework/areg/component/private/ServiceDefs.cpp
@@ -119,7 +119,7 @@ void areg::ParameterArray::construct( const uint32_t * params, uint32_t count ) 
     // space for parameters
     size += count_param_space(params, count);
 
-    uint8_t* buffer = DEBUG_NEW uint8_t[size];
+    uint8_t* buffer = new uint8_t[size];
     if (buffer == nullptr)
         return;
     

--- a/framework/areg/component/private/ServiceManagerEventProcessor.cpp
+++ b/framework/areg/component/private/ServiceManagerEventProcessor.cpp
@@ -481,7 +481,7 @@ void ServiceManagerEventProcessor::_start_component_thread( const String & threa
     Thread * thread = Thread::find_by_address(ThreadAddress(threadName));
     if ( entry.is_valid( ) && (thread == nullptr) )
     {
-        ComponentThread * compThread = DEBUG_NEW ComponentThread( entry.mThreadName, entry.mWatchdogTimeout );
+        ComponentThread * compThread = new ComponentThread( entry.mThreadName, entry.mWatchdogTimeout );
         if ( (compThread != nullptr) && compThread->start( areg::WAIT_INFINITE ) )
         {
             LOG_DBG( "Succeeded to create and start component thread [ %s ]", threadName.as_string( ) );

--- a/framework/areg/component/private/posix/TimerBasePosix.cpp
+++ b/framework/areg/component/private/posix/TimerBasePosix.cpp
@@ -31,7 +31,7 @@ namespace areg {
 
 TIMERHANDLE TimerBase::_os_create() noexcept
 {
-    return static_cast<TIMERHANDLE>(DEBUG_NEW areg::os::TimerPosix( ));
+    return static_cast<TIMERHANDLE>(new areg::os::TimerPosix( ));
 }
 
 void TimerBase::_os_destroy( TIMERHANDLE handle ) noexcept

--- a/framework/areg/ipc/ServiceClientConnectionBase.hpp
+++ b/framework/areg/ipc/ServiceClientConnectionBase.hpp
@@ -402,6 +402,27 @@ protected:
     void cancel_connection();
 
     /**
+     * \brief   Single, uniform entry point that a subclass MUST call when it detects that the
+     *          active connection to the remote service is broken (e.g. a failed send or receive).
+     *
+     *          It closes the socket and then queues the lost-connection command on the dispatcher,
+     *          which in turn arms the reconnect timer. Closing the socket first is an integral part
+     *          of the contract: on_connection_lost() treats a still-valid connection as a stale /
+     *          duplicate notification (a newer attempt is already in progress) and deliberately
+     *          skips reconnection. By funnelling every producer through this single method, the
+     *          reconnect behavior is identical for every service kind (router client, logger, and
+     *          any future client) and cannot be silently broken by a subclass that forgets to close
+     *          the socket before signaling.
+     *
+     *          The connection is torn down for good (no reconnect) only when the developer explicitly
+     *          stops it via on_service_stop() / disconnect_service_host(), or when servicing becomes
+     *          unavailable while the application is closing.
+     *
+     * \param   eventPrio   The priority of the queued lost-connection command. Normal by default.
+     **/
+    void notify_connection_lost( areg::EventPriority eventPrio = areg::EventPriority::NormalPrio );
+
+    /**
      * \brief   Sets the client socket connection state.
      *
      * \param   newState    The connection state to set.

--- a/framework/areg/ipc/private/RouterClient.cpp
+++ b/framework/areg/ipc/private/RouterClient.cpp
@@ -206,8 +206,7 @@ void RouterClient::failed_send_message(const MessageEnvelope & msgFailed, Socket
             if ( whichTarget.is_valid() && (whichTarget.is_alive() == false))
             {
                 LOG_DBG("Trying to reconnect");
-                cancel_connection( );
-                send_command( ServiceEventData::ServiceCommand::CMD_ServiceLost, areg::EventPriority::NormalPrio );
+                notify_connection_lost( );
             }
         }
         else
@@ -232,8 +231,7 @@ void RouterClient::failed_receive_message( [[maybe_unused]] Socket & whichSource
                    , static_cast<uint32_t>(whichSource.handle())
                    , whichSource.is_valid() ? "VALID" : "INVALID"
                    , whichSource.is_alive() ? "ALIVE" : "DEAD");
-        cancel_connection();
-        send_command(ServiceEventData::ServiceCommand::CMD_ServiceLost, areg::EventPriority::NormalPrio);
+        notify_connection_lost();
     }
     else
     {

--- a/framework/areg/ipc/private/ServiceClientConnectionBase.cpp
+++ b/framework/areg/ipc/private/ServiceClientConnectionBase.cpp
@@ -121,9 +121,8 @@ void ServiceClientConnectionBase::service_connection_event(const MessageEnvelope
         }
         else
         {
-            cancel_connection();
             on_channel_connected(areg::COOKIE_UNKNOWN);
-            send_command(ServiceEventData::ServiceCommand::CMD_ServiceLost);
+            notify_connection_lost();
         }
     }
     break;
@@ -132,9 +131,8 @@ void ServiceClientConnectionBase::service_connection_event(const MessageEnvelope
     case areg::ServiceConnectionState::Disconnected:
     case areg::ServiceConnectionState::Failed:
     {
-        cancel_connection();
         on_channel_connected(areg::COOKIE_UNKNOWN);
-        send_command(ServiceEventData::ServiceCommand::CMD_ServiceLost);
+        notify_connection_lost();
     }
     break;
 
@@ -251,7 +249,7 @@ void ServiceClientConnectionBase::on_service_start()
 {
     LOG_SCOPE( areg_ipc_private_ServiceClientConnectionBase, on_service_start );
 
-    if (connection_state() == ConnectionPhase::ConnectionStopping || !Application::is_servicing_ready())
+    if (connection_state() == ConnectionPhase::ConnectionStopping || !Application::is_servicing_available())
     {
         LOG_WARN("Ignoring start event: connection is stopping or application is releasing.");
         return;
@@ -353,7 +351,7 @@ void ServiceClientConnectionBase::on_connection_stopped()
     mThreadSend.shutdown( areg::WAIT_INFINITE );
     mConnectionConsumer.on_service_channel_disconnected( channel );
 
-    if ( Application::is_servicing_ready( ) && (prevState != ConnectionPhase::ConnectionStopping) )
+    if ( Application::is_servicing_available( ) && (prevState != ConnectionPhase::ConnectionStopping) )
     {
         if (!mTimerConnect.start_timer(areg::DEFAULT_RETRY_CONNECT_TIMEOUT, mMessageDispatcher, 1))
         {
@@ -380,7 +378,7 @@ void ServiceClientConnectionBase::on_connection_lost()
     Channel channel = mChannel;
     mChannel.invalidate();
 
-    if (!Application::is_servicing_ready() || !mTimerConnect.is_stopped() ||
+    if (!Application::is_servicing_available() || !mTimerConnect.is_stopped() ||
         (prevState == ConnectionPhase::ConnectionStopping))
     {
         LOG_WARN("Ignoring lost connection event, either servicing state is not allowed, or application is closing.");
@@ -450,7 +448,7 @@ bool ServiceClientConnectionBase::start_connection()
         if (!mTimerConnect.start_timer(areg::DEFAULT_RETRY_CONNECT_TIMEOUT, mMessageDispatcher, 1))
         {
             LOG_WARN("Failed to start reconnect timer, retrying connection immediately.");
-            if (Application::is_servicing_ready())
+            if (Application::is_servicing_available())
                 send_command(ServiceEventData::ServiceCommand::CMD_StartService);
         }
 
@@ -484,7 +482,7 @@ bool ServiceClientConnectionBase::start_connection()
         if (!mTimerConnect.start_timer(areg::DEFAULT_RETRY_CONNECT_TIMEOUT, mMessageDispatcher, 1))
         {
             LOG_WARN("Failed to start reconnect timer, retrying connection immediately.");
-            if (Application::is_servicing_ready())
+            if (Application::is_servicing_available())
                 send_command(ServiceEventData::ServiceCommand::CMD_StartService);
         }
     }
@@ -503,6 +501,13 @@ void ServiceClientConnectionBase::cancel_connection()
 
     mThreadReceive.trigger_exit();
     mThreadSend.trigger_exit();
+}
+
+void ServiceClientConnectionBase::notify_connection_lost( areg::EventPriority eventPrio )
+{
+    // Close the socket BEFORE queuing the lost-connection command
+    cancel_connection();
+    send_command( ServiceEventData::ServiceCommand::CMD_ServiceLost, eventPrio );
 }
 
 } // namespace areg

--- a/framework/areg/logging/private/LayoutManager.cpp
+++ b/framework/areg/logging/private/LayoutManager.cpp
@@ -30,7 +30,7 @@ bool LayoutManager::create_layouts( const char * layoutFormat )
 {
     delete_layouts();
     int32_t len = !areg::is_empty<char>(layoutFormat) ? areg::string_length<char>( layoutFormat ) : 0;
-    char * strFormat = len > 0 ? DEBUG_NEW char[ static_cast<uint32_t>(len) + 1u ] : nullptr;
+    char * strFormat = len > 0 ? new char[ static_cast<uint32_t>(len) + 1u ] : nullptr;
 
     if ( strFormat != nullptr )
     {
@@ -101,59 +101,59 @@ inline void LayoutManager::_create_layouts(char* layoutFormat)
             switch (static_cast<areg::LayoutToken>(ch))
             {
             case areg::LayoutToken::TickCount:
-                newLayout = DEBUG_NEW TickCountLayout();
+                newLayout = new TickCountLayout();
                 break;
 
             case areg::LayoutToken::DayTime:
-                newLayout = DEBUG_NEW DayTimeLayout();
+                newLayout = new DayTimeLayout();
                 break;
 
             case areg::LayoutToken::ExecutableId:
-                newLayout = DEBUG_NEW ModuleIdLayout();
+                newLayout = new ModuleIdLayout();
                 break;
 
             case areg::LayoutToken::Message:
                 if (!hasExclusive)
                 {
-                    newLayout = DEBUG_NEW MessageLayout();
+                    newLayout = new MessageLayout();
                     hasExclusive = true;
                 }
                 break;
 
             case areg::LayoutToken::EndOfLine:
-                newLayout = DEBUG_NEW EndOfLineLayout();
+                newLayout = new EndOfLineLayout();
                 break;
 
             case areg::LayoutToken::Priority:
-                newLayout = DEBUG_NEW PriorityLayout();
+                newLayout = new PriorityLayout();
                 break;
 
             case areg::LayoutToken::ScopeId:
-                newLayout = DEBUG_NEW ScopeIdLayout();
+                newLayout = new ScopeIdLayout();
                 break;
 
             case areg::LayoutToken::ThreadId:
-                newLayout = DEBUG_NEW ThreadIdLayout();
+                newLayout = new ThreadIdLayout();
                 break;
 
             case areg::LayoutToken::ExecutableName:
-                newLayout = DEBUG_NEW ModuleNameLayout();
+                newLayout = new ModuleNameLayout();
                 break;
 
             case areg::LayoutToken::ThreadName:
-                newLayout = DEBUG_NEW ThreadNameLayout();
+                newLayout = new ThreadNameLayout();
                 break;
 
             case areg::LayoutToken::ScopeName:
                 if (!hasExclusive)
                 {
-                    newLayout = DEBUG_NEW ScopeNameLayout();
+                    newLayout = new ScopeNameLayout();
                     hasExclusive = true;
                 }
                 break;
 
             case areg::LayoutToken::CookieId:
-                newLayout = DEBUG_NEW CookieIdLayout();
+                newLayout = new CookieIdLayout();
                 break;
 
             case areg::LayoutToken::Undefined:  // fall through
@@ -162,7 +162,7 @@ inline void LayoutManager::_create_layouts(char* layoutFormat)
                 if (ch == areg::SYNTAX_SPECIAL_FORMAT)
                 {
                     *(pos + 1) = String::EmptyChar;
-                    newLayout = DEBUG_NEW AnyTextLayout(pos1);
+                    newLayout = new AnyTextLayout(pos1);
                     pos1 = pos; // <== will automatically move 2 positions when newLayout is not nullptr;
                 }
                 else
@@ -175,7 +175,7 @@ inline void LayoutManager::_create_layouts(char* layoutFormat)
             if (newLayout != nullptr)
             {
                 *pos = String::EmptyChar;
-                anyText = pos1 != pos ? DEBUG_NEW AnyTextLayout(pos1) : nullptr;
+                anyText = pos1 != pos ? new AnyTextLayout(pos1) : nullptr;
                 if (anyText != nullptr)
                 {
                     mLayoutList.add(anyText);
@@ -192,7 +192,7 @@ inline void LayoutManager::_create_layouts(char* layoutFormat)
         }
     }
     
-    anyText = pos1 != pos ? DEBUG_NEW AnyTextLayout(pos1) : nullptr;
+    anyText = pos1 != pos ? new AnyTextLayout(pos1) : nullptr;
     if (anyText != nullptr)
     {
         mLayoutList.add(anyText);

--- a/framework/areg/logging/private/LogManager.cpp
+++ b/framework/areg/logging/private/LogManager.cpp
@@ -314,7 +314,8 @@ void LogManager::ready_for_events( bool is_ready )
         DispatcherThread::ready_for_events( false );
         LoggingEvent::remove_listener( static_cast<LoggingEventConsumer &>(self( )), static_cast<DispatcherThread &>(self( )) );
 
-        // When we are here, all loggers should be already closed.
+        stop_logs();
+
         ASSERT(!mLoggerFile.is_logger_opened());
         ASSERT(!mLoggerDebug.is_logger_opened());
         ASSERT(!mLoggerTcp.is_logger_opened());

--- a/framework/areg/logging/private/NetTcpLogger.cpp
+++ b/framework/areg/logging/private/NetTcpLogger.cpp
@@ -89,7 +89,7 @@ void NetTcpLogger::log_message(const areg::LogEntry& logMessage)
     if (!mIsEnabled)
         return;
 
-    if (mChannel.is_valid() && is_connect_state())
+    if (mChannel.is_valid() && is_connected_state())
     {
         send_message(areg::create_log_message(logMessage, areg::LogDataType::Remote, mChannel.cookie()), areg::EventPriority::NormalPrio);
     }
@@ -104,7 +104,7 @@ void NetTcpLogger::forward_message(const areg::MessageEnvelope& msg)
     if (!mIsEnabled)
         return;
 
-    if (mChannel.is_valid() && is_connect_state())
+    if (mChannel.is_valid() && is_connected_state())
     {
         send_message(msg, areg::EventPriority::NormalPrio);
     }
@@ -119,7 +119,7 @@ void NetTcpLogger::forward_message(areg::MessageEnvelope&& msg)
     if (!mIsEnabled)
         return;
 
-    if (mChannel.is_valid() && is_connect_state())
+    if (mChannel.is_valid() && is_connected_state())
     {
         send_message(std::move(msg), areg::EventPriority::NormalPrio);
     }
@@ -143,6 +143,10 @@ void NetTcpLogger::on_service_channel_connected(const Channel & channel)
 
     mIsEnabled = true;
     const ITEM_ID& cookie = channel.cookie();
+
+    const areg::ScopeList& scopes{ static_cast<const areg::ScopeList&>(mScopeController.scope_list()) };
+    send_message(areg::message_register_scopes(cookie, areg::COOKIE_LOGGER, scopes));
+
     while (mRingStack.is_empty() == false)
     {
         areg::MessageEnvelope msgLog{ mRingStack.pop() };
@@ -167,18 +171,24 @@ void NetTcpLogger::on_service_channel_lost(const Channel & /* channel */)
 
 void NetTcpLogger::failed_send_message(const MessageEnvelope & msgFailed, Socket & /* whichTarget */)
 {
+    if (connection_state() == ConnectionPhase::ConnectionStopping)
+        return;
+
     ASSERT(mIsEnabled);
     if (mLogConfiguration.stack_size() > 0)
     {
         mRingStack.push(msgFailed);
     }
 
-    send_command(ServiceEventData::ServiceCommand::CMD_ServiceLost);
+    notify_connection_lost();
 }
 
 void NetTcpLogger::failed_receive_message(Socket & /* whichSource */)
 {
-    send_command(ServiceEventData::ServiceCommand::CMD_ServiceLost);
+    if (connection_state() == ConnectionPhase::ConnectionStopping)
+        return;
+
+    notify_connection_lost();
 }
 
 void NetTcpLogger::failed_process_message(const MessageEnvelope & /* msgUnprocessed */)

--- a/framework/aregextend/service/SystemServiceDefs.hpp
+++ b/framework/aregextend/service/SystemServiceDefs.hpp
@@ -288,7 +288,7 @@ inline constexpr const char * as_string( areg::ext::ServicePhase serviceState ) 
 template<typename CharType>
 inline char** convert_arguments(CharType** argv, int32_t argc)
 {
-    char** result = argc != 0 ? DEBUG_NEW char* [static_cast<uint32_t>(argc)] : nullptr;
+    char** result = argc != 0 ? new char* [static_cast<uint32_t>(argc)] : nullptr;
     if (result != nullptr)
     {
         for (uint32_t i = 0; i < static_cast<uint32_t>(argc); ++i)
@@ -296,7 +296,7 @@ inline char** convert_arguments(CharType** argv, int32_t argc)
             CharType* entry = argv[i];
             uint32_t length = static_cast<uint32_t>(areg::string_length<CharType>(entry));
             uint32_t size = length + 1u;
-            char* arg = DEBUG_NEW char[size];
+            char* arg = new char[size];
             areg::copy_string<char, CharType>(arg, static_cast<areg::CharCount>(size), entry);
             result[i] = arg;
         }

--- a/framework/logobserver/app/private/win32/LogObserverWin32.cpp
+++ b/framework/logobserver/app/private/win32/LogObserverWin32.cpp
@@ -44,7 +44,7 @@ namespace
 
     inline char ** _convert_args( TCHAR ** argv, int32_t argc )
     {
-        char ** argvTemp = argc != 0 ? DEBUG_NEW char * [static_cast<uint32_t>(argc)] : nullptr;
+        char ** argvTemp = argc != 0 ? new char * [static_cast<uint32_t>(argc)] : nullptr;
         if ( argvTemp != nullptr )
         {
             for ( uint32_t i = 0; i < static_cast<uint32_t>(argc); ++i )
@@ -52,7 +52,7 @@ namespace
                 TCHAR * entry = argv[i];
                 uint32_t length = static_cast<uint32_t>(areg::string_length<TCHAR>( entry ));
                 uint32_t size = length + 1u;
-                char * arg = DEBUG_NEW char[size];
+                char * arg = new char[size];
                 areg::copy_string<char, TCHAR>( arg, static_cast<areg::CharCount>(size), entry );
                 argvTemp[i] = arg;
             }


### PR DESCRIPTION
## Summary
- Fixed bug connecting logcollector;
- Fixed bug sending "hello server" handshake message;
- Fixed bug of sending messages before the connection is accepted -> first connection accepted, cookie is set, then send messages
- Fixed bug of sending logging scopes before messages -> before sending any message, send logging scopes so that the system knows the scopes and prios
- Fixed bug of reconnecting to the service when connection is lost,  made that on base class level, so that the logic is same for `logcollector` and `mtrouter`
- use `new` operator instead of calling `DEBUG_NEW` (which is `new(_NORMAL_BLOCK, __FILE__, __LINE__)`), because in MSVC it is aligning to 16-bit, which is causing segmentation fault -- in `EventQueue` we use 128-bit alignment.

[x] I have read CONTRIBUTING.md

Signed-off-by: Artak Avetyan
