### PR TITLE
fixed link, latency project is at least 10 tests

### DIFF
--- a/docs/wiki/08c-areg-vs-hitachi-benchmark.md
+++ b/docs/wiki/08c-areg-vs-hitachi-benchmark.md
@@ -9,7 +9,7 @@
 This document compares areg-sdk OWT (one-way) and RTT (round-trip) latency
 against ZeroMQ, NanoMsg, and NNG as measured in a peer-reviewed benchmark
 published by Hitachi Energy Research (arXiv:2508.07934v1, August 2025).
-Raw data source: github.com/hitachienergy/messaging-libraries-benchmark/results/results.csv
+Raw data source: https://github.com/hitachienergy/messaging-libraries-benchmark/blob/main/results/results.csv
 
 All measurements are same-machine TCP loopback only.
 No cross-machine or real-network numbers appear anywhere in this document.

--- a/examples/30_publatency/pubconsumer/src/LatencyConsumer.hpp
+++ b/examples/30_publatency/pubconsumer/src/LatencyConsumer.hpp
@@ -188,7 +188,7 @@ class LatencyConsumer final : public    areg::Component
 // Internal constants
 //////////////////////////////////////////////////////////////////////////
 private:
-    static constexpr uint32_t MAX_RESULT_ROWS { 8u };
+    static constexpr uint32_t MAX_RESULT_ROWS { 10u };
 
     static constexpr std::string_view THREAD_INPUT   { "LatencyConsumerInputThread" };
     static constexpr std::string_view THREAD_DISPLAY { "LatencyConsumerDisplayThread" };
@@ -230,7 +230,7 @@ private:
     static constexpr areg::ext::Console::Coord COORD_TBL_HDR  { 1, 24 };
     static constexpr areg::ext::Console::Coord COORD_TBL_SEP  { 1, 25 };
     static constexpr areg::ext::Console::Coord COORD_TBL_ROW0 { 1, 26 };  //!< First data row
-    static constexpr areg::ext::Console::Coord COORD_TBL_BOT  { 1, 34 };  //!< 26 + MAX_RESULT_ROWS
+    static constexpr areg::ext::Console::Coord COORD_TBL_BOT  { 1, COORD_TBL_ROW0.posY + MAX_RESULT_ROWS };  //!< 26 + MAX_RESULT_ROWS
 
 //////////////////////////////////////////////////////////////////////////
 // Console message strings


### PR DESCRIPTION
## Summary
- Fixed link
- Latency benchmark displays 10 entries instead of 8

[x] I have read CONTRIBUTING.md

Signed-off-by: Artak Avetyan