### PR TITLE
feat(benchmarks): expand HashMap and DateTime benchmarks, adjust CMake Google Benchmark dependency

### DIFF
--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -27,10 +27,19 @@ if (AREG_BENCHMARKS)
     set(BENCHMARK_INSTALL_DOCS          OFF CACHE BOOL "Disable google_benchmark documentation"  FORCE)
     set(BENCHMARK_ENABLE_WERROR         OFF CACHE BOOL "Disable google_benchmark warning errors" FORCE)
 
-    FetchContent_Declare( google_benchmark
-                          GIT_REPOSITORY https://github.com/CodSpeedHQ/codspeed-cpp.git
-                          GIT_TAG        "v2.4.0"
-                          SOURCE_SUBDIR  google_benchmark)
+    option(CODSPEED_MODE "Enable CodSpeed instrumentation" OFF)
+
+    if (CODSPEED_MODE)
+        FetchContent_Declare( google_benchmark
+                GIT_REPOSITORY https://github.com/CodSpeedHQ/codspeed-cpp.git
+                GIT_TAG        "v2.4.0"
+                SOURCE_SUBDIR  google_benchmark)
+    else()
+        FetchContent_Declare( google_benchmark
+                GIT_REPOSITORY https://github.com/google/benchmark.git
+                GIT_TAG        "v1.8.3")
+    endif()
+
 
     # Always build the benchmark library as a static library.
     set(_areg_saved_build_shared_libs ${BUILD_SHARED_LIBS})

--- a/tests/benchmarks/ContainerBenchmark.cpp
+++ b/tests/benchmarks/ContainerBenchmark.cpp
@@ -322,6 +322,147 @@ void BM_HashMap_FindString(benchmark::State& state)
 }
 BENCHMARK(BM_HashMap_FindString);
 
+//!< Measures allocation and setup overhead of an empty hash map with reserved buckets.
+void BM_HashMap_Construct(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        areg::HashMap<areg::String, int> hash(1024u);
+        benchmark::DoNotOptimize(hash);
+        benchmark::ClobberMemory();
+    }
+
+}
+BENCHMARK(BM_HashMap_Construct);
+
+//!< Measures hash calculation, key copying, and element insertion when constructing from arrays.
+void BM_HashMap_ConstructInsertString(benchmark::State& state)
+{
+    const std::vector<int> value{ bench::make_integers(1024u) };
+    const std::vector<areg::String> key{ bench::make_strings(1024u) };
+
+    for (auto _ : state)
+    {
+        areg::HashMap<areg::String, int> hash(key.data(), value.data(), 1024u);
+        benchmark::DoNotOptimize(hash);
+        benchmark::ClobberMemory();
+    }
+
+}
+BENCHMARK(BM_HashMap_ConstructInsertString);
+
+//!< Measures hash lookup and entry insertion when merging two populated hash maps.
+void BM_HashMap_Merge(benchmark::State& state)
+{
+    const std::vector<areg::String> src {bench::make_strings(1024u)};
+    areg::HashMap<areg::String, int> main_hash;
+    uint32_t index = 0 ;
+    for (const auto& key : src )
+    {
+        main_hash.set_value_at(key, index++ );
+    }
+
+
+    for ( auto _ : state )
+    {
+        state.PauseTiming();
+        areg::HashMap<areg::String, int > target_hash(main_hash);
+
+        state.ResumeTiming();
+
+        target_hash.merge(main_hash);
+        benchmark::DoNotOptimize(target_hash);
+        benchmark::ClobberMemory();
+    }
+    state.SetItemsProcessed(state.iterations() * 1024);
+}
+BENCHMARK(BM_HashMap_Merge);
+
+//!< Measures the time taken to sequentially add a block of 1024 elements to the hash using the update_at method.
+void BM_HashMap_UpdateIntegers(benchmark::State& state) {
+    const std::vector<areg::String> src {bench::make_strings(1024u)};
+    areg::HashMap<areg::String, int> target;
+    uint32_t index = 0 ;
+    for (const auto& key: src) {
+        target.set_value_at(key, index ++);
+    }
+    for ( auto _ : state )
+    {
+        for (size_t i = 0; i < src.size(); ++i)
+        {
+            target.update_at(src[i], i);
+        }
+
+        benchmark::DoNotOptimize(target);
+        benchmark::ClobberMemory();
+
+    }
+    state.SetItemsProcessed(state.iterations() * 1024);
+
+}
+BENCHMARK(BM_HashMap_UpdateIntegers);
+
+//!< Measures sequential removal of all 1024 elements from a populated hash map.
+void BM_HashMap_RemoveKey(benchmark::State& state)
+{
+    const std::vector<areg::String> src {bench::make_strings(1024u)};
+    uint32_t index = 0 ;
+    areg::HashMap<areg::String, int> hash;
+
+    for ( const auto& key : src)
+    {
+        hash.set_value_at(key, index ++);
+
+    }
+
+    for ( auto _ : state) {
+        state.PauseTiming();
+
+        areg::HashMap<areg::String, int> target(hash);
+
+        state.ResumeTiming();
+
+        for (size_t i = 0 ; i < src.size() ; ++i )
+        {
+            target.remove_at(src[i]);
+        }
+
+        benchmark::DoNotOptimize(target);
+        benchmark::ClobberMemory();
+    }
+    state.SetItemsProcessed(state.iterations() * 1024);
+}
+BENCHMARK(BM_HashMap_RemoveKey);
+
+//!< Measures the time taken to sequentially remove all 1024 elements from a populated hash map using the clear() method.
+void BM_HashMap_Clear(benchmark::State& state) {
+    std::vector<areg::String> src { bench::make_strings(1024u) };
+    uint32_t index = 0 ;
+    areg::HashMap<areg::String, int> hash;
+
+    for (const auto& key : src)
+    {
+        hash.set_value_at(key, index ++);
+
+    }
+
+    for ( auto _ : state)
+    {
+        state.PauseTiming();
+
+        areg::HashMap<areg::String, int> target(hash);
+
+        state.ResumeTiming();
+
+        target.clear();
+
+        benchmark::DoNotOptimize(target);
+        benchmark::ClobberMemory();
+
+    }
+}
+BENCHMARK(BM_HashMap_Clear);
+
 //!< Fills the ordered (tree based) map with the string keys.
 void BM_OrderedMap_InsertString(benchmark::State& state)
 {

--- a/tests/benchmarks/DateTimeBenchmark.cpp
+++ b/tests/benchmarks/DateTimeBenchmark.cpp
@@ -140,3 +140,51 @@ void BM_DateTime_Compare(benchmark::State& state)
 }
 BENCHMARK(BM_DateTime_Compare);
 
+//!< Measures fetching the current system tick count.
+void BM_DateTime_TickCount(benchmark::State& state)
+{
+    areg::DateTime date;
+
+    for (auto _ : state)
+    {
+
+        uint64_t ticks = date.system_tick_count();
+        benchmark::DoNotOptimize(ticks);
+    }
+}
+BENCHMARK(BM_DateTime_TickCount);
+
+//!< Measures day-of-week calculation performance across a set of pre-generated dates.
+void BM_DateTime_DayOfWeek(benchmark::State& state)
+{
+    const std::vector<areg::DateTime> times{bench::make_times(1024u)};
+
+    for (auto _ : state)
+    {
+        for (auto time : times ) {
+            uint32_t dow = time.day_of_week();
+            benchmark::DoNotOptimize(dow);
+        }
+
+    }
+    state.SetItemsProcessed(state.iterations() * 1024);
+}
+BENCHMARK(BM_DateTime_DayOfWeek);
+
+//!< Measures microsecond component extraction performance across a set of pre-generated dates.
+void BM_DateTime_Microseconds(benchmark::State& state)
+{
+    std::vector<areg::DateTime> times {bench::make_times(1024u)};
+
+    for (auto _ : state)
+    {
+        for ( auto time : times) {
+             uint32_t micro = time.microseconds();
+            benchmark::DoNotOptimize(micro);
+        }
+
+    }
+    state.SetItemsProcessed(state.iterations() * 1024);
+}
+BENCHMARK(BM_DateTime_Microseconds);
+


### PR DESCRIPTION
### Summary
This PR expands the suite of performance benchmarks for `areg::HashMap` and `areg::DateTime` containers/utilities, and introduces a CMake option to toggle between native Google Benchmark and CodSpeed instrumentation.

### Key Changes
* **CMake Build Configuration:**
  * Added `CODSPEED_MODE` option (default `OFF`).
  * Conditioned `FetchContent` for `google_benchmark` to allow building with native Google Benchmark (`v1.8.3`) when CodSpeed instrumentation is disabled, fixing local compilation issues.
* **`areg::HashMap` Benchmarks:**
  * Refactored and added benchmarks for core map operations: `BM_HashMap_Construct`, `BM_HashMap_ConstructInsertString`, `BM_HashMap_Merge`, `BM_HashMap_UpdateIntegers`, `BM_HashMap_RemoveKey`, and `BM_HashMap_Clear`.
  * Utilized `PauseTiming()` / `ResumeTiming()` to isolate setup/copying costs from actual measurement loops.
  * Added `SetItemsProcessed()` for throughput (`items/s`) metric generation.
* **`areg::DateTime` Benchmarks:**
  * Added benchmarks for time operations: `BM_DateTime_TickCount`, `BM_DateTime_DayOfWeek`, and `BM_DateTime_Microseconds`.
  * Optimized benchmark loops to eliminate `%` (modulo) performance overhead for accurate sub-nanosecond measurements.

### Testing
* Verified local builds without CodSpeed (`-DCODSPEED_MODE=OFF`).
* Executed all benchmark suites locally to ensure proper isolation of operations and clean throughput results.
* 

[x] I have read CONTRIBUTING.md

Signed-off-by: Kuba Słowikowski / Kuba70
